### PR TITLE
Upgrade default Opus model to 4.7

### DIFF
--- a/src/ai_rules/config/claude/settings.json
+++ b/src/ai_rules/config/claude/settings.json
@@ -2,11 +2,10 @@
   "cleanupPeriodDays": 99999,
   "env": {
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6",
-    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh"
   },
   "attribution": {
     "commit": "",

--- a/src/ai_rules/config/profiles/work.yaml
+++ b/src/ai_rules/config/profiles/work.yaml
@@ -10,7 +10,8 @@ settings_overrides:
     env:
       ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6[1m]"
       CLAUDE_CODE_SUBAGENT_MODEL: "claude-sonnet-4-6[1m]"
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6[1m]"
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-7[1m]"
+      CLAUDE_CODE_EFFORT_LEVEL: "max"
     model: "opus[1m]"
   codex:
     service_tier: "fast"


### PR DESCRIPTION
Opus 4.7 launched with several breaking changes: extended thinking is removed (adaptive-only now, sending the old fixed-budget param returns 400), and thinking content defaults to `"omitted"` rather than `"summarized"` — meaning thinking blocks appear in the TUI but with empty content.

- `ANTHROPIC_DEFAULT_OPUS_MODEL` → `claude-opus-4-7` (base) / `claude-opus-4-7[1m]` (work profile)
- Removes `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` — was a v0.30.1 workaround for an Opus 4.6 under-allocation bug; no-op on 4.7
- Adds `showThinkingSummaries: true` to fix silent empty thinking blocks (separate from `alwaysThinkingEnabled`, which only controls the TUI toggle)
- Splits effort level: `xhigh` as base default (new 4.7 tier, falls back to `high` on non-4.7 models), `max` as work profile override