### PR TITLE
feat: standardize on ai-agent-rules as canonical name, fix shell completions PATH shadowing

### DIFF
--- a/.ai-agent-rules-config.yaml.example
+++ b/.ai-agent-rules-config.yaml.example
@@ -1,8 +1,8 @@
 # Example AI Rules configuration file
 #
-# Place this file at: ~/.ai-rules-config.yaml
+# Place this file at: ~/.ai-agent-rules-config.yaml
 #
-# Quick setup: Run `ai-rules config init` for an interactive wizard
+# Quick setup: Run `ai-agent-rulesconfig init` for an interactive wizard
 
 version: 1
 
@@ -13,9 +13,9 @@ version: 1
 # Supports glob patterns: *.json, **/*.yaml, etc.
 #
 # CLI commands:
-#   ai-rules exclude add "~/.claude/*.log"
-#   ai-rules exclude remove "~/.claude/settings.json"
-#   ai-rules exclude list
+#   ai-agent-rulesexclude add "~/.claude/*.log"
+#   ai-agent-rulesexclude remove "~/.claude/settings.json"
+#   ai-agent-rulesexclude list
 exclude_symlinks:
   # Exact path exclusions
   # - "~/.config/goose/config.yaml"
@@ -35,17 +35,17 @@ exclude_symlinks:
 # How it works:
 #   1. Base settings from config/claude/settings.json (git-tracked)
 #   2. Merged with overrides below (local only, not in git)
-#   3. Result cached in ~/.ai-rules/cache/claude/settings.json
+#   3. Result cached in ~/.ai-agent-rules/cache/claude/settings.json
 #   4. Symlinked to ~/.claude/settings.json
 #
 # Use case: Different model access on work vs personal laptop
 #
 # CLI commands:
-#   ai-rules override set claude.model "claude-sonnet-4-5-20250929"
-#   ai-rules override set claude.hooks.SubagentStop[0].hooks[0].command "script.py"
-#   ai-rules override unset claude.model
-#   ai-rules override list
-#   ai-rules config show --merged
+#   ai-agent-rulesoverride set claude.model "claude-sonnet-4-5-20250929"
+#   ai-agent-rulesoverride set claude.hooks.SubagentStop[0].hooks[0].command "script.py"
+#   ai-agent-rulesoverride unset claude.model
+#   ai-agent-rulesoverride list
+#   ai-agent-rulesconfig show --merged
 #
 # Array notation:
 #   Use [0], [1], etc. for array indices in nested structures
@@ -55,7 +55,7 @@ exclude_symlinks:
 #   Commands validate paths against base settings and provide suggestions
 #   Invalid paths are rejected with helpful error messages
 #
-# After changing overrides: ai-rules install --rebuild-cache
+# After changing overrides: ai-agent-rulesinstall --rebuild-cache
 settings_overrides:
   # Simple overrides
   # claude:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ Instructions for AI coding agents working on this repository.
 | Aspect | Value |
 |--------|-------|
 | **PyPI package** | `ai-agent-rules` |
-| **CLI command** | `ai-rules` (preferred) or `ai-agent-rules` |
+| **CLI command** | `ai-agent-rules` (canonical) or `ai-rules` (alias) |
 | **Python module** | `ai_rules` |
 
-The name `ai-rules` was taken on PyPI, so the package is published as `ai-agent-rules`. Both CLI entry points work, but use `ai-rules` in docs and examples (shorter).
+The name `ai-rules` was taken on PyPI, so the package is published as `ai-agent-rules`. Both CLI entry points work. Use `ai-agent-rules` as the canonical name; `ai-rules` is kept as a convenience alias.
 
 **Supported agents:** Claude Code, Goose, Shared (AGENTS.md)
 
@@ -21,26 +21,26 @@ just                          # Lint, format, and type check
 just test                     # Run tests
 just test-unit                # Run unit tests only
 just test-integration         # Run integration tests only
-uv run ai-rules <cmd>         # Run CLI
+uv run ai-agent-rules <cmd>         # Run CLI
 
 # GitHub installation
-uv run ai-rules setup --github  # Install from GitHub instead of PyPI
+uv run ai-agent-rules setup --github  # Install from GitHub instead of PyPI
 
 # Key CLI commands
-uv run ai-rules install        # Install symlinks
-uv run ai-rules status         # Check symlink status (shows diffs)
-uv run ai-rules info           # Show installation method and version info
-uv run ai-rules upgrade        # Upgrade to latest (shows changelogs)
-uv run ai-rules validate       # Validate config files
-uv run ai-rules diff           # Show diffs between repo and installed
+uv run ai-agent-rules install        # Install symlinks
+uv run ai-agent-rules status         # Check symlink status (shows diffs)
+uv run ai-agent-rules info           # Show installation method and version info
+uv run ai-agent-rules upgrade        # Upgrade to latest (shows changelogs)
+uv run ai-agent-rules validate       # Validate config files
+uv run ai-agent-rules diff           # Show diffs between repo and installed
 
 # Subcommands
-uv run ai-rules config show    # Show current config
-uv run ai-rules config edit    # Edit user config in $EDITOR
-uv run ai-rules override list  # List settings overrides
-uv run ai-rules completions install  # Install shell completions
-uv run ai-rules profile list   # List available profiles
-uv run ai-rules profile switch <name>  # Switch to different profile
+uv run ai-agent-rules config show    # Show current config
+uv run ai-agent-rules config edit    # Edit user config in $EDITOR
+uv run ai-agent-rules override list  # List settings overrides
+uv run ai-agent-rules completions install  # Install shell completions
+uv run ai-agent-rules profile list   # List available profiles
+uv run ai-agent-rules profile switch <name>  # Switch to different profile
 ```
 
 ## Tech Stack
@@ -102,19 +102,19 @@ All AI tools inherit from `Agent` (`agents/base.py`). To add a new tool:
 3. Register in `cli.py::get_agents()`
 
 ### Config System
-- User config: `~/.ai-rules-config.yaml`
-- **State file**: `~/.ai-rules/state.yaml` (tracks active profile, last install time)
+- User config: `~/.ai-agent-rules-config.yaml`
+- **State file**: `~/.ai-agent-rules/state.yaml` (tracks active profile, last install time)
 - **Profiles**: Named collections of overrides (default, work) with inheritance
   - Built-in: `config/profiles/{default,work}.yaml`
-  - User: `~/.ai-rules/profiles/*.yaml`
+  - User: `~/.ai-agent-rules/profiles/*.yaml`
   - Inheritance via `extends:` key (e.g., work extends default)
   - Commands: `profile list`, `profile show`, `profile current`, `profile switch`
 - `settings_overrides` for machine-specific agent settings
 - Cache-based override merging for settings.json files (Claude, Goose)
   - **Critical**: Preserves Claude-managed fields (`enabledPlugins`) during cache rebuild
 - **Plugin management**: Declarative plugin installs from profiles (`plugins`, `marketplaces` keys)
-  - Auto-uninstalls orphaned plugins (previously managed by ai-rules, removed from config)
-  - Tracks managed plugins in `~/.claude/plugins/ai-rules-managed.json`
+  - Auto-uninstalls orphaned plugins (previously managed by ai-agent-rules, removed from config)
+  - Tracks managed plugins in `~/.claude/plugins/ai-agent-rules-managed.json`
   - Warns about manually-installed plugins not in config (doesn't auto-remove)
 - Agent-specific hints (CLAUDE.md, .goosehints) use `@~/AGENTS.md` to reference main file (token-saving)
 
@@ -152,8 +152,8 @@ uv run pytest -m state          # State management tests only
    - `uv tool` → uv config (UV_DEFAULT_INDEX/UV_INDEX_URL)
    - Solution: Pass explicit `--index-url` to pip, `--default-index` to uv
 
-4. **Local development vs installed tool** - **CRITICAL**: Always use `uv run ai-rules` when developing locally:
-   - **Local dev (from repo)**: `uv run ai-rules <command>` → runs YOUR local code changes directly
+4. **Local development vs installed tool** - **CRITICAL**: Always use `uv run ai-agent-rules` when developing locally:
+   - **Local dev (from repo)**: `uv run ai-agent-rules <command>` → runs YOUR local code changes directly
    - **Installed tool (any directory)**: `ai-rules <command>` → runs installed version from `~/.local/share/uv/tools/`
    - Running `ai-rules` without `uv run` will NOT reflect your local changes
    - **NEVER use editable install** (`uv pip install -e .`) - risks conflicts with installed version, unnecessary complexity
@@ -167,10 +167,10 @@ uv run pytest -m state          # State management tests only
    - Useful for pre-release features before PyPI publish
 
 7. **Preserved fields in settings.json** - `enabledPlugins`, `hooks` managed by Claude Code or user:
-   - ai-rules preserves these fields during cache rebuilds
+   - ai-agent-rules preserves these fields during cache rebuilds
    - Defined in `PRESERVED_FIELDS` constant (config.py, formerly `CLAUDE_MANAGED_FIELDS`)
-   - Tracking file: `~/.claude/ai-rules-managed-fields.json` (tracks ai-rules contributions)
-   - Cleanup: When ai-rules removes a hook from source, it's removed from user settings
+   - Tracking file: `~/.claude/ai-agent-rules-managed-fields.json` (tracks ai-agent-rules contributions)
+   - Cleanup: When ai-agent-rules removes a hook from source, it's removed from user settings
    - User hooks preserved (e.g., custom UserPromptSubmit hooks won't be removed)
 
 8. **Upgrade shows changelogs** - `upgrade` command fetches CHANGELOG.md from GitHub:

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Manage AI agent configurations through symlinks. Keep all your configs in one gi
 [![PyPI Downloads](https://img.shields.io/pypi/dm/ai-agent-rules.svg)](https://pypi.org/project/ai-agent-rules/)
 [![PyPI version](https://img.shields.io/pypi/v/ai-agent-rules.svg)](https://pypi.org/project/ai-agent-rules/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/ai-agent-rules.svg)](https://pypi.org/project/ai-agent-rules/)
-[![CI](https://github.com/wpfleger96/ai-rules/actions/workflows/ci.yml/badge.svg)](https://github.com/wpfleger96/ai-rules/actions/workflows/ci.yml)
-[![GitHub Contributors](https://img.shields.io/github/contributors/wpfleger96/ai-rules.svg)](https://github.com/wpfleger96/ai-rules/graphs/contributors)
-[![Lines of Code](https://aschey.tech/tokei/github/wpfleger96/ai-rules?category=code)](https://github.com/wpfleger96/ai-rules)
-[![License](https://img.shields.io/github/license/wpfleger96/ai-rules.svg)](https://github.com/wpfleger96/ai-rules/blob/main/LICENSE)
+[![CI](https://github.com/wpfleger96/ai-agent-rules/actions/workflows/ci.yml/badge.svg)](https://github.com/wpfleger96/ai-agent-rules/actions/workflows/ci.yml)
+[![GitHub Contributors](https://img.shields.io/github/contributors/wpfleger96/ai-agent-rules.svg)](https://github.com/wpfleger96/ai-agent-rules/graphs/contributors)
+[![Lines of Code](https://aschey.tech/tokei/github/wpfleger96/ai-agent-rules?category=code)](https://github.com/wpfleger96/ai-agent-rules)
+[![License](https://img.shields.io/github/license/wpfleger96/ai-agent-rules.svg)](https://github.com/wpfleger96/ai-agent-rules/blob/main/LICENSE)
 
 ## Overview
 
@@ -31,22 +31,22 @@ Consolidates config files for AI coding agents (Claude Code, Goose) into a singl
 One-command setup from PyPI:
 
 ```bash
-uvx --from ai-agent-rules ai-rules setup
+uvx --from ai-agent-rules ai-agent-rules setup
 ```
 
 This will:
 1. Install AI agent configuration symlinks
-2. Make `ai-rules` available system-wide
+2. Make `ai-agent-rules` (and the `ai-rules` alias) available system-wide
 3. Auto-install optional tools (claude-code-statusline)
 
-After setup, you can run `ai-rules` from any directory.
+After setup, you can run `ai-agent-rules` (or `ai-rules` for short) from any directory.
 
 ### From GitHub (Development)
 
 Install from GitHub to get the latest development code:
 
 ```bash
-uvx --from ai-agent-rules ai-rules setup --github
+uvx --from ai-agent-rules ai-agent-rules setup --github
 ```
 
 This installs from the main branch and auto-detects the GitHub source for future updates.
@@ -56,20 +56,20 @@ This installs from the main branch and auto-detects the GitHub source for future
 For contributing or local development:
 
 ```bash
-git clone https://github.com/wpfleger96/ai-rules.git
-cd ai-rules
-uv run ai-rules install
+git clone https://github.com/wpfleger96/ai-agent-rules.git
+cd ai-agent-rules
+uv run ai-agent-rules install
 ```
 
-Use `uv run ai-rules <command>` to test local changes. The global `ai-rules` command continues to run your installed version (PyPI/GitHub).
+Use `uv run ai-agent-rules <command>` to test local changes. The global `ai-agent-rules` command continues to run your installed version (PyPI/GitHub).
 
 ### Updating
 
 Check for and install updates:
 
 ```bash
-ai-rules upgrade              # Check and install updates (shows changelogs)
-ai-rules upgrade --check      # Only check for updates
+ai-agent-rules upgrade              # Check and install updates (shows changelogs)
+ai-agent-rules upgrade --check      # Only check for updates
 ```
 
 The `upgrade` command automatically displays changelogs for new versions and installs without additional prompts.
@@ -81,48 +81,48 @@ The `upgrade` command automatically displays changelogs for new versions and ins
 ### User-Level Configuration
 
 ```bash
-ai-rules setup                      # One-time setup: install symlinks + make available system-wide
-ai-rules setup --github             # Install from GitHub (pre-release)
-ai-rules setup --profile work       # Setup with a specific profile
-ai-rules upgrade                    # Upgrade to latest version
-ai-rules upgrade --check            # Check for updates without installing
+ai-agent-rules setup                      # One-time setup: install symlinks + make available system-wide
+ai-agent-rules setup --github             # Install from GitHub (pre-release)
+ai-agent-rules setup --profile work       # Setup with a specific profile
+ai-agent-rules upgrade                    # Upgrade to latest version
+ai-agent-rules upgrade --check            # Check for updates without installing
 
-ai-rules install                    # Install all agent configs + optional tools
-ai-rules install --agents claude    # Install specific agents
-ai-rules install --dry-run          # Preview changes
-ai-rules install -y                 # Auto-confirm without prompting
-ai-rules install --rebuild-cache    # Rebuild merged settings cache
+ai-agent-rules install                    # Install all agent configs + optional tools
+ai-agent-rules install --agents claude    # Install specific agents
+ai-agent-rules install --dry-run          # Preview changes
+ai-agent-rules install -y                 # Auto-confirm without prompting
+ai-agent-rules install --rebuild-cache    # Rebuild merged settings cache
 
-ai-rules status                     # Check symlink status + optional tools + active profile (✓✗⚠○), shows diffs
-ai-rules diff                       # Show config differences
-ai-rules validate                   # Verify source files exist
-ai-rules install                    # Re-sync after adding files
-ai-rules uninstall                  # Remove all symlinks
-ai-rules list-agents                # Show available agents
+ai-agent-rules status                     # Check symlink status + optional tools + active profile (✓✗⚠○), shows diffs
+ai-agent-rules diff                       # Show config differences
+ai-agent-rules validate                   # Verify source files exist
+ai-agent-rules install                    # Re-sync after adding files
+ai-agent-rules uninstall                  # Remove all symlinks
+ai-agent-rules list-agents                # Show available agents
 ```
 
 ### Configuration Management
 
 ```bash
 # Interactive wizard for first-time setup
-ai-rules config init                # Start configuration wizard
+ai-agent-rules config init                # Start configuration wizard
 
 # View configuration
-ai-rules config show                # Show raw config files
-ai-rules config show --merged       # Show merged settings with overrides
-ai-rules config show --agent claude # Show config for specific agent
-ai-rules config edit                # Edit user config in $EDITOR
+ai-agent-rules config show                # Show raw config files
+ai-agent-rules config show --merged       # Show merged settings with overrides
+ai-agent-rules config show --agent claude # Show config for specific agent
+ai-agent-rules config edit                # Edit user config in $EDITOR
 
 # Manage exclusions
-ai-rules exclude add "~/.claude/*.json"      # Add exclusion pattern (supports globs)
-ai-rules exclude remove "~/.claude/*.json"   # Remove exclusion pattern
-ai-rules exclude list                        # List all exclusions
+ai-agent-rules exclude add "~/.claude/*.json"      # Add exclusion pattern (supports globs)
+ai-agent-rules exclude remove "~/.claude/*.json"   # Remove exclusion pattern
+ai-agent-rules exclude list                        # List all exclusions
 
 # Manage settings overrides (for machine-specific settings)
-ai-rules override set claude.model "claude-sonnet-4-5-20250929"  # Set simple override
-ai-rules override set claude.hooks.SubagentStop[0].hooks[0].command "script.py"  # Array notation
-ai-rules override unset claude.model         # Remove override
-ai-rules override list                       # List all overrides
+ai-agent-rules override set claude.model "claude-sonnet-4-5-20250929"  # Set simple override
+ai-agent-rules override set claude.hooks.SubagentStop[0].hooks[0].command "script.py"  # Array notation
+ai-agent-rules override unset claude.model         # Remove override
+ai-agent-rules override list                       # List all overrides
 ```
 
 ## Configuration
@@ -132,7 +132,7 @@ ai-rules override list                       # List all overrides
 Run the interactive configuration wizard for guided setup:
 
 ```bash
-ai-rules config init
+ai-agent-rules config init
 ```
 
 This will walk you through:
@@ -142,7 +142,7 @@ This will walk you through:
 
 ### User-Level Config
 
-Create `~/.ai-rules-config.yaml` for user-level settings:
+Create `~/.ai-agent-rules-config.yaml` for user-level settings:
 
 ```yaml
 version: 1
@@ -165,9 +165,9 @@ settings_overrides:
 ```
 
 **Config File Location:**
-- `~/.ai-rules-config.yaml` - User-specific config (exclusions and overrides)
-- `~/.ai-rules/state.yaml` - Active profile and last install timestamp (auto-managed)
-- `~/.ai-rules/cache/` - Merged settings cache (auto-generated)
+- `~/.ai-agent-rules-config.yaml` - User-specific config (exclusions and overrides)
+- `~/.ai-agent-rules/state.yaml` - Active profile and last install timestamp (auto-managed)
+- `~/.ai-agent-rules/cache/` - Merged settings cache (auto-generated)
 
 ### Settings Overrides - Syncing Configs Across Machines
 
@@ -176,12 +176,12 @@ settings_overrides:
 **Solution:** Use `settings_overrides` in your user config:
 
 ```yaml
-# ~/.ai-rules-config.yaml on personal laptop
+# ~/.ai-agent-rules-config.yaml on personal laptop
 settings_overrides:
   claude:
     model: "claude-sonnet-4-5-20250929"  # No Opus access
 
-# ~/.ai-rules-config.yaml on work laptop
+# ~/.ai-agent-rules-config.yaml on work laptop
 settings_overrides:
   claude:
     model: "claude-opus-4-20250514"  # Has Opus access
@@ -190,13 +190,13 @@ settings_overrides:
 Both machines sync the same `config/claude/settings.json` via git, but each has different local overrides. The system merges them at install time:
 
 1. **Base settings** from `config/claude/settings.json` (git-tracked)
-2. **Merged with** overrides from `~/.ai-rules-config.yaml` (local only)
-3. **Cached** in `~/.ai-rules/cache/claude/settings.json`
+2. **Merged with** overrides from `~/.ai-agent-rules-config.yaml` (local only)
+3. **Cached** in `~/.ai-agent-rules/cache/claude/settings.json`
 4. **Symlinked** to `~/.claude/settings.json`
 
 After changing overrides, run:
 ```bash
-ai-rules install --rebuild-cache
+ai-agent-rules install --rebuild-cache
 ```
 
 #### Array Notation for Nested Settings
@@ -205,13 +205,13 @@ Override commands support array index notation for complex nested structures:
 
 ```bash
 # Override nested array elements (e.g., hooks)
-ai-rules override set claude.hooks.SubagentStop[0].hooks[0].command "uv run ~/my-hook.py"
+ai-agent-rules override set claude.hooks.SubagentStop[0].hooks[0].command "uv run ~/my-hook.py"
 
 # Override environment variables
-ai-rules override set claude.env.MY_VAR "value"
+ai-agent-rules override set claude.env.MY_VAR "value"
 
 # The system validates paths and provides helpful suggestions
-ai-rules override set claude.modle "sonnet"
+ai-agent-rules override set claude.modle "sonnet"
 # Error: Key 'modle' not found at 'modle'
 # Available options: model, env, hooks, statusLine, ...
 ```
@@ -220,24 +220,24 @@ Path validation ensures you only set valid overrides that exist in the base sett
 
 ### Profiles - Machine-Specific Configuration
 
-Profiles let you group configuration overrides into named presets. Instead of manually maintaining different `~/.ai-rules-config.yaml` files across machines, define profiles once and select them at install time.
+Profiles let you group configuration overrides into named presets. Instead of manually maintaining different `~/.ai-agent-rules-config.yaml` files across machines, define profiles once and select them at install time.
 
 ```bash
 # List available profiles
-ai-rules profile list
+ai-agent-rules profile list
 
 # View profile details
-ai-rules profile show work
-ai-rules profile show work --resolved  # Show with inheritance
+ai-agent-rules profile show work
+ai-agent-rules profile show work --resolved  # Show with inheritance
 
 # Check which profile is active
-ai-rules profile current
+ai-agent-rules profile current
 
 # Switch to a different profile
-ai-rules profile switch work
+ai-agent-rules profile switch work
 
 # Install with a specific profile
-ai-rules install --profile work
+ai-agent-rules install --profile work
 ```
 
 Profiles are stored in `src/ai_rules/config/profiles/` and support inheritance:
@@ -256,18 +256,18 @@ settings_overrides:
 
 Configuration layers (lowest to highest priority):
 1. Profile overrides
-2. Local `~/.ai-rules-config.yaml` overrides
+2. Local `~/.ai-agent-rules-config.yaml` overrides
 
 Your local config always wins, so you can use a profile as a base and tweak specific settings per-machine. Profiles are git-tracked and can be shared across your team.
 
-The active profile is tracked in `~/.ai-rules/state.yaml` and persists across sessions. Use `profile current` to see which profile is active, or `profile switch` to quickly change profiles without re-running the full install.
+The active profile is tracked in `~/.ai-agent-rules/state.yaml` and persists across sessions. Use `profile current` to see which profile is active, or `profile switch` to quickly change profiles without re-running the full install.
 
 ### Plugin Management - Declarative Claude Code Plugins
 
-Specify Claude Code plugins in your profile or user config, and ai-rules automatically installs them via `claude plugin install`:
+Specify Claude Code plugins in your profile or user config, and ai-agent-rules automatically installs them via `claude plugin install`:
 
 ```yaml
-# profiles/work.yaml or ~/.ai-rules-config.yaml
+# profiles/work.yaml or ~/.ai-agent-rules-config.yaml
 plugins:
   - name: feature-dev
     marketplace: claude-plugins-official
@@ -279,18 +279,18 @@ marketplaces:
     source: ananddtyagi/cc-marketplace
 ```
 
-When you run `ai-rules install`:
+When you run `ai-agent-rules install`:
 1. Adds missing marketplaces via `claude plugin marketplace add`
 2. Installs missing plugins via `claude plugin install <name>@<marketplace>`
-3. Auto-uninstalls orphaned plugins that were previously managed by ai-rules but removed from config
+3. Auto-uninstalls orphaned plugins that were previously managed by ai-agent-rules but removed from config
 4. Warns about manually-installed plugins not in config (doesn't auto-uninstall them)
 
 Check plugin status:
 ```bash
-ai-rules status  # Shows Plugins section with installed/pending/extra
+ai-agent-rules status  # Shows Plugins section with installed/pending/extra
 ```
 
-Plugins are tracked in `~/.claude/plugins/installed_plugins.json` and synced across machines via your git-tracked profile configuration. ai-rules tracks which plugins it manages in `~/.claude/plugins/ai-rules-managed.json` to avoid removing manually-installed plugins.
+Plugins are tracked in `~/.claude/plugins/installed_plugins.json` and synced across machines via your git-tracked profile configuration. ai-agent-rules tracks which plugins it manages in `~/.claude/plugins/ai-agent-rules-managed.json` to avoid removing manually-installed plugins.
 
 ## Structure
 
@@ -317,10 +317,10 @@ AI Rules automatically installs optional tools that enhance functionality:
 These tools are installed automatically during `setup` and `install` commands. Check installation status:
 
 ```bash
-ai-rules status  # Shows Optional Tools section
+ai-agent-rules status  # Shows Optional Tools section
 ```
 
-If a tool fails to install, ai-rules continues normally (fail-open behavior).
+If a tool fails to install, ai-agent-rules continues normally (fail-open behavior).
 
 ## Extending
 
@@ -335,13 +335,13 @@ metadata:
   trigger-patterns: "pattern1, pattern2"
 ---
 ```
-2. Run `ai-rules install`
+2. Run `ai-agent-rules install`
 3. Skill symlinked to both `~/.claude/skills/` and `~/.config/goose/skills/`
 4. Auto-suggests when user prompt matches keywords/patterns
 
 **Add Claude hook:**
 1. Create `config/claude/hooks/my-hook.py`
-2. Run `ai-rules install`
+2. Run `ai-agent-rules install`
 3. Configure in settings or overrides (e.g., UserPromptSubmit, SubagentStop)
 
 **Add new AI tool:**
@@ -352,7 +352,7 @@ metadata:
 ## Safety
 
 - First-run warnings
-- Timestamped backups (`*.ai-rules-backup.YYYYMMDD-HHMMSS`)
+- Timestamped backups (`*.ai-agent-rules-backup.YYYYMMDD-HHMMSS`)
 - Interactive prompts and dry-run mode
 - Only manages symlinks (never deletes real files)
 - Contextual error messages with tips
@@ -421,29 +421,29 @@ uv run pytest -m integration  # Integration tests only
 
 ## Troubleshooting
 
-**Wrong target:** `ai-rules status` then `ai-rules install -y`
+**Wrong target:** `ai-agent-rules status` then `ai-agent-rules install -y`
 
 **Restore backup:**
 ```bash
-ls -la ~/.CLAUDE.md.ai-rules-backup.*
-mv ~/.CLAUDE.md.ai-rules-backup.20250104-143022 ~/.CLAUDE.md
+ls -la ~/.CLAUDE.md.ai-agent-rules-backup.*
+mv ~/.CLAUDE.md.ai-agent-rules-backup.20250104-143022 ~/.CLAUDE.md
 ```
 
 **Disable symlink:** Use the exclude command or add to config manually:
 ```bash
-ai-rules exclude add "~/.claude/settings.json"
-# Or edit manually: ai-rules config edit
+ai-agent-rules exclude add "~/.claude/settings.json"
+# Or edit manually: ai-agent-rules config edit
 ```
 
 **Override not applying:** Rebuild the merged settings cache:
 ```bash
-ai-rules install --rebuild-cache
+ai-agent-rules install --rebuild-cache
 ```
 
 **View merged settings:** Check what's actually being applied:
 ```bash
-ai-rules config show --merged
-ai-rules config show --merged --agent claude
+ai-agent-rules config show --merged
+ai-agent-rules config show --merged --agent claude
 ```
 
 ## License

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,13 +1,13 @@
-# ai-rules CLI Reference
+# ai-agent-rules CLI Reference
 
 Auto-generated from `--help`. Do not edit manually.
 
-This is the complete CLI reference for ai-rules. For quick start examples and usage guides, see [README.md](../README.md).
+This is the complete CLI reference for ai-agent-rules. For quick start examples and usage guides, see [README.md](../README.md).
 
-## `ai-rules`
+## `ai-agent-rules`
 
 ```
-Usage: ai-rules [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules [OPTIONS] COMMAND [ARGS]...
 
   AI Rules - Manage user-level AI agent configurations.
 
@@ -17,25 +17,25 @@ Options:
 
 Commands:
   completions  Manage shell tab completion.
-  config       Manage ai-rules configuration.
+  config       Manage ai-agent-rules configuration.
   diff         Show differences between repo configs and installed symlinks.
   exclude      Manage exclusion patterns.
-  info         Show installation method and version info for ai-rules tools.
+  info         Show installation method and version info for...
   install      Install AI agent configs via symlinks.
   list-agents  List available AI agents.
   override     Manage settings overrides.
   profile      Manage configuration profiles.
-  setup        One-time setup: install symlinks and make ai-rules...
+  setup        One-time setup: install symlinks and make ai-agent-rules...
   status       Check status of AI agent symlinks.
   uninstall    Remove AI agent symlinks.
-  upgrade      Upgrade ai-rules and related tools to the latest versions...
+  upgrade      Upgrade ai-agent-rules and related tools to the latest...
   validate     Validate configuration and source files.
 ```
 
-## `ai-rules completions`
+## `ai-agent-rules completions`
 
 ```
-Usage: ai-rules completions [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules completions [OPTIONS] COMMAND [ARGS]...
 
   Manage shell tab completion.
 
@@ -47,13 +47,14 @@ Commands:
   install    Install shell completion to config file.
   status     Show shell completion installation status.
   uninstall  Remove shell completion from config file.
+  update     Re-generate completion block (fixes PATH shadowing issues).
   zsh        Output zsh completion script for manual installation.
 ```
 
-## `ai-rules completions bash`
+## `ai-agent-rules completions bash`
 
 ```
-Usage: ai-rules completions bash [OPTIONS]
+Usage: ai-agent-rules completions bash [OPTIONS]
 
   Output bash completion script for manual installation.
 
@@ -61,10 +62,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules completions install`
+## `ai-agent-rules completions install`
 
 ```
-Usage: ai-rules completions install [OPTIONS]
+Usage: ai-agent-rules completions install [OPTIONS]
 
   Install shell completion to config file.
 
@@ -73,10 +74,10 @@ Options:
   --help              Show this message and exit.
 ```
 
-## `ai-rules completions status`
+## `ai-agent-rules completions status`
 
 ```
-Usage: ai-rules completions status [OPTIONS]
+Usage: ai-agent-rules completions status [OPTIONS]
 
   Show shell completion installation status.
 
@@ -84,10 +85,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules completions uninstall`
+## `ai-agent-rules completions uninstall`
 
 ```
-Usage: ai-rules completions uninstall [OPTIONS]
+Usage: ai-agent-rules completions uninstall [OPTIONS]
 
   Remove shell completion from config file.
 
@@ -96,10 +97,22 @@ Options:
   --help              Show this message and exit.
 ```
 
-## `ai-rules completions zsh`
+## `ai-agent-rules completions update`
 
 ```
-Usage: ai-rules completions zsh [OPTIONS]
+Usage: ai-agent-rules completions update [OPTIONS]
+
+  Re-generate completion block (fixes PATH shadowing issues).
+
+Options:
+  --shell [bash|zsh]  Shell type (auto-detected if not specified)
+  --help              Show this message and exit.
+```
+
+## `ai-agent-rules completions zsh`
+
+```
+Usage: ai-agent-rules completions zsh [OPTIONS]
 
   Output zsh completion script for manual installation.
 
@@ -107,12 +120,12 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules config`
+## `ai-agent-rules config`
 
 ```
-Usage: ai-rules config [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules config [OPTIONS] COMMAND [ARGS]...
 
-  Manage ai-rules configuration.
+  Manage ai-agent-rules configuration.
 
 Options:
   --help  Show this message and exit.
@@ -123,10 +136,10 @@ Commands:
   show  Show current configuration.
 ```
 
-## `ai-rules config edit`
+## `ai-agent-rules config edit`
 
 ```
-Usage: ai-rules config edit [OPTIONS]
+Usage: ai-agent-rules config edit [OPTIONS]
 
   Edit user configuration file in $EDITOR.
 
@@ -134,10 +147,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules config init`
+## `ai-agent-rules config init`
 
 ```
-Usage: ai-rules config init [OPTIONS]
+Usage: ai-agent-rules config init [OPTIONS]
 
   Interactive configuration wizard.
 
@@ -145,10 +158,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules config show`
+## `ai-agent-rules config show`
 
 ```
-Usage: ai-rules config show [OPTIONS]
+Usage: ai-agent-rules config show [OPTIONS]
 
   Show current configuration.
 
@@ -158,10 +171,10 @@ Options:
   --help        Show this message and exit.
 ```
 
-## `ai-rules diff`
+## `ai-agent-rules diff`
 
 ```
-Usage: ai-rules diff [OPTIONS]
+Usage: ai-agent-rules diff [OPTIONS]
 
   Show differences between repo configs and installed symlinks.
 
@@ -170,10 +183,10 @@ Options:
   --help         Show this message and exit.
 ```
 
-## `ai-rules exclude`
+## `ai-agent-rules exclude`
 
 ```
-Usage: ai-rules exclude [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules exclude [OPTIONS] COMMAND [ARGS]...
 
   Manage exclusion patterns.
 
@@ -186,10 +199,10 @@ Commands:
   remove  Remove an exclusion pattern from user config.
 ```
 
-## `ai-rules exclude add`
+## `ai-agent-rules exclude add`
 
 ```
-Usage: ai-rules exclude add [OPTIONS] PATTERN
+Usage: ai-agent-rules exclude add [OPTIONS] PATTERN
 
   Add an exclusion pattern to user config.
 
@@ -199,10 +212,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules exclude list`
+## `ai-agent-rules exclude list`
 
 ```
-Usage: ai-rules exclude list [OPTIONS]
+Usage: ai-agent-rules exclude list [OPTIONS]
 
   List all exclusion patterns.
 
@@ -210,10 +223,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules exclude remove`
+## `ai-agent-rules exclude remove`
 
 ```
-Usage: ai-rules exclude remove [OPTIONS] PATTERN
+Usage: ai-agent-rules exclude remove [OPTIONS] PATTERN
 
   Remove an exclusion pattern from user config.
 
@@ -221,12 +234,12 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules info`
+## `ai-agent-rules info`
 
 ```
-Usage: ai-rules info [OPTIONS]
+Usage: ai-agent-rules info [OPTIONS]
 
-  Show installation method and version info for ai-rules tools.
+  Show installation method and version info for ai-agent-rules tools.
 
   Displays how each tool was installed (PyPI or GitHub) along with current
   versions and update availability.
@@ -235,10 +248,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules install`
+## `ai-agent-rules install`
 
 ```
-Usage: ai-rules install [OPTIONS]
+Usage: ai-agent-rules install [OPTIONS]
 
   Install AI agent configs via symlinks.
 
@@ -254,10 +267,10 @@ Options:
   --help              Show this message and exit.
 ```
 
-## `ai-rules list-agents`
+## `ai-agent-rules list-agents`
 
 ```
-Usage: ai-rules list-agents [OPTIONS]
+Usage: ai-agent-rules list-agents [OPTIONS]
 
   List available AI agents.
 
@@ -265,10 +278,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules override`
+## `ai-agent-rules override`
 
 ```
-Usage: ai-rules override [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules override [OPTIONS] COMMAND [ARGS]...
 
   Manage settings overrides.
 
@@ -281,10 +294,10 @@ Commands:
   unset  Remove a settings override.
 ```
 
-## `ai-rules override list`
+## `ai-agent-rules override list`
 
 ```
-Usage: ai-rules override list [OPTIONS]
+Usage: ai-agent-rules override list [OPTIONS]
 
   List all settings overrides.
 
@@ -292,10 +305,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules override set`
+## `ai-agent-rules override set`
 
 ```
-Usage: ai-rules override set [OPTIONS] KEY VALUE
+Usage: ai-agent-rules override set [OPTIONS] KEY VALUE
 
   Set a settings override for an agent.
 
@@ -315,10 +328,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules override unset`
+## `ai-agent-rules override unset`
 
 ```
-Usage: ai-rules override unset [OPTIONS] KEY
+Usage: ai-agent-rules override unset [OPTIONS] KEY
 
   Remove a settings override.
 
@@ -329,10 +342,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules profile`
+## `ai-agent-rules profile`
 
 ```
-Usage: ai-rules profile [OPTIONS] COMMAND [ARGS]...
+Usage: ai-agent-rules profile [OPTIONS] COMMAND [ARGS]...
 
   Manage configuration profiles.
 
@@ -346,10 +359,10 @@ Commands:
   switch   Switch to a different profile.
 ```
 
-## `ai-rules profile current`
+## `ai-agent-rules profile current`
 
 ```
-Usage: ai-rules profile current [OPTIONS]
+Usage: ai-agent-rules profile current [OPTIONS]
 
   Show currently active profile.
 
@@ -357,10 +370,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules profile list`
+## `ai-agent-rules profile list`
 
 ```
-Usage: ai-rules profile list [OPTIONS]
+Usage: ai-agent-rules profile list [OPTIONS]
 
   List available profiles.
 
@@ -368,10 +381,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules profile show`
+## `ai-agent-rules profile show`
 
 ```
-Usage: ai-rules profile show [OPTIONS] NAME
+Usage: ai-agent-rules profile show [OPTIONS] NAME
 
   Show profile details.
 
@@ -380,10 +393,10 @@ Options:
   --help      Show this message and exit.
 ```
 
-## `ai-rules profile switch`
+## `ai-agent-rules profile switch`
 
 ```
-Usage: ai-rules profile switch [OPTIONS] NAME
+Usage: ai-agent-rules profile switch [OPTIONS] NAME
 
   Switch to a different profile.
 
@@ -391,14 +404,15 @@ Options:
   --help  Show this message and exit.
 ```
 
-## `ai-rules setup`
+## `ai-agent-rules setup`
 
 ```
-Usage: ai-rules setup [OPTIONS]
+Usage: ai-agent-rules setup [OPTIONS]
 
-  One-time setup: install symlinks and make ai-rules available system-wide.
+  One-time setup: install symlinks and make ai-agent-rules available system-
+  wide.
 
-  This is the recommended way to install ai-rules for first-time users.
+  This is the recommended way to install ai-agent-rules for first-time users.
 
   Example:     uvx ai-agent-rules setup
 
@@ -412,10 +426,10 @@ Options:
   --help              Show this message and exit.
 ```
 
-## `ai-rules status`
+## `ai-agent-rules status`
 
 ```
-Usage: ai-rules status [OPTIONS]
+Usage: ai-agent-rules status [OPTIONS]
 
   Check status of AI agent symlinks.
 
@@ -424,10 +438,10 @@ Options:
   --help         Show this message and exit.
 ```
 
-## `ai-rules uninstall`
+## `ai-agent-rules uninstall`
 
 ```
-Usage: ai-rules uninstall [OPTIONS]
+Usage: ai-agent-rules uninstall [OPTIONS]
 
   Remove AI agent symlinks.
 
@@ -437,32 +451,34 @@ Options:
   --help         Show this message and exit.
 ```
 
-## `ai-rules upgrade`
+## `ai-agent-rules upgrade`
 
 ```
-Usage: ai-rules upgrade [OPTIONS]
+Usage: ai-agent-rules upgrade [OPTIONS]
 
-  Upgrade ai-rules and related tools to the latest versions from PyPI.
+  Upgrade ai-agent-rules and related tools to the latest versions from PyPI.
 
-  Examples:     ai-rules upgrade                    # Check and install all
-  updates     ai-rules upgrade --check            # Only check for updates
-  ai-rules upgrade -y                 # Auto-confirm installation     ai-rules
-  upgrade --only=statusline  # Only upgrade statusline tool
+  Examples:     ai-agent-rules upgrade                    # Check and install
+  all updates     ai-agent-rules upgrade --check            # Only check for
+  updates     ai-agent-rules upgrade -y                 # Auto-confirm
+  installation     ai-agent-rules upgrade --only=statusline  # Only upgrade
+  statusline tool
 
 Options:
-  --check                       Check for updates without installing
-  --force                       Force reinstall even if up to date
-  -y, --yes                     Auto-confirm installation without prompting
-  --skip-install                Skip running 'install --rebuild-cache' after
-                                upgrade
-  --only [ai-rules|statusline]  Only upgrade specific tool
-  --help                        Show this message and exit.
+  --check                         Check for updates without installing
+  --force                         Force reinstall even if up to date
+  -y, --yes                       Auto-confirm installation without prompting
+  --skip-install                  Skip running 'install --rebuild-cache' after
+                                  upgrade
+  --only [ai-agent-rules|ai-rules|statusline]
+                                  Only upgrade specific tool
+  --help                          Show this message and exit.
 ```
 
-## `ai-rules validate`
+## `ai-agent-rules validate`
 
 ```
-Usage: ai-rules validate [OPTIONS]
+Usage: ai-agent-rules validate [OPTIONS]
 
   Validate configuration and source files.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/willpfleger/ai-rules"
-Repository = "https://github.com/willpfleger/ai-rules"
-Issues = "https://github.com/willpfleger/ai-rules/issues"
+Homepage = "https://github.com/wpfleger96/ai-agent-rules"
+Repository = "https://github.com/wpfleger96/ai-agent-rules"
+Issues = "https://github.com/wpfleger96/ai-agent-rules/issues"
 
 [project.scripts]
 ai-rules = "ai_rules.cli:main"

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -11,7 +11,7 @@ from ai_rules.cli import main
 
 
 def discover_commands(
-    group: Any, prefix: str = "ai-rules", include_root: bool = True
+    group: Any, prefix: str = "ai-agent-rules", include_root: bool = True
 ) -> list[str]:
     """Recursively discover all CLI commands."""
     commands = []
@@ -66,9 +66,9 @@ def generate() -> None:
             print(f"  - {cmd}")
 
     output: list[str] = [
-        "# ai-rules CLI Reference\n\n",
+        "# ai-agent-rules CLI Reference\n\n",
         "Auto-generated from `--help`. Do not edit manually.\n\n",
-        "This is the complete CLI reference for ai-rules. For quick start examples and usage guides, see [README.md](../README.md).\n\n",
+        "This is the complete CLI reference for ai-agent-rules. For quick start examples and usage guides, see [README.md](../README.md).\n\n",
     ]
 
     for cmd in commands:

--- a/src/ai_rules/agents/base.py
+++ b/src/ai_rules/agents/base.py
@@ -185,7 +185,9 @@ class Agent(ABC):
             if base_settings_path.stat().st_mtime > cache_mtime:
                 return True
 
-        user_config_path = Path.home() / ".ai-rules-config.yaml"
+        from ai_rules.config import get_user_config_path
+
+        user_config_path = get_user_config_path()
         if user_config_path.exists():
             if user_config_path.stat().st_mtime > cache_mtime:
                 return True

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -35,7 +35,7 @@ def make_github_install_url(repo: str) -> str:
 
 
 UV_NOT_FOUND_ERROR = "uv not found in PATH. Install from https://docs.astral.sh/uv/"
-GITHUB_REPO = "wpfleger96/ai-rules"
+GITHUB_REPO = "wpfleger96/ai-agent-rules"
 STATUSLINE_GITHUB_REPO = "wpfleger96/claude-code-status-line"
 
 

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -389,9 +389,9 @@ def perform_tool_upgrade(tool: ToolSpec) -> tuple[bool, str, bool]:
 
 UPDATABLE_TOOLS: list[ToolSpec] = [
     ToolSpec(
-        tool_id="ai-rules",
+        tool_id="ai-agent-rules",
         package_name="ai-agent-rules",
-        display_name="ai-rules",
+        display_name="ai-agent-rules",
         get_version=lambda: get_tool_version("ai-agent-rules"),
         is_installed=lambda: True,  # Always installed (it's us)
         github_repo=GITHUB_REPO,
@@ -434,13 +434,19 @@ def check_tool_updates(tool: ToolSpec, timeout: int = 30) -> UpdateInfo | None:
         )
 
 
+_TOOL_ID_ALIASES: dict[str, str] = {
+    "ai-rules": "ai-agent-rules",
+}
+
+
 def get_tool_by_id(tool_id: str) -> ToolSpec | None:
-    """Look up tool spec by ID.
+    """Look up tool spec by ID, with alias support.
 
     Args:
-        tool_id: Tool identifier (e.g., "ai-rules", "statusline")
+        tool_id: Tool identifier (e.g., "ai-agent-rules", "ai-rules", "statusline")
 
     Returns:
         ToolSpec if found, None otherwise
     """
-    return next((t for t in UPDATABLE_TOOLS if t.tool_id == tool_id), None)
+    canonical = _TOOL_ID_ALIASES.get(tool_id, tool_id)
+    return next((t for t in UPDATABLE_TOOLS if t.tool_id == canonical), None)

--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -139,7 +139,11 @@ class ClaudeExtensionManager:
             except (OSError, RuntimeError):
                 try:
                     raw_target = str(item.readlink())
-                    if "ai_rules/config" in raw_target or "ai-rules" in raw_target:
+                    if (
+                        "ai_rules/config" in raw_target
+                        or "ai-agent-rules" in raw_target
+                        or "ai-rules" in raw_target
+                    ):
                         orphaned[item.stem if not is_directory else item.name] = item
                 except (OSError, RuntimeError):
                     pass

--- a/src/ai_rules/cli.py
+++ b/src/ai_rules/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for ai-rules."""
+"""Command-line interface for ai-agent-rules."""
 
 import logging
 import os
@@ -28,6 +28,12 @@ except PackageNotFoundError:
     __version__ = "dev"
 
 GIT_SUBPROCESS_TIMEOUT = 5
+
+
+def get_user_config_path() -> Path:
+    from ai_rules.config import get_user_config_path as _get_user_config_path
+
+    return _get_user_config_path()
 
 
 def _get_plugin_status(config: "Config") -> tuple[Any, Any] | None:
@@ -430,7 +436,7 @@ def version_callback(ctx: click.Context, param: click.Parameter, value: bool) ->
     if not value or ctx.resilient_parsing:
         return
 
-    console.print(f"ai-rules, version {__version__}")
+    console.print(f"ai-agent-rules, version {__version__}")
 
     try:
         from ai_rules.bootstrap import get_tool_version, is_command_available
@@ -449,14 +455,14 @@ def version_callback(ctx: click.Context, param: click.Parameter, value: bool) ->
     try:
         from ai_rules.bootstrap import check_tool_updates, get_tool_by_id
 
-        tool = get_tool_by_id("ai-rules")
+        tool = get_tool_by_id("ai-agent-rules")
         if tool:
             update_info = check_tool_updates(tool, timeout=3)
             if update_info and update_info.has_update:
                 console.print(
                     f"\n[cyan]Update available:[/cyan] {update_info.current_version} → {update_info.latest_version}"
                 )
-                console.print("[dim]Run 'ai-rules upgrade' to install[/dim]")
+                console.print("[dim]Run 'ai-agent-rules upgrade' to install[/dim]")
     except Exception as e:
         logger.debug(f"Failed to check for updates in version callback: {e}")
 
@@ -721,9 +727,9 @@ def setup(
     skip_completions: bool,
     profile: str | None,
 ) -> None:
-    """One-time setup: install symlinks and make ai-rules available system-wide.
+    """One-time setup: install symlinks and make ai-agent-rules available system-wide.
 
-    This is the recommended way to install ai-rules for first-time users.
+    This is the recommended way to install ai-agent-rules for first-time users.
 
     Example:
         uvx ai-agent-rules setup
@@ -744,8 +750,8 @@ def setup(
         perform_tool_upgrade,
     )
 
-    console.print("[bold cyan]Step 1/3: Install ai-rules system-wide[/bold cyan]")
-    console.print("This allows you to run 'ai-rules' from any directory.\n")
+    console.print("[bold cyan]Step 1/3: Install ai-agent-rules system-wide[/bold cyan]")
+    console.print("This allows you to run 'ai-agent-rules' from any directory.\n")
 
     statusline_result, statusline_message = ensure_statusline_installed(
         dry_run=dry_run, from_github=github
@@ -766,7 +772,7 @@ def setup(
             "[yellow]⚠[/yellow] Failed to install claude-statusline (continuing anyway)"
         )
 
-    ai_rules_tool = get_tool_by_id("ai-rules")
+    ai_rules_tool = get_tool_by_id("ai-agent-rules")
     tool_install_success = False
 
     if ai_rules_tool and ai_rules_tool.is_installed():
@@ -780,12 +786,12 @@ def setup(
             source_name = "GitHub" if github else "PyPI"
             if dry_run:
                 console.print(
-                    f"[dim]Would switch ai-rules from {current_source.name if current_source else 'unknown'} to {source_name}[/dim]"
+                    f"[dim]Would switch ai-agent-rules from {current_source.name if current_source else 'unknown'} to {source_name}[/dim]"
                 )
                 tool_install_success = True
             else:
                 if not yes and not Confirm.ask(
-                    f"Switch ai-rules to {source_name} install?", default=True
+                    f"Switch ai-agent-rules to {source_name} install?", default=True
                 ):
                     console.print("[yellow]Skipped source switch[/yellow]")
                     tool_install_success = True
@@ -814,26 +820,28 @@ def setup(
                 if update_info and update_info.has_update:
                     if dry_run:
                         console.print(
-                            f"[dim]Would upgrade ai-rules {update_info.current_version} → {update_info.latest_version}[/dim]"
+                            f"[dim]Would upgrade ai-agent-rules {update_info.current_version} → {update_info.latest_version}[/dim]"
                         )
                         tool_install_success = True
                     else:
                         if not yes and not Confirm.ask(
-                            f"Upgrade ai-rules {update_info.current_version} → {update_info.latest_version}?",
+                            f"Upgrade ai-agent-rules {update_info.current_version} → {update_info.latest_version}?",
                             default=True,
                         ):
-                            console.print("[yellow]Skipped ai-rules upgrade[/yellow]")
+                            console.print(
+                                "[yellow]Skipped ai-agent-rules upgrade[/yellow]"
+                            )
                             tool_install_success = True
                         else:
                             success, msg, _ = perform_tool_upgrade(ai_rules_tool)
                             if success:
                                 console.print(
-                                    f"[green]✓[/green] Upgraded ai-rules ({update_info.current_version} → {update_info.latest_version})"
+                                    f"[green]✓[/green] Upgraded ai-agent-rules ({update_info.current_version} → {update_info.latest_version})"
                                 )
                                 tool_install_success = True
                             else:
                                 console.print(
-                                    "[red]Error:[/red] Failed to upgrade ai-rules"
+                                    "[red]Error:[/red] Failed to upgrade ai-agent-rules"
                                 )
                 else:
                     tool_install_success = True
@@ -842,9 +850,9 @@ def setup(
 
     if not tool_install_success:
         if not yes and not dry_run:
-            if not Confirm.ask("Install ai-rules permanently?", default=True):
+            if not Confirm.ask("Install ai-agent-rules permanently?", default=True):
                 console.print(
-                    "\n[yellow]Skipped.[/yellow] You can still run via: uvx ai-rules <command>"
+                    "\n[yellow]Skipped.[/yellow] You can still run via: uvx ai-agent-rules <command>"
                 )
                 return
 
@@ -910,6 +918,8 @@ def setup(
             get_supported_shells,
             install_completion,
             is_completion_installed,
+            is_legacy_completion_block,
+            update_completion,
         )
 
         console.print("\n[bold cyan]Step 3/3: Shell completion setup[/bold cyan]\n")
@@ -918,7 +928,16 @@ def setup(
         if shell:
             config_path = find_config_file(shell)
             if config_path and is_completion_installed(config_path):
-                console.print(f"[green]✓[/green] {shell} completion already installed")
+                if is_legacy_completion_block(config_path):
+                    success, msg = update_completion(shell, dry_run=dry_run)
+                    if success:
+                        console.print(f"[green]✓[/green] {msg}")
+                    else:
+                        console.print(f"[yellow]⚠[/yellow] {msg}")
+                else:
+                    console.print(
+                        f"[green]✓[/green] {shell} completion already installed"
+                    )
             elif (
                 yes
                 or dry_run
@@ -939,7 +958,9 @@ def setup(
         console.print("\n[dim]Dry run complete - no changes were made.[/dim]")
     else:
         console.print("\n[green]✓ Setup complete![/green]")
-        console.print("You can now run [bold]ai-rules[/bold] from anywhere.")
+        console.print(
+            "You can now run [bold]ai-agent-rules[/bold] (or [bold]ai-rules[/bold]) from anywhere."
+        )
 
 
 @main.command()
@@ -1192,7 +1213,7 @@ def install(
         shell = detect_shell()
         if shell:
             success, msg = install_completion(shell, dry_run=dry_run)
-            if success and not dry_run:
+            if success and not dry_run and "already installed" not in msg:
                 console.print(f"\n[dim]✓ {msg}[/dim]")
 
     format_summary(
@@ -1606,7 +1627,7 @@ def status(agents: str | None) -> None:
         else:
             console.print(
                 f"  [yellow]○[/yellow] {shell} completion not installed "
-                "(run: ai-rules completions install)"
+                "(run: ai-agent-rules completions install)"
             )
     else:
         supported = ", ".join(get_supported_shells())
@@ -1619,15 +1640,17 @@ def status(agents: str | None) -> None:
     if not all_correct:
         if cache_stale:
             console.print(
-                "[yellow]💡 Run 'ai-rules install --rebuild-cache' to fix issues[/yellow]"
+                "[yellow]💡 Run 'ai-agent-rules install --rebuild-cache' to fix issues[/yellow]"
             )
         else:
-            console.print("[yellow]💡 Run 'ai-rules install' to fix issues[/yellow]")
+            console.print(
+                "[yellow]💡 Run 'ai-agent-rules install' to fix issues[/yellow]"
+            )
         sys.exit(1)
     elif statusline_missing:
         console.print("[green]All symlinks are correct![/green]")
         console.print(
-            "[yellow]💡 Run 'ai-rules install' to install optional tools[/yellow]"
+            "[yellow]💡 Run 'ai-agent-rules install' to install optional tools[/yellow]"
         )
     else:
         console.print("[green]All symlinks are correct![/green]")
@@ -1753,19 +1776,19 @@ def list_agents_cmd() -> None:
 )
 @click.option(
     "--only",
-    type=click.Choice(["ai-rules", "statusline"]),
+    type=click.Choice(["ai-agent-rules", "ai-rules", "statusline"]),
     help="Only upgrade specific tool",
 )
 def upgrade(
     check: bool, force: bool, yes: bool, skip_install: bool, only: str | None
 ) -> None:
-    """Upgrade ai-rules and related tools to the latest versions from PyPI.
+    """Upgrade ai-agent-rules and related tools to the latest versions from PyPI.
 
     Examples:
-        ai-rules upgrade                    # Check and install all updates
-        ai-rules upgrade --check            # Only check for updates
-        ai-rules upgrade -y                 # Auto-confirm installation
-        ai-rules upgrade --only=statusline  # Only upgrade statusline tool
+        ai-agent-rules upgrade                    # Check and install all updates
+        ai-agent-rules upgrade --check            # Only check for updates
+        ai-agent-rules upgrade -y                 # Auto-confirm installation
+        ai-agent-rules upgrade --only=statusline  # Only upgrade statusline tool
     """
     from rich.console import Console
     from rich.prompt import Confirm
@@ -1775,10 +1798,16 @@ def upgrade(
         check_tool_updates,
         perform_tool_upgrade,
     )
+    from ai_rules.bootstrap.updater import _TOOL_ID_ALIASES
 
     console = Console()
 
-    tools = [t for t in UPDATABLE_TOOLS if only is None or t.tool_id == only]
+    resolved_only = _TOOL_ID_ALIASES.get(only, only) if only else None
+    tools = [
+        t
+        for t in UPDATABLE_TOOLS
+        if resolved_only is None or t.tool_id == resolved_only
+    ]
     tools = [t for t in tools if t.is_installed()]
 
     if not tools:
@@ -1842,7 +1871,7 @@ def upgrade(
 
     if check:
         if tool_updates:
-            console.print("\nRun [bold]ai-rules upgrade[/bold] to install")
+            console.print("\nRun [bold]ai-agent-rules upgrade[/bold] to install")
         return
 
     if not force and not yes:
@@ -1871,7 +1900,7 @@ def upgrade(
                 console.print(
                     f"[green]✓[/green] {tool.display_name} upgraded to {new_version}"
                 )
-                if tool.tool_id == "ai-rules":
+                if tool.tool_id == "ai-agent-rules":
                     ai_rules_upgraded = True
             elif new_version == update_info.current_version:
                 console.print(
@@ -1881,7 +1910,7 @@ def upgrade(
                 console.print(
                     f"[green]✓[/green] {tool.display_name} upgraded to {new_version}"
                 )
-                if tool.tool_id == "ai-rules":
+                if tool.tool_id == "ai-agent-rules":
                     ai_rules_upgraded = True
         else:
             console.print(
@@ -1892,7 +1921,9 @@ def upgrade(
         try:
             import subprocess
 
-            console.print("\n[dim]Running 'ai-rules install --rebuild-cache'...[/dim]")
+            console.print(
+                "\n[dim]Running 'ai-agent-rules install --rebuild-cache'...[/dim]"
+            )
 
             from ai_rules.state import get_active_profile
 
@@ -1900,7 +1931,7 @@ def upgrade(
 
             result = subprocess.run(
                 [
-                    "ai-rules",
+                    "ai-agent-rules",
                     "install",
                     "--rebuild-cache",
                     "-y",
@@ -1919,21 +1950,23 @@ def upgrade(
                     f"[yellow]⚠[/yellow] Install failed with exit code {result.returncode}"
                 )
                 console.print(
-                    "[dim]Run 'ai-rules install --rebuild-cache' manually to retry[/dim]"
+                    "[dim]Run 'ai-agent-rules install --rebuild-cache' manually to retry[/dim]"
                 )
         except subprocess.TimeoutExpired:
             console.print("[yellow]⚠[/yellow] Install timed out after 30 seconds")
             console.print(
-                "[dim]Run 'ai-rules install --rebuild-cache' manually to retry[/dim]"
+                "[dim]Run 'ai-agent-rules install --rebuild-cache' manually to retry[/dim]"
             )
         except Exception as e:
             console.print(f"[yellow]⚠[/yellow] Could not run install: {e}")
-            console.print("[dim]Run 'ai-rules install --rebuild-cache' manually[/dim]")
+            console.print(
+                "[dim]Run 'ai-agent-rules install --rebuild-cache' manually[/dim]"
+            )
 
 
 @main.command()
 def info() -> None:
-    """Show installation method and version info for ai-rules tools.
+    """Show installation method and version info for ai-agent-rules tools.
 
     Displays how each tool was installed (PyPI or GitHub)
     along with current versions and update availability.
@@ -1984,7 +2017,7 @@ def info() -> None:
     console.print(table)
 
     if has_updates:
-        console.print("\n[dim]Run 'ai-rules upgrade' to install updates.[/dim]")
+        console.print("\n[dim]Run 'ai-agent-rules upgrade' to install updates.[/dim]")
 
 
 @main.command()
@@ -2173,7 +2206,7 @@ def diff(agents: str | None) -> None:
         console.print("[green]No differences found - all symlinks are correct![/green]")
     else:
         console.print(
-            "[yellow]💡 Run 'ai-rules install' to fix these differences[/yellow]"
+            "[yellow]💡 Run 'ai-agent-rules install' to fix these differences[/yellow]"
         )
 
 
@@ -2208,7 +2241,7 @@ def exclude_add(pattern: str) -> None:
     data["exclude_symlinks"].append(pattern)
     Config.save_user_config(data)
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
     console.print(f"[green]✓[/green] Added exclusion pattern: {pattern}")
     console.print(f"[dim]Config updated: {user_config_path}[/dim]")
 
@@ -2223,7 +2256,7 @@ def exclude_remove(pattern: str) -> None:
 
     console = Console()
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
 
     if not user_config_path.exists():
         console.print("[red]No user config found[/red]")
@@ -2299,7 +2332,7 @@ def override_set(key: str, value: str) -> None:
 
     console = Console()
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
     config_dir = get_config_dir()
 
     parts = key.split(".", 1)
@@ -2395,7 +2428,7 @@ def override_set(key: str, value: str) -> None:
     console.print(f"[green]✓[/green] Set override: {agent}.{setting} = {parsed_value}")
     console.print(f"[dim]Config updated: {user_config_path}[/dim]")
     console.print(
-        "\n[yellow]💡 Run 'ai-rules install --rebuild-cache' to apply changes[/yellow]"
+        "\n[yellow]💡 Run 'ai-agent-rules install --rebuild-cache' to apply changes[/yellow]"
     )
 
 
@@ -2413,7 +2446,7 @@ def override_unset(key: str) -> None:
 
     console = Console()
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
 
     if not user_config_path.exists():
         console.print("[red]No user config found[/red]")
@@ -2469,7 +2502,7 @@ def override_unset(key: str) -> None:
     console.print(f"[green]✓[/green] Removed override: {key}")
     console.print(f"[dim]Config updated: {user_config_path}[/dim]")
     console.print(
-        "\n[yellow]💡 Run 'ai-rules install --rebuild-cache' to apply changes[/yellow]"
+        "\n[yellow]💡 Run 'ai-agent-rules install --rebuild-cache' to apply changes[/yellow]"
     )
 
 
@@ -2500,7 +2533,7 @@ def override_list() -> None:
 
 @main.group()
 def config() -> None:
-    """Manage ai-rules configuration."""
+    """Manage ai-agent-rules configuration."""
     pass
 
 
@@ -2519,7 +2552,7 @@ def config_show(merged: bool, agent: str | None) -> None:
 
     config_dir = get_config_dir()
     cfg = Config.load()
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
 
     if merged:
         console.print("[bold]Merged Settings:[/bold]\n")
@@ -2616,7 +2649,7 @@ def config_edit() -> None:
     import os
     import subprocess
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
     editor = os.environ.get("EDITOR", "vi")
 
     if not user_config_path.exists():
@@ -2813,10 +2846,12 @@ def config_init() -> None:
 
     console = Console()
 
-    user_config_path = Path.home() / ".ai-rules-config.yaml"
+    user_config_path = get_user_config_path()
 
-    console.print("[bold cyan]Welcome to ai-rules configuration wizard![/bold cyan]\n")
-    console.print("This will help you set up your .ai-rules-config.yaml file.")
+    console.print(
+        "[bold cyan]Welcome to ai-agent-rules configuration wizard![/bold cyan]\n"
+    )
+    console.print("This will help you set up your .ai-agent-rules-config.yaml file.")
     console.print(f"Config will be created at: [dim]{user_config_path}[/dim]\n")
 
     if user_config_path.exists():
@@ -2842,10 +2877,14 @@ def config_init() -> None:
 
         console.print(f"\n[green]✓[/green] Configuration saved to {user_config_path}")
         console.print("\n[bold]Next steps:[/bold]")
-        console.print("  • Run [cyan]ai-rules install[/cyan] to apply these settings")
-        console.print("  • Run [cyan]ai-rules config show[/cyan] to view your config")
         console.print(
-            "  • Run [cyan]ai-rules config show --merged[/cyan] to see merged settings"
+            "  • Run [cyan]ai-agent-rules install[/cyan] to apply these settings"
+        )
+        console.print(
+            "  • Run [cyan]ai-agent-rules config show[/cyan] to view your config"
+        )
+        console.print(
+            "  • Run [cyan]ai-agent-rules config show --merged[/cyan] to see merged settings"
         )
     else:
         console.print("[dim]Configuration not saved[/dim]")
@@ -2970,7 +3009,7 @@ def _detect_profile_override_conflicts(
 
     Args:
         profile: The profile being installed
-        user_config: User config dict from ~/.ai-rules-config.yaml
+        user_config: User config dict from ~/.ai-agent-rules-config.yaml
 
     Returns:
         List of (agent, key, value) tuples for settings that conflict
@@ -3091,7 +3130,7 @@ def completions_bash() -> None:
         console.print(
             "\n[dim]To install: Add the above to your ~/.bashrc or run:[/dim]"
         )
-        console.print("[dim]  ai-rules completions install[/dim]")
+        console.print("[dim]  ai-agent-rules completions install[/dim]")
     except Exception as e:
         console.print(f"[red]Error generating completion script:[/red] {e}")
         sys.exit(1)
@@ -3110,7 +3149,7 @@ def completions_zsh() -> None:
         script = generate_completion_script("zsh")
         console.print(script)
         console.print("\n[dim]To install: Add the above to your ~/.zshrc or run:[/dim]")
-        console.print("[dim]  ai-rules completions install[/dim]")
+        console.print("[dim]  ai-agent-rules completions install[/dim]")
     except Exception as e:
         console.print(f"[red]Error generating completion script:[/red] {e}")
         sys.exit(1)
@@ -3188,6 +3227,38 @@ def completions_uninstall(shell: str | None) -> None:
         sys.exit(1)
 
 
+@completions.command(name="update")
+@click.option(
+    "--shell",
+    type=click.Choice(_SUPPORTED_SHELLS, case_sensitive=False),
+    help="Shell type (auto-detected if not specified)",
+)
+def completions_update(shell: str | None) -> None:
+    """Re-generate completion block (fixes PATH shadowing issues)."""
+    from rich.console import Console
+
+    from ai_rules.completions import detect_shell, update_completion
+
+    console = Console()
+
+    if shell is None:
+        shell = detect_shell()
+        if shell is None:
+            console.print(
+                "[red]Error:[/red] Could not detect shell. Use --shell to specify."
+            )
+            sys.exit(1)
+        console.print(f"[dim]Detected shell:[/dim] {shell}")
+
+    success, message = update_completion(shell, dry_run=False)
+
+    if success:
+        console.print(f"[green]✓[/green] {message}")
+    else:
+        console.print(f"[red]Error:[/red] {message}")
+        sys.exit(1)
+
+
 @completions.command(name="status")
 def completions_status() -> None:
     """Show shell completion installation status."""
@@ -3233,7 +3304,7 @@ def completions_status() -> None:
         table.add_row(shell_name, status, config_str)
 
     console.print(table)
-    console.print("\n[dim]To install: ai-rules completions install[/dim]")
+    console.print("\n[dim]To install: ai-agent-rules completions install[/dim]")
 
 
 if __name__ == "__main__":

--- a/src/ai_rules/completions.py
+++ b/src/ai_rules/completions.py
@@ -1,12 +1,19 @@
 """Shell completion installation and management."""
 
 import os
+import re
 
 from dataclasses import dataclass
 from pathlib import Path
 
-COMPLETION_MARKER_START = "# ai-rules shell completion"
-COMPLETION_MARKER_END = "# End ai-rules shell completion"
+COMPLETION_MARKER_START = "# ai-agent-rules shell completion"
+COMPLETION_MARKER_END = "# End ai-agent-rules shell completion"
+
+_LEGACY_MARKER_START = "# ai-rules shell completion"
+_LEGACY_MARKER_END = "# End ai-rules shell completion"
+
+CANONICAL_CMD = "ai-agent-rules"
+ALIAS_CMD = "ai-rules"
 
 
 @dataclass
@@ -72,6 +79,11 @@ def find_config_file(shell: str) -> Path | None:
     return candidates[0] if candidates else None
 
 
+def _has_any_marker(content: str) -> bool:
+    """Check if content contains any completion marker (current or legacy)."""
+    return COMPLETION_MARKER_START in content or _LEGACY_MARKER_START in content
+
+
 def is_completion_installed(config_path: Path) -> bool:
     """Check if completion is already installed in config file.
 
@@ -79,17 +91,36 @@ def is_completion_installed(config_path: Path) -> bool:
         config_path: Path to shell config file
 
     Returns:
-        True if completion marker found in file
+        True if any completion marker (current or legacy) found in file
     """
     if not config_path.exists():
         return False
 
     content = config_path.read_text()
-    return COMPLETION_MARKER_START in content
+    return _has_any_marker(content)
+
+
+def is_legacy_completion_block(config_path: Path) -> bool:
+    """Check if the installed completion block uses the legacy format.
+
+    Legacy format: old markers or missing `command -v` guard.
+    """
+    if not config_path.exists():
+        return False
+
+    content = config_path.read_text()
+    if _LEGACY_MARKER_START in content:
+        return True
+    if COMPLETION_MARKER_START in content and "command -v" not in content:
+        return True
+    return False
 
 
 def generate_completion_script(shell: str) -> str:
-    """Generate completion script using Click's shell_completion module.
+    """Generate completion script with shell-native aliasing.
+
+    Uses ai-agent-rules (unshadowed by Hermit) as the canonical binary,
+    then aliases the completion function to ai-rules via compdef/complete.
 
     Args:
         shell: Shell name ('bash' or 'zsh')
@@ -106,11 +137,21 @@ def generate_completion_script(shell: str) -> str:
     if comp_cls is None:
         raise ValueError(f"Unsupported shell: {shell}")
 
-    prog_name = "ai-rules"
-    env_var = f"_{prog_name.upper().replace('-', '_')}_COMPLETE"
+    env_var = f"_{CANONICAL_CMD.upper().replace('-', '_')}_COMPLETE"
 
-    return f"""{COMPLETION_MARKER_START}
-eval "$({env_var}={shell}_source {prog_name})"
+    if shell == "zsh":
+        return f"""{COMPLETION_MARKER_START}
+if command -v {CANONICAL_CMD} >/dev/null 2>&1; then
+  eval "$({env_var}=zsh_source {CANONICAL_CMD})"
+  compdef _ai_agent_rules_completion {ALIAS_CMD}
+fi
+{COMPLETION_MARKER_END}"""
+    else:
+        return f"""{COMPLETION_MARKER_START}
+if command -v {CANONICAL_CMD} >/dev/null 2>&1; then
+  eval "$({env_var}=bash_source {CANONICAL_CMD})"
+  complete -o nosort -F _ai_agent_rules_completion {ALIAS_CMD}
+fi
 {COMPLETION_MARKER_END}"""
 
 
@@ -137,6 +178,8 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
         )
 
     if is_completion_installed(config_path):
+        if is_legacy_completion_block(config_path):
+            return update_completion(shell, dry_run=dry_run)
         return True, f"Completion already installed in {config_path}"
 
     script = generate_completion_script(shell)
@@ -155,8 +198,37 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
         return False, f"Failed to write to {config_path}: {e}"
 
 
+def update_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
+    """Replace existing completion block with a freshly generated one."""
+    config_path = find_config_file(shell)
+    if config_path is None:
+        return False, f"No {shell} config file found"
+    if not is_completion_installed(config_path):
+        return install_completion(shell, dry_run=dry_run)
+
+    new_script = generate_completion_script(shell)
+    if dry_run:
+        return True, f"Would update completion in {config_path}"
+
+    content = config_path.read_text()
+
+    start_re = (
+        re.escape(COMPLETION_MARKER_START) + "|" + re.escape(_LEGACY_MARKER_START)
+    )
+    end_re = re.escape(COMPLETION_MARKER_END) + "|" + re.escape(_LEGACY_MARKER_END)
+    pattern = f"({start_re}).*?({end_re})"
+    new_content, n = re.subn(pattern, new_script, content, flags=re.DOTALL)
+    if n == 0:
+        return False, f"Could not find completion block in {config_path}"
+    config_path.write_text(new_content)
+    return (
+        True,
+        f"Completion updated in {config_path}. Restart your shell or run: source {config_path}",
+    )
+
+
 def uninstall_completion(config_path: Path) -> tuple[bool, str]:
-    """Remove completion block from shell config file.
+    """Remove all completion blocks (current and legacy) from shell config file.
 
     Args:
         config_path: Path to shell config file
@@ -172,23 +244,18 @@ def uninstall_completion(config_path: Path) -> tuple[bool, str]:
 
     try:
         content = config_path.read_text()
-        lines = content.split("\n")
 
-        start_idx = None
-        end_idx = None
-        for i, line in enumerate(lines):
-            if COMPLETION_MARKER_START in line:
-                start_idx = i
-            elif COMPLETION_MARKER_END in line:
-                end_idx = i
-                break
+        start_re = (
+            re.escape(COMPLETION_MARKER_START) + "|" + re.escape(_LEGACY_MARKER_START)
+        )
+        end_re = re.escape(COMPLETION_MARKER_END) + "|" + re.escape(_LEGACY_MARKER_END)
+        pattern = f"({start_re}).*?({end_re})"
+        new_content = re.sub(pattern, "", content, flags=re.DOTALL)
 
-        if start_idx is not None and end_idx is not None:
-            new_lines = lines[:start_idx] + lines[end_idx + 1 :]
-            new_content = "\n".join(new_lines)
-            config_path.write_text(new_content)
-            return True, f"Completion removed from {config_path}"
-        else:
-            return False, f"Could not find completion block markers in {config_path}"
+        # Clean up extra blank lines left behind
+        new_content = re.sub(r"\n{3,}", "\n\n", new_content)
+
+        config_path.write_text(new_content)
+        return True, f"Completion removed from {config_path}"
     except Exception as e:
         return False, f"Failed to modify {config_path}: {e}"

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -35,6 +35,8 @@ __all__ = [
     "CONFIG_PARSE_ERRORS",
     "ManagedFieldsTracker",
     "dump_config_file",
+    "get_managed_fields_path",
+    "get_user_config_path",
     "load_config_file",
     "navigate_path",
     "parse_setting_path",
@@ -65,7 +67,53 @@ AGENT_SKILLS_DIRS = {
     "goose": Path("~/.config/goose/skills"),
 }
 
-MANAGED_FIELDS_PATH = Path.home() / ".claude" / "ai-rules-managed-fields.json"
+_CONFIG_FILE_NAME = ".ai-agent-rules-config.yaml"
+_LEGACY_CONFIG_FILE_NAME = ".ai-rules-config.yaml"
+
+_MANAGED_FIELDS_FILE = "ai-agent-rules-managed-fields.json"
+_LEGACY_MANAGED_FIELDS_FILE = "ai-rules-managed-fields.json"
+
+
+def get_user_config_path() -> Path:
+    """Get the user config file path, migrating from legacy path if needed."""
+    import sys
+
+    home = Path.home()
+    new_path = home / _CONFIG_FILE_NAME
+    old_path = home / _LEGACY_CONFIG_FILE_NAME
+
+    if new_path.exists():
+        if old_path.exists():
+            old_size = old_path.stat().st_size
+            new_size = new_path.stat().st_size
+            if new_size == 0 and old_size > 0:
+                shutil.copy2(old_path, new_path)
+                old_path.rename(old_path.with_suffix(".yaml.migrated"))
+            else:
+                print(
+                    f"Warning: Found config at both {old_path} and {new_path}. Using {new_path}.",
+                    file=sys.stderr,
+                )
+        return new_path
+
+    if old_path.exists():
+        old_path.rename(new_path)
+        return new_path
+
+    return new_path
+
+
+def get_managed_fields_path() -> Path:
+    """Get the managed fields tracking file path, migrating from legacy if needed."""
+    claude_dir = Path.home() / ".claude"
+    new_path = claude_dir / _MANAGED_FIELDS_FILE
+    old_path = claude_dir / _LEGACY_MANAGED_FIELDS_FILE
+
+    if not new_path.exists() and old_path.exists():
+        old_path.rename(new_path)
+
+    return new_path
+
 
 CONFIG_PARSE_ERRORS = (
     json.JSONDecodeError,
@@ -325,18 +373,20 @@ def validate_override_path(
 
 
 class ManagedFieldsTracker:
-    """Track ai-rules contributions to preserved fields.
+    """Track ai-agent-rules contributions to preserved fields.
 
-    Prevents stale entries when ai-rules removes something from source config
+    Prevents stale entries when ai-agent-rules removes something from source config
     while preserving user-added entries.
     """
 
-    def __init__(self, path: Path = MANAGED_FIELDS_PATH):
+    def __init__(self, path: Path | None = None):
+        if path is None:
+            path = get_managed_fields_path()
         self.path = path
         self._data: dict[str, Any] = {}
 
     def load(self) -> dict[str, Any]:
-        """Load tracked ai-rules contributions."""
+        """Load tracked ai-agent-rules contributions."""
         if not self.path.exists():
             return {"version": 1}
 
@@ -348,7 +398,7 @@ class ManagedFieldsTracker:
             return {"version": 1}
 
     def save(self, contributions: dict[str, Any] | None = None) -> None:
-        """Save ai-rules contributions."""
+        """Save ai-agent-rules contributions."""
         if contributions is not None:
             self._data = contributions
 
@@ -362,13 +412,13 @@ class ManagedFieldsTracker:
             pass
 
     def get_field_contributions(self, field: str) -> Any:
-        """Get ai-rules contributions for a specific field."""
+        """Get ai-agent-rules contributions for a specific field."""
         if not self._data:
             self.load()
         return self._data.get(field)
 
     def set_field_contributions(self, field: str, value: Any) -> None:
-        """Update ai-rules contributions for a specific field."""
+        """Update ai-agent-rules contributions for a specific field."""
         if not self._data:
             self.load()
         if value is None:
@@ -382,12 +432,12 @@ class ManagedFieldsTracker:
         source_settings: dict[str, Any],
         preserved_fields: list[str],
     ) -> dict[str, Any]:
-        """Remove stale ai-rules contributions from existing settings.
+        """Remove stale ai-agent-rules contributions from existing settings.
 
         For each preserved field:
-        1. Get what ai-rules previously contributed (from tracking file)
-        2. Get what ai-rules currently contributes (from source settings)
-        3. Find entries in existing that match stale ai-rules contributions
+        1. Get what ai-agent-rules previously contributed (from tracking file)
+        2. Get what ai-agent-rules currently contributes (from source settings)
+        3. Find entries in existing that match stale ai-agent-rules contributions
         4. Remove those stale entries, keep everything else
 
         Returns cleaned existing_settings.
@@ -422,7 +472,7 @@ class ManagedFieldsTracker:
         """Remove stale ai-rules hook contributions.
 
         For each event type (UserPromptSubmit, PreCompact, etc.):
-        1. Get tracked commands ai-rules added
+        1. Get tracked commands ai-agent-rules added
         2. Get current commands in source config
         3. For each tracked command not in source, remove from existing
         4. Keep all user-added hooks
@@ -469,7 +519,7 @@ class ManagedFieldsTracker:
 
 
 class Config:
-    """Configuration for ai-rules tool."""
+    """Configuration for ai-agent-rules tool."""
 
     def __init__(
         self,
@@ -515,11 +565,11 @@ class Config:
 
     @classmethod
     def load(cls, profile: str | None = None) -> Config:
-        """Load configuration from profile and ~/.ai-rules-config.yaml.
+        """Load configuration from profile and ~/.ai-agent-rules-config.yaml.
 
         Merge order (lowest to highest priority):
         1. Profile overrides (if profile specified, defaults to active profile or "default")
-        2. Local overrides from ~/.ai-rules-config.yaml
+        2. Local overrides from ~/.ai-agent-rules-config.yaml
 
         Args:
             profile: Optional profile name to load (default: active profile or "default")
@@ -552,7 +602,7 @@ class Config:
         plugins = copy.deepcopy(profile_data.plugins)
         marketplaces = copy.deepcopy(profile_data.marketplaces)
 
-        user_config_path = Path.home() / ".ai-rules-config.yaml"
+        user_config_path = get_user_config_path()
         if user_config_path.exists():
             with open(user_config_path) as f:
                 user_data = yaml.safe_load(f) or {}
@@ -606,7 +656,9 @@ class Config:
     @staticmethod
     def get_cache_dir() -> Path:
         """Get the cache directory for merged settings."""
-        cache_dir = Path.home() / ".ai-rules" / "cache"
+        from ai_rules.state import get_state_dir
+
+        cache_dir = get_state_dir() / "cache"
         cache_dir.mkdir(parents=True, exist_ok=True)
         return cache_dir
 
@@ -685,7 +737,7 @@ class Config:
         Returns:
             Dictionary with user config data, or empty dict with version if file doesn't exist
         """
-        user_config_path = Path.home() / ".ai-rules-config.yaml"
+        user_config_path = get_user_config_path()
 
         if user_config_path.exists():
             with open(user_config_path) as f:
@@ -699,7 +751,7 @@ class Config:
         Args:
             data: Configuration dictionary to save
         """
-        user_config_path = Path.home() / ".ai-rules-config.yaml"
+        user_config_path = get_user_config_path()
         user_config_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(user_config_path, "w") as f:

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -36,13 +36,19 @@ class MCPStatus:
         self.has_overrides: dict[str, bool] = {}
 
 
-MANAGED_BY_VALUE = "ai-rules"
+MANAGED_BY_VALUE = "ai-agent-rules"
+_MANAGED_BY_VALUE_LEGACY = "ai-rules"
+
+
+def is_managed_value(v: str | None) -> bool:
+    """Check if a value matches the current or legacy managed-by marker."""
+    return v in (MANAGED_BY_VALUE, _MANAGED_BY_VALUE_LEGACY)
 
 
 class MCPManager(ABC):
     """Abstract base for agent-specific MCP config managers."""
 
-    BACKUP_SUFFIX = "ai-rules-backup"
+    BACKUP_SUFFIX = "ai-agent-rules-backup"
 
     # --- abstract interface ---------------------------------------------------
 
@@ -181,7 +187,7 @@ class MCPManager(ABC):
         tracked_mcps = {
             name
             for name, cfg in current_mcps.items()
-            if cfg.get(self._marker_field) == MANAGED_BY_VALUE
+            if is_managed_value(cfg.get(self._marker_field))
         }
         removed_mcps = tracked_mcps - set(native_mcps.keys())
 
@@ -226,7 +232,7 @@ class MCPManager(ABC):
         tracked_mcps = {
             name
             for name, cfg in current_mcps.items()
-            if cfg.get(self._marker_field) == MANAGED_BY_VALUE
+            if is_managed_value(cfg.get(self._marker_field))
         }
 
         if not tracked_mcps:
@@ -261,7 +267,7 @@ class MCPManager(ABC):
         marker = self._marker_field
 
         for name, mcp_config in installed_mcps.items():
-            if mcp_config.get(marker) == MANAGED_BY_VALUE:
+            if is_managed_value(mcp_config.get(marker)):
                 if name in native_mcps:
                     status.managed_mcps[name] = mcp_config
                     expected_clean = {
@@ -450,18 +456,16 @@ class CodexMCPManager(MCPManager):
     Uses tomlkit for round-trip editing so non-MCP keys (approval_policy,
     trust_level, model) and comments are preserved.
 
-    The managed-names list is stored in a dedicated [_ai_rules_managed] section
+    The managed-names list is stored in a dedicated TOML section
     because TOML inline per-table markers are awkward.
     """
 
-    _MANAGED_SECTION = "_ai_rules_managed"
+    _MANAGED_SECTION = "_ai_agent_rules_managed"
+    _LEGACY_MANAGED_SECTION = "_ai_rules_managed"
 
     @property
     def _marker_field(self) -> str:
-        # Codex uses a dedicated section rather than per-entry markers;
-        # this value is returned for interface compatibility but not embedded
-        # inside individual MCP entries.
-        return "_ai_rules_managed_entry"
+        return "_ai_agent_rules_managed_entry"
 
     @property
     def _config_path(self) -> Path:
@@ -479,7 +483,9 @@ class CodexMCPManager(MCPManager):
             return tomlkit.load(f)
 
     def _get_managed_names(self, doc: Any) -> set[str]:
-        section = doc.get(self._MANAGED_SECTION, {})
+        section = doc.get(self._MANAGED_SECTION) or doc.get(
+            self._LEGACY_MANAGED_SECTION, {}
+        )
         names = section.get("names", [])
         return set(names) if isinstance(names, list) else set()
 
@@ -510,7 +516,7 @@ class CodexMCPManager(MCPManager):
         mcp_table = tomlkit.table()
 
         for name, cfg in mcps.items():
-            is_managed = cfg.get(self._marker_field) == MANAGED_BY_VALUE
+            is_managed = is_managed_value(cfg.get(self._marker_field))
             entry = tomlkit.table()
             for k, v in cfg.items():
                 if k == self._marker_field:
@@ -531,6 +537,9 @@ class CodexMCPManager(MCPManager):
         mgmt_section = tomlkit.table()
         mgmt_section["names"] = managed_names
         doc[self._MANAGED_SECTION] = mgmt_section
+
+        if self._LEGACY_MANAGED_SECTION in doc:
+            del doc[self._LEGACY_MANAGED_SECTION]
 
         with open(self._config_path, "w") as f:
             f.write(tomlkit.dumps(doc))

--- a/src/ai_rules/plugins.py
+++ b/src/ai_rules/plugins.py
@@ -54,7 +54,18 @@ class PluginManager:
     KNOWN_MARKETPLACES_PATH = (
         Path.home() / ".claude" / "plugins" / "known_marketplaces.json"
     )
-    MANAGED_PLUGINS_PATH = Path.home() / ".claude" / "plugins" / "ai-rules-managed.json"
+    _MANAGED_PLUGINS_FILE = "ai-agent-rules-managed.json"
+    _LEGACY_MANAGED_PLUGINS_FILE = "ai-rules-managed.json"
+
+    @property
+    def MANAGED_PLUGINS_PATH(self) -> Path:
+        plugins_dir = Path.home() / ".claude" / "plugins"
+        new_path = plugins_dir / self._MANAGED_PLUGINS_FILE
+        old_path = plugins_dir / self._LEGACY_MANAGED_PLUGINS_FILE
+        if not new_path.exists() and old_path.exists():
+            old_path.rename(new_path)
+        return new_path
+
     SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
     CLI_TIMEOUT = 30
 

--- a/src/ai_rules/state.py
+++ b/src/ai_rules/state.py
@@ -1,4 +1,4 @@
-"""State management for ai-rules."""
+"""State management for ai-agent-rules."""
 
 from datetime import UTC, datetime
 from pathlib import Path
@@ -6,10 +6,28 @@ from typing import Any
 
 import yaml
 
+_STATE_DIR_NAME = ".ai-agent-rules"
+_LEGACY_STATE_DIR_NAME = ".ai-rules"
+
+
+def get_state_dir() -> Path:
+    """Get the state directory, migrating from legacy path if needed."""
+    home = Path.home()
+    new_dir = home / _STATE_DIR_NAME
+    if new_dir.exists():
+        return new_dir
+
+    old_dir = home / _LEGACY_STATE_DIR_NAME
+    if old_dir.exists():
+        old_dir.rename(new_dir)
+        return new_dir
+
+    return new_dir
+
 
 def _get_state_file() -> Path:
     """Get the state file path."""
-    return Path.home() / ".ai-rules" / "state.yaml"
+    return get_state_dir() / "state.yaml"
 
 
 def get_state() -> dict[str, Any]:

--- a/src/ai_rules/symlinks.py
+++ b/src/ai_rules/symlinks.py
@@ -18,10 +18,10 @@ def create_backup_path(target: Path) -> Path:
         target: The file to backup
 
     Returns:
-        Path with timestamp appended (e.g., file.md.ai-rules-backup.20250104-143022)
+        Path with timestamp appended (e.g., file.md.ai-agent-rules-backup.20250104-143022)
     """
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    return Path(f"{target}.ai-rules-backup.{timestamp}")
+    return Path(f"{target}.ai-agent-rules-backup.{timestamp}")
 
 
 class SymlinkResult(Enum):

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -9,7 +9,7 @@ class TestConfigInitCommand:
     """Tests for the config init command."""
 
     def test_config_init_creates_basic_config(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
@@ -37,7 +37,7 @@ class TestConfigInitCommand:
         assert "exclude_symlinks" not in data or len(data["exclude_symlinks"]) == 0
 
     def test_config_init_with_exclusions(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
@@ -67,7 +67,7 @@ class TestConfigInitCommand:
         assert "~/.custom/pattern.txt" in data["exclude_symlinks"]
 
     def test_config_init_with_settings_overrides(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
@@ -104,7 +104,7 @@ class TestConfigInitCommand:
     def test_config_init_cancels_on_overwrite_decline(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         with open(config_path, "w") as f:
@@ -120,7 +120,7 @@ class TestConfigInitCommand:
     def test_config_init_overwrites_existing_config(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         with open(config_path, "w") as f:
@@ -151,7 +151,7 @@ class TestConfigInitCommand:
         assert data["version"] == 1
 
     def test_config_init_cancels_on_save_decline(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
@@ -179,7 +179,7 @@ class TestConfigShowCommand:
     """Tests for the config show command."""
 
     def test_config_show_displays_user_config(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         config_data = {

--- a/tests/integration/test_exclude_commands.py
+++ b/tests/integration/test_exclude_commands.py
@@ -9,7 +9,7 @@ class TestExcludeAddCommand:
     """Tests for the exclude add command."""
 
     def test_exclude_add_creates_config_if_missing(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(main, ["exclude", "add", "~/.claude/test.json"])
@@ -26,7 +26,7 @@ class TestExcludeAddCommand:
     def test_exclude_add_appends_to_existing_config(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -48,7 +48,7 @@ class TestExcludeAddCommand:
         assert "~/.new/pattern.txt" in data["exclude_symlinks"]
 
     def test_exclude_add_rejects_duplicate_pattern(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -69,7 +69,7 @@ class TestExcludeAddCommand:
         assert data["exclude_symlinks"].count("~/.claude/settings.json") == 1
 
     def test_exclude_add_handles_glob_patterns(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(main, ["exclude", "add", "~/.claude/*.json"])
@@ -86,7 +86,7 @@ class TestExcludeRemoveCommand:
     """Tests for the exclude remove command."""
 
     def test_exclude_remove_deletes_pattern(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -120,7 +120,7 @@ class TestExcludeRemoveCommand:
     def test_exclude_remove_fails_on_nonexistent_pattern(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -140,7 +140,7 @@ class TestExcludeListCommand:
     """Tests for the exclude list command."""
 
     def test_exclude_list_shows_patterns(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -161,7 +161,7 @@ class TestExcludeListCommand:
         assert "~/.pattern2.txt" in result.output
 
     def test_exclude_list_shows_empty_message(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {"version": 1}

--- a/tests/integration/test_install_flow.py
+++ b/tests/integration/test_install_flow.py
@@ -62,7 +62,7 @@ class TestInstallFlow:
         create_symlink(target_path, source, force=True, dry_run=False)
 
         assert target_path.is_symlink()
-        backup_files = list(claude_dir.glob("CLAUDE.md.ai-rules-backup.*"))
+        backup_files = list(claude_dir.glob("CLAUDE.md.ai-agent-rules-backup.*"))
         assert len(backup_files) == 1
         assert backup_files[0].read_text() == "existing content"
 

--- a/tests/integration/test_override_commands.py
+++ b/tests/integration/test_override_commands.py
@@ -11,7 +11,7 @@ class TestOverrideSetCommand:
     def test_override_set_creates_config_if_missing(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(
@@ -27,7 +27,7 @@ class TestOverrideSetCommand:
         assert data["settings_overrides"]["claude"]["model"] == "claude-3-opus"
 
     def test_override_set_with_json_value(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(
@@ -45,7 +45,7 @@ class TestOverrideSetCommand:
         )
 
     def test_override_set_with_string_value(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(
@@ -60,7 +60,7 @@ class TestOverrideSetCommand:
         assert data["settings_overrides"]["claude"]["model"] == "my-model-name"
 
     def test_override_set_with_nested_key(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         result = runner.invoke(
@@ -86,7 +86,7 @@ class TestOverrideSetCommand:
         )
 
     def test_override_set_updates_existing_value(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -106,7 +106,7 @@ class TestOverrideSetCommand:
         assert data["settings_overrides"]["claude"]["model"] == "new-model"
 
     def test_override_set_supports_multiple_agents(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         runner.invoke(main, ["override", "set", "claude.model", "claude-model"])
@@ -127,7 +127,7 @@ class TestOverrideUnsetCommand:
     """Tests for the override unset command."""
 
     def test_override_unset_removes_setting(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -148,7 +148,7 @@ class TestOverrideUnsetCommand:
         assert data["settings_overrides"]["claude"]["timeout"] == 30
 
     def test_override_unset_removes_nested_setting(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -173,7 +173,7 @@ class TestOverrideUnsetCommand:
         assert data["settings_overrides"]["claude"]["api"]["key"] == "secret"
 
     def test_override_unset_cleans_up_empty_dicts(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -197,7 +197,7 @@ class TestOverrideUnsetCommand:
     def test_override_unset_removes_agent_when_empty(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -229,7 +229,7 @@ class TestOverrideUnsetCommand:
     def test_override_unset_fails_on_nonexistent_override(
         self, runner, tmp_path, monkeypatch
     ):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -249,7 +249,7 @@ class TestOverrideListCommand:
     """Tests for the override list command."""
 
     def test_override_list_shows_overrides(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {
@@ -274,7 +274,7 @@ class TestOverrideListCommand:
         assert "goose:" in result.output
 
     def test_override_list_shows_empty_message(self, runner, tmp_path, monkeypatch):
-        config_path = tmp_path / ".ai-rules-config.yaml"
+        config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {"version": 1}

--- a/tests/integration/test_status_command.py
+++ b/tests/integration/test_status_command.py
@@ -140,7 +140,7 @@ class TestStatusCacheValidation:
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
@@ -174,7 +174,7 @@ class TestStatusCacheValidation:
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config: dict[str, Any] = {
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
@@ -210,7 +210,7 @@ class TestStatusCacheValidation:
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
@@ -243,7 +243,7 @@ class TestStatusCacheValidation:
             lambda: (_ for _ in ()).throw(RuntimeError("Not in git repo")),
         )
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
@@ -318,7 +318,7 @@ class TestStatusCacheValidation:
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-sonnet-4"}},
@@ -363,7 +363,7 @@ class TestStatusCacheValidation:
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
 
-        user_config_path = mock_home / ".ai-rules-config.yaml"
+        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-sonnet-4"}},

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import pytest
 
 from ai_rules.completions import (
+    _LEGACY_MARKER_END,
+    _LEGACY_MARKER_START,
     COMPLETION_MARKER_END,
     COMPLETION_MARKER_START,
     detect_shell,
@@ -13,7 +15,9 @@ from ai_rules.completions import (
     get_shell_config_candidates,
     install_completion,
     is_completion_installed,
+    is_legacy_completion_block,
     uninstall_completion,
+    update_completion,
 )
 
 
@@ -128,7 +132,7 @@ class TestIsCompletionInstalled:
 
         assert is_completion_installed(config_file) is False
 
-    def test_installed(self, tmp_path):
+    def test_installed_current_markers(self, tmp_path):
         config_file = tmp_path / ".bashrc"
         config_file.write_text(
             f"# Some config\n{COMPLETION_MARKER_START}\neval something\n{COMPLETION_MARKER_END}\n"
@@ -136,9 +140,52 @@ class TestIsCompletionInstalled:
 
         assert is_completion_installed(config_file) is True
 
+    def test_installed_legacy_markers(self, tmp_path):
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text(
+            f"# Some config\n{_LEGACY_MARKER_START}\neval something\n{_LEGACY_MARKER_END}\n"
+        )
+
+        assert is_completion_installed(config_file) is True
+
     def test_file_not_exists(self, tmp_path):
         config_file = tmp_path / ".bashrc"
         assert is_completion_installed(config_file) is False
+
+
+@pytest.mark.unit
+@pytest.mark.completions
+class TestIsLegacyCompletionBlock:
+    """Test detecting legacy completion blocks."""
+
+    def test_legacy_markers(self, tmp_path):
+        config_file = tmp_path / ".zshrc"
+        config_file.write_text(
+            f'{_LEGACY_MARKER_START}\neval "$(_AI_RULES_COMPLETE=zsh_source ai-rules)"\n{_LEGACY_MARKER_END}\n'
+        )
+        assert is_legacy_completion_block(config_file) is True
+
+    def test_current_markers_without_command_v(self, tmp_path):
+        config_file = tmp_path / ".zshrc"
+        config_file.write_text(
+            f'{COMPLETION_MARKER_START}\neval "$(_AI_AGENT_RULES_COMPLETE=zsh_source ai-agent-rules)"\n{COMPLETION_MARKER_END}\n'
+        )
+        assert is_legacy_completion_block(config_file) is True
+
+    def test_current_format_not_legacy(self, tmp_path):
+        config_file = tmp_path / ".zshrc"
+        script = generate_completion_script("zsh")
+        config_file.write_text(script)
+        assert is_legacy_completion_block(config_file) is False
+
+    def test_file_not_exists(self, tmp_path):
+        config_file = tmp_path / ".zshrc"
+        assert is_legacy_completion_block(config_file) is False
+
+    def test_no_markers_at_all(self, tmp_path):
+        config_file = tmp_path / ".zshrc"
+        config_file.write_text("# just a normal zshrc\n")
+        assert is_legacy_completion_block(config_file) is False
 
 
 @pytest.mark.unit
@@ -151,18 +198,28 @@ class TestGenerateCompletionScript:
 
         assert COMPLETION_MARKER_START in script
         assert COMPLETION_MARKER_END in script
-        assert "_AI_RULES_COMPLETE=bash_source ai-rules" in script
+        assert "command -v ai-agent-rules" in script
+        assert "_AI_AGENT_RULES_COMPLETE=bash_source ai-agent-rules" in script
+        assert "complete -o nosort -F _ai_agent_rules_completion ai-rules" in script
 
     def test_generates_zsh_script(self):
         script = generate_completion_script("zsh")
 
         assert COMPLETION_MARKER_START in script
         assert COMPLETION_MARKER_END in script
-        assert "_AI_RULES_COMPLETE=zsh_source ai-rules" in script
+        assert "command -v ai-agent-rules" in script
+        assert "_AI_AGENT_RULES_COMPLETE=zsh_source ai-agent-rules" in script
+        assert "compdef _ai_agent_rules_completion ai-rules" in script
 
     def test_unsupported_shell_raises_error(self):
         with pytest.raises(ValueError, match="Unsupported shell"):
             generate_completion_script("ksh")
+
+    def test_contains_if_guard(self):
+        for shell in ("bash", "zsh"):
+            script = generate_completion_script(shell)
+            assert "if command -v ai-agent-rules >/dev/null 2>&1; then" in script
+            assert "fi" in script
 
 
 @pytest.mark.unit
@@ -183,7 +240,7 @@ class TestInstallCompletion:
             assert "Completion installed" in message
             content = bashrc.read_text()
             assert COMPLETION_MARKER_START in content
-            assert "_AI_RULES_COMPLETE=bash_source ai-rules" in content
+            assert "_AI_AGENT_RULES_COMPLETE=bash_source ai-agent-rules" in content
 
     def test_install_dry_run(self, tmp_path):
         home = tmp_path / "home"
@@ -203,15 +260,32 @@ class TestInstallCompletion:
         home = tmp_path / "home"
         home.mkdir()
         bashrc = home / ".bashrc"
-        bashrc.write_text(
-            f"# bashrc\n{COMPLETION_MARKER_START}\neval something\n{COMPLETION_MARKER_END}\n"
-        )
+        script = generate_completion_script("bash")
+        bashrc.write_text(f"# bashrc\n{script}\n")
 
         with patch("ai_rules.completions.Path.home", return_value=home):
             success, message = install_completion("bash", dry_run=False)
 
             assert success is True
             assert "already installed" in message
+
+    def test_install_upgrades_legacy_block(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        bashrc = home / ".bashrc"
+        bashrc.write_text(
+            f'# bashrc\n{_LEGACY_MARKER_START}\neval "$(_AI_RULES_COMPLETE=bash_source ai-rules)"\n{_LEGACY_MARKER_END}\n'
+        )
+
+        with patch("ai_rules.completions.Path.home", return_value=home):
+            success, message = install_completion("bash", dry_run=False)
+
+            assert success is True
+            assert "updated" in message.lower()
+            content = bashrc.read_text()
+            assert _LEGACY_MARKER_START not in content
+            assert COMPLETION_MARKER_START in content
+            assert "command -v ai-agent-rules" in content
 
     def test_install_no_config_file(self, tmp_path):
         home = tmp_path / "home"
@@ -232,14 +306,85 @@ class TestInstallCompletion:
 
 @pytest.mark.unit
 @pytest.mark.completions
+class TestUpdateCompletion:
+    """Test completion update (in-place replacement)."""
+
+    def test_update_replaces_legacy_block(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        zshrc = home / ".zshrc"
+        zshrc.write_text(
+            f'# before\n{_LEGACY_MARKER_START}\neval "$(_AI_RULES_COMPLETE=zsh_source ai-rules)"\n{_LEGACY_MARKER_END}\n# after\n'
+        )
+
+        with patch("ai_rules.completions.Path.home", return_value=home):
+            success, message = update_completion("zsh")
+
+        assert success is True
+        content = zshrc.read_text()
+        assert "# before\n" in content
+        assert "# after\n" in content
+        assert _LEGACY_MARKER_START not in content
+        assert COMPLETION_MARKER_START in content
+        assert "command -v ai-agent-rules" in content
+        assert "compdef _ai_agent_rules_completion ai-rules" in content
+
+    def test_update_replaces_current_block(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        zshrc = home / ".zshrc"
+        old_script = f'{COMPLETION_MARKER_START}\neval "$(_AI_AGENT_RULES_COMPLETE=zsh_source ai-agent-rules)"\n{COMPLETION_MARKER_END}'
+        zshrc.write_text(f"# before\n{old_script}\n# after\n")
+
+        with patch("ai_rules.completions.Path.home", return_value=home):
+            success, message = update_completion("zsh")
+
+        assert success is True
+        content = zshrc.read_text()
+        assert "# before\n" in content
+        assert "# after\n" in content
+        assert "command -v ai-agent-rules" in content
+
+    def test_update_installs_when_no_block(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        zshrc = home / ".zshrc"
+        zshrc.write_text("# zshrc\n")
+
+        with patch("ai_rules.completions.Path.home", return_value=home):
+            success, message = update_completion("zsh")
+
+        assert success is True
+        assert "installed" in message.lower()
+        content = zshrc.read_text()
+        assert COMPLETION_MARKER_START in content
+
+    def test_update_dry_run(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        zshrc = home / ".zshrc"
+        zshrc.write_text(
+            f"# zshrc\n{_LEGACY_MARKER_START}\neval old\n{_LEGACY_MARKER_END}\n"
+        )
+
+        with patch("ai_rules.completions.Path.home", return_value=home):
+            success, message = update_completion("zsh", dry_run=True)
+
+        assert success is True
+        assert "Would update" in message
+        content = zshrc.read_text()
+        assert _LEGACY_MARKER_START in content
+
+
+@pytest.mark.unit
+@pytest.mark.completions
 class TestUninstallCompletion:
     """Test completion uninstallation."""
 
-    def test_uninstall(self, tmp_path):
+    def test_uninstall_current_markers(self, tmp_path):
         config_file = tmp_path / ".bashrc"
-        config_file.write_text(
-            f"# before\n{COMPLETION_MARKER_START}\neval something\n{COMPLETION_MARKER_END}\n# after\n"
-        )
+        script = generate_completion_script("bash")
+        config_file.write_text(f"# before\n{script}\n# after\n")
 
         success, message = uninstall_completion(config_file)
 
@@ -247,8 +392,39 @@ class TestUninstallCompletion:
         assert "Completion removed" in message
         content = config_file.read_text()
         assert COMPLETION_MARKER_START not in content
-        assert "# before\n" in content
-        assert "# after\n" in content
+        assert "# before" in content
+        assert "# after" in content
+
+    def test_uninstall_legacy_markers(self, tmp_path):
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text(
+            f"# before\n{_LEGACY_MARKER_START}\neval old\n{_LEGACY_MARKER_END}\n# after\n"
+        )
+
+        success, message = uninstall_completion(config_file)
+
+        assert success is True
+        assert "Completion removed" in message
+        content = config_file.read_text()
+        assert _LEGACY_MARKER_START not in content
+        assert "# before" in content
+        assert "# after" in content
+
+    def test_uninstall_both_blocks(self, tmp_path):
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text(
+            f"# before\n{_LEGACY_MARKER_START}\neval old\n{_LEGACY_MARKER_END}\n"
+            f"{COMPLETION_MARKER_START}\neval new\n{COMPLETION_MARKER_END}\n# after\n"
+        )
+
+        success, message = uninstall_completion(config_file)
+
+        assert success is True
+        content = config_file.read_text()
+        assert _LEGACY_MARKER_START not in content
+        assert COMPLETION_MARKER_START not in content
+        assert "# before" in content
+        assert "# after" in content
 
     def test_uninstall_not_installed(self, tmp_path):
         config_file = tmp_path / ".bashrc"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -50,7 +50,7 @@ def cache_setup(tmp_path, monkeypatch):
 class TestConfigLoading:
     """Test configuration file loading.
 
-    Note: As of v0.5.0, only user-level config (~/.ai-rules-config.yaml) is supported.
+    Note: As of v0.5.0, only user-level config (~/.ai-agent-rules-config.yaml) is supported.
     Repo-level config support was removed.
     """
 
@@ -60,7 +60,7 @@ class TestConfigLoading:
         monkeypatch.setenv("HOME", str(home))
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        user_config = home / ".ai-rules-config.yaml"
+        user_config = home / ".ai-agent-rules-config.yaml"
         user_config.write_text(
             "version: 1\nexclude_symlinks:\n  - ~/.config/goose/config.yaml\n"
         )
@@ -85,7 +85,7 @@ class TestConfigLoading:
         monkeypatch.setenv("HOME", str(home))
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        user_config = home / ".ai-rules-config.yaml"
+        user_config = home / ".ai-agent-rules-config.yaml"
         user_config.write_text("invalid: yaml: content: [[[")
 
         with pytest.raises(yaml.YAMLError):
@@ -181,7 +181,7 @@ class TestSettingsOverrides:
         monkeypatch.setenv("HOME", str(home))
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        config_path = home / ".ai-rules-config.yaml"
+        config_path = home / ".ai-agent-rules-config.yaml"
         config_path.write_text(
             """version: 1
 settings_overrides:
@@ -363,7 +363,7 @@ settings_overrides:
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
 
-        cache_dir = home / ".ai-rules" / "cache" / "claude"
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
         cache_dir.mkdir(parents=True)
         cache_file = cache_dir / "settings.json"
         cache_file.write_text(
@@ -720,11 +720,11 @@ class TestCacheCleanup:
         monkeypatch.setenv("HOME", str(home))
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        claude_cache = home / ".ai-rules" / "cache" / "claude"
+        claude_cache = home / ".ai-agent-rules" / "cache" / "claude"
         claude_cache.mkdir(parents=True)
         (claude_cache / "settings.json").write_text('{"active": true}')
 
-        stale_cache = home / ".ai-rules" / "cache" / "old_agent"
+        stale_cache = home / ".ai-agent-rules" / "cache" / "old_agent"
         stale_cache.mkdir(parents=True)
         (stale_cache / "config.json").write_text('{"stale": true}')
 
@@ -744,7 +744,7 @@ class TestCacheCleanup:
         monkeypatch.setenv("HOME", str(home))
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        cache_dir = home / ".ai-rules" / "cache" / "claude"
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
         cache_dir.mkdir(parents=True)
         (cache_dir / "settings.json").write_text('{"active": true}')
 
@@ -811,7 +811,7 @@ settings_overrides:
         home.mkdir()
         monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-        (home / ".ai-rules-config.yaml").write_text("""
+        (home / ".ai-agent-rules-config.yaml").write_text("""
 settings_overrides:
   claude:
     model: user-model

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -78,7 +78,7 @@ def test_install_mcps_fresh(manager, mock_home, test_repo):
         data = json.load(f)
         assert "mcpServers" in data
         assert "test-mcp" in data["mcpServers"]
-        assert data["mcpServers"]["test-mcp"]["_managedBy"] == "ai-rules"
+        assert data["mcpServers"]["test-mcp"]["_managedBy"] == "ai-agent-rules"
 
 
 def test_install_mcps_update(manager, mock_home, test_repo):
@@ -202,7 +202,7 @@ def test_atomic_write_backup(manager, mock_home, test_repo):
 
     manager.install_mcps(test_repo, config, force=True)
 
-    backup_files = list(manager.CLAUDE_JSON.parent.glob("*.ai-rules-backup.*"))
+    backup_files = list(manager.CLAUDE_JSON.parent.glob("*.ai-agent-rules-backup.*"))
     assert len(backup_files) == 1
 
     with open(backup_files[0]) as f:
@@ -280,7 +280,7 @@ def test_install_removes_mcps_no_longer_in_repo(manager, mock_home, test_repo):
     with open(manager.CLAUDE_JSON) as f:
         data = json.load(f)
         assert "test-mcp" in data["mcpServers"]
-        assert data["mcpServers"]["test-mcp"]["_managedBy"] == "ai-rules"
+        assert data["mcpServers"]["test-mcp"]["_managedBy"] == "ai-agent-rules"
 
     mcps_file = test_repo / "claude" / "mcps.json"
     mcps_file.write_text("{}")
@@ -386,7 +386,7 @@ def test_goose_install_and_uninstall(mock_home, test_repo):
         data = yaml.safe_load(f)
 
     assert "recall" in data["extensions"]
-    assert data["extensions"]["recall"]["_managed_by"] == "ai-rules"
+    assert data["extensions"]["recall"]["_managed_by"] == "ai-agent-rules"
     assert data["extensions"]["recall"]["cmd"] == "uvx"
 
     result, message = mgr.uninstall_mcps()
@@ -474,7 +474,7 @@ def test_codex_install_and_uninstall(mock_home, test_repo):
 
     mcp_servers = dict(doc["mcp_servers"])  # type: ignore[arg-type]
     assert "recall" in mcp_servers
-    managed_section = doc["_ai_rules_managed"]
+    managed_section = doc["_ai_agent_rules_managed"]
     managed_names = list(managed_section["names"])  # type: ignore[index,arg-type]
     assert "recall" in managed_names
 
@@ -484,7 +484,7 @@ def test_codex_install_and_uninstall(mock_home, test_repo):
         doc = tomlkit.load(f)
     mcp_servers_after = dict(doc.get("mcp_servers", {}))
     assert "recall" not in mcp_servers_after
-    managed_after = doc.get("_ai_rules_managed", {})
+    managed_after = doc.get("_ai_agent_rules_managed", {})
     names_after = list(managed_after.get("names", []))
     assert "recall" not in names_after
 
@@ -563,7 +563,7 @@ def test_gemini_install_and_uninstall(mock_home, test_repo):
         data = json.load(f)
 
     assert "recall" in data["mcpServers"]
-    assert data["mcpServers"]["recall"]["_managedBy"] == "ai-rules"
+    assert data["mcpServers"]["recall"]["_managedBy"] == "ai-agent-rules"
     assert data["mcpServers"]["recall"]["timeout"] == 30000
     assert data["mcpServers"]["recall"]["trust"] is False
 
@@ -649,7 +649,7 @@ def test_amp_install_and_uninstall(mock_home, test_repo):
         data = json.load(f)
 
     assert "recall" in data["amp.mcpServers"]
-    assert data["amp.mcpServers"]["recall"]["_managedBy"] == "ai-rules"
+    assert data["amp.mcpServers"]["recall"]["_managedBy"] == "ai-agent-rules"
     assert data["amp.mcpServers"]["recall"]["command"] == "uvx"
 
     result, message = mgr.uninstall_mcps()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -13,7 +13,7 @@ def state_setup(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
 
-    state_dir = home / ".ai-rules"
+    state_dir = home / ".ai-agent-rules"
     state_dir.mkdir()
 
     return {

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -50,7 +50,7 @@ class TestCreateSymlink:
 
         assert result == SymlinkResult.CREATED
         assert target.is_symlink()
-        backup_files = list(tmp_path.glob("target.txt.ai-rules-backup.*"))
+        backup_files = list(tmp_path.glob("target.txt.ai-agent-rules-backup.*"))
         assert len(backup_files) == 1
         assert backup_files[0].read_text() == "original content"
 
@@ -88,7 +88,7 @@ class TestCreateSymlink:
 
         assert result == SymlinkResult.CREATED
         assert target.read_text() == "original content"
-        backup_files = list(tmp_path.glob("target.txt.ai-rules-backup.*"))
+        backup_files = list(tmp_path.glob("target.txt.ai-agent-rules-backup.*"))
         assert len(backup_files) == 0
 
     def test_fails_when_source_does_not_exist(self, tmp_path):


### PR DESCRIPTION
feat: standardize on ai-agent-rules as canonical name, fix shell completions PATH shadowing

Shell completions hardcoded `ai-rules` as a bare command name in the eval line written to .zshrc. When Hermit installs a different `ai-rules` binary earlier on PATH, it shadows the Python CLI at shell startup — every new terminal in a Hermit-managed repo dumps Rust --help text through eval, producing a cascade of errors.

Replaced the hardcoded eval with shell-native completion aliasing: generates completions via `ai-agent-rules` (unshadowed by Hermit) with a `command -v` guard, then aliases the completion function to `ai-rules` via compdef/complete. Both commands get tab completion without hardcoded paths.

Broader naming standardization: `ai-agent-rules` is now the canonical name in all user-facing strings, tool IDs, config paths, and documentation. `ai-rules` remains as a CLI alias. Centralized path accessors (`get_user_config_path`, `get_state_dir`) handle lazy migration from old paths (`~/.ai-rules-config.yaml` → `~/.ai-agent-rules-config.yaml`, `~/.ai-rules/` → `~/.ai-agent-rules/`). MCP managed-by values use dual-read for backward compatibility. Fixed broken `willpfleger` GitHub URLs in pyproject.toml (username was never valid).