### PR TITLE
feat: add generic local install source for managed tools

### DIFF
--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -20,6 +20,7 @@ class ToolSource(Enum):
 
     PYPI = auto()
     GITHUB = auto()
+    LOCAL = auto()
 
 
 def make_github_install_url(repo: str) -> str:
@@ -100,6 +101,8 @@ def get_tool_source(package_name: str) -> ToolSource | None:
         if isinstance(first_req, dict):
             if "git" in first_req and "github.com" in first_req["git"]:
                 return ToolSource.GITHUB
+            if "path" in first_req or "directory" in first_req:
+                return ToolSource.LOCAL
 
         return ToolSource.PYPI
 
@@ -123,28 +126,32 @@ def install_tool(
     package_name: str = "ai-agent-rules",
     from_github: bool = False,
     github_url: str | None = None,
+    local_path: str | None = None,
     force: bool = False,
     dry_run: bool = False,
 ) -> tuple[bool, str]:
     """Install package as a uv tool.
 
     Args:
-        package_name: Name of package to install (ignored if from_github=True)
+        package_name: Name of package to install (ignored if from_github or local_path)
         from_github: Install from GitHub instead of PyPI
         github_url: GitHub URL to install from (only used if from_github=True)
+        local_path: Local filesystem path to install from (takes priority over from_github)
         force: Force reinstall if already installed
         dry_run: Show what would be done without executing
 
     Returns:
         Tuple of (success, message)
     """
-    if not from_github and not _validate_package_name(package_name):
+    if not local_path and not from_github and not _validate_package_name(package_name):
         return False, f"Invalid package name: {package_name}"
 
     if not is_command_available("uv"):
         return False, UV_NOT_FOUND_ERROR
 
-    if from_github:
+    if local_path:
+        source = str(Path(local_path).expanduser().resolve())
+    elif from_github:
         if not github_url:
             raise ValueError("github_url is required when from_github=True")
         source = github_url
@@ -154,7 +161,7 @@ def install_tool(
 
     if force:
         cmd.insert(3, "--force")
-        if from_github:
+        if from_github or local_path:
             cmd.insert(4, "--reinstall")
 
     if dry_run:
@@ -261,44 +268,50 @@ def get_tool_version(tool_name: str) -> str | None:
         return None
 
 
-def get_effective_install_source(tool_id: str, cli_github_flag: bool = False) -> bool:
-    """Resolve whether a tool should use GitHub install.
+def get_effective_install_source(
+    tool_id: str, cli_github_flag: bool = False
+) -> tuple[ToolSource, str | None]:
+    """Resolve the install source for a tool.
 
     Priority (highest first):
     1. cli_github_flag — explicit session override (--github flag)
     2. Merged config (user config > active profile) managed_tools.install_sources
-    3. Default: False (PyPI)
+    3. Default: (ToolSource.PYPI, None)
 
     Args:
         tool_id: Tool identifier (e.g., "statusline", "ai-agent-rules")
         cli_github_flag: True if --github was passed on the CLI
 
     Returns:
-        True for GitHub, False for PyPI
+        Tuple of (ToolSource, local_path). local_path is set only for LOCAL source.
     """
     if cli_github_flag:
-        return True
+        return ToolSource.GITHUB, None
     try:
         from ai_rules.config import Config
 
         config = Config.load()
         source = config.get_tool_install_source(tool_id)
         if source == "github":
-            return True
+            return ToolSource.GITHUB, None
         if source == "pypi":
-            return False
+            return ToolSource.PYPI, None
+        if source and source.startswith("local:"):
+            local_path = source[len("local:") :]
+            return ToolSource.LOCAL, local_path
     except Exception as e:
         import logging
 
         logging.getLogger(__name__).debug(
             f"Config load failed in install source resolver: {e}"
         )
-    return False
+    return ToolSource.PYPI, None
 
 
 def ensure_statusline_installed(
     dry_run: bool = False,
     from_github: bool = False,
+    local_path: str | None = None,
     allow_source_switch: bool = False,
 ) -> tuple[str, str | None]:
     """Install or upgrade claude-code-statusline if needed. Fails open.
@@ -306,6 +319,7 @@ def ensure_statusline_installed(
     Args:
         dry_run: If True, show what would be done without executing
         from_github: Install from GitHub instead of PyPI
+        local_path: Local filesystem path to install from (takes priority)
         allow_source_switch: If True and the installed source differs from desired,
             uninstall and reinstall from the correct source (only setup should pass True)
 
@@ -322,10 +336,16 @@ def ensure_statusline_installed(
     except Exception:
         statusline_spec = None
 
+    if local_path:
+        desired_source = ToolSource.LOCAL
+    elif from_github:
+        desired_source = ToolSource.GITHUB
+    else:
+        desired_source = ToolSource.PYPI
+
     if is_command_available("claude-statusline"):
         if allow_source_switch and statusline_spec:
             current_source = get_tool_source(statusline_spec.package_name)
-            desired_source = ToolSource.GITHUB if from_github else ToolSource.PYPI
             if current_source is not None and current_source != desired_source:
                 if dry_run:
                     return (
@@ -341,6 +361,7 @@ def ensure_statusline_installed(
                         statusline_spec.package_name,
                         from_github=from_github,
                         github_url=github_url,
+                        local_path=local_path,
                         force=True,
                     )
                     if success:
@@ -386,6 +407,7 @@ def ensure_statusline_installed(
             else "claude-code-statusline",
             from_github=from_github,
             github_url=github_url,
+            local_path=local_path,
             force=False,
             dry_run=dry_run,
         )

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -81,6 +81,7 @@ def get_tool_source(package_name: str) -> ToolSource | None:
     Returns:
         ToolSource.PYPI if installed from PyPI
         ToolSource.GITHUB if installed from GitHub
+        ToolSource.LOCAL if installed from a local path
         None if tool not installed or receipt file not found
     """
     data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -317,6 +317,9 @@ def perform_tool_upgrade(tool: ToolSpec) -> tuple[bool, str, bool]:
 
     source = get_tool_source(tool.package_name)
 
+    if source == ToolSource.LOCAL:
+        return True, "Local install — upgrade manually", False
+
     if source == ToolSource.GITHUB and tool.github_install_url:
         cmd = [
             "uv",

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -426,6 +426,9 @@ def check_tool_updates(tool: ToolSpec, timeout: int = 30) -> UpdateInfo | None:
 
     source = get_tool_source(tool.package_name)
 
+    if source == ToolSource.LOCAL:
+        return None  # Local installs don't have a remote version to check
+
     if source == ToolSource.GITHUB and tool.github_repo:
         return check_github_updates(tool.github_repo, current, timeout)
     else:

--- a/src/ai_rules/cli.py
+++ b/src/ai_rules/cli.py
@@ -742,6 +742,7 @@ def setup(
     from rich.prompt import Confirm
 
     from ai_rules.bootstrap import (
+        ToolSource,
         ensure_statusline_installed,
         get_effective_install_source,
         get_tool_config_dir,
@@ -758,11 +759,14 @@ def setup(
     console.print("[bold cyan]Step 1/3: Install ai-agent-rules system-wide[/bold cyan]")
     console.print("This allows you to run 'ai-agent-rules' from any directory.\n")
 
-    statusline_from_github = get_effective_install_source(
+    statusline_source, statusline_local_path = get_effective_install_source(
         "statusline", cli_github_flag=github
     )
     statusline_result, statusline_message = ensure_statusline_installed(
-        dry_run=dry_run, from_github=statusline_from_github, allow_source_switch=True
+        dry_run=dry_run,
+        from_github=statusline_source == ToolSource.GITHUB,
+        local_path=statusline_local_path,
+        allow_source_switch=True,
     )
     if statusline_result == "installed":
         if dry_run and statusline_message:
@@ -793,15 +797,21 @@ def setup(
     if ai_rules_tool and ai_rules_tool.is_installed():
         from ai_rules.bootstrap import ToolSource, get_tool_source, uninstall_tool
 
-        ai_rules_from_github = get_effective_install_source(
+        ai_rules_source, ai_rules_local_path = get_effective_install_source(
             "ai-agent-rules", cli_github_flag=github
         )
+        ai_rules_from_github = ai_rules_source == ToolSource.GITHUB
         current_source = get_tool_source(ai_rules_tool.package_name)
-        desired_source = ToolSource.GITHUB if ai_rules_from_github else ToolSource.PYPI
+        desired_source = ai_rules_source
         needs_source_switch = current_source != desired_source
 
         if needs_source_switch:
-            source_name = "GitHub" if ai_rules_from_github else "PyPI"
+            if ai_rules_source == ToolSource.LOCAL:
+                source_name = f"local ({ai_rules_local_path})"
+            elif ai_rules_from_github:
+                source_name = "GitHub"
+            else:
+                source_name = "PyPI"
             if dry_run:
                 console.print(
                     f"[dim]Would switch ai-agent-rules from {current_source.name if current_source else 'unknown'} to {source_name}[/dim]"
@@ -825,6 +835,7 @@ def setup(
                             ai_rules_tool.package_name,
                             from_github=ai_rules_from_github,
                             github_url=github_url,
+                            local_path=ai_rules_local_path,
                             force=True,
                         )
                         if success:
@@ -883,9 +894,10 @@ def setup(
                 return
 
         try:
-            ai_rules_from_github = get_effective_install_source(
+            ai_rules_source, ai_rules_local_path = get_effective_install_source(
                 "ai-agent-rules", cli_github_flag=github
             )
+            ai_rules_from_github = ai_rules_source == ToolSource.GITHUB
             ai_rules_tool_spec = get_tool_by_id("ai-agent-rules")
             github_url = (
                 ai_rules_tool_spec.github_install_url
@@ -896,6 +908,7 @@ def setup(
                 "ai-agent-rules",
                 from_github=ai_rules_from_github,
                 github_url=github_url,
+                local_path=ai_rules_local_path,
                 force=yes,
                 dry_run=dry_run,
             )
@@ -1046,6 +1059,7 @@ def install(
     from rich.prompt import Confirm
 
     from ai_rules.bootstrap import (
+        ToolSource,
         ensure_statusline_installed,
         get_effective_install_source,
     )
@@ -1053,9 +1067,11 @@ def install(
 
     console = Console()
 
+    sl_source, sl_local_path = get_effective_install_source("statusline")
     statusline_result, statusline_message = ensure_statusline_installed(
         dry_run=dry_run,
-        from_github=get_effective_install_source("statusline"),
+        from_github=sl_source == ToolSource.GITHUB,
+        local_path=sl_local_path,
     )
     if statusline_result == "installed":
         if dry_run and statusline_message:
@@ -1858,6 +1874,7 @@ def upgrade(
     from rich.prompt import Confirm
 
     from ai_rules.bootstrap import (
+        ToolSource,
         check_tool_updates,
         get_effective_install_source,
         get_updatable_tools,
@@ -1883,13 +1900,15 @@ def upgrade(
     if missing_tools and not check:
         if yes or Confirm.ask("\nReinstall missing tools?", default=True):
             for tool in missing_tools:
-                from_github = get_effective_install_source(tool.tool_id)
+                source, local_path = get_effective_install_source(tool.tool_id)
+                from_github = source == ToolSource.GITHUB
                 github_url = tool.github_install_url if from_github else None
                 with console.status(f"Installing {tool.display_name}..."):
                     success, msg = install_tool(
                         tool.package_name,
                         from_github=from_github,
                         github_url=github_url,
+                        local_path=local_path,
                     )
                 if success:
                     console.print(f"[green]✓[/green] {tool.display_name} reinstalled")
@@ -2098,13 +2117,16 @@ def info() -> None:
 
         if source:
             source_str = source.name.lower()
-            configured_source = (
-                ToolSource.GITHUB
-                if configured == "github"
-                else (ToolSource.PYPI if configured == "pypi" else None)
-            )
+            if configured and configured.startswith("local:"):
+                configured_source = ToolSource.LOCAL
+            elif configured == "github":
+                configured_source = ToolSource.GITHUB
+            elif configured == "pypi":
+                configured_source = ToolSource.PYPI
+            else:
+                configured_source = None
+
             if configured_source is not None and configured_source != source:
-                # Drift: config says one thing, receipt says another
                 source_display = f"{source_str} [yellow](config: {configured} — run 'setup' to switch)[/yellow]"
             elif configured is not None:
                 source_display = f"{source_str} [dim](config)[/dim]"
@@ -3530,20 +3552,20 @@ def tool() -> None:
 @click.argument(
     "source_value",
     required=False,
-    type=click.Choice(["pypi", "github", "reset"]),
 )
 def tool_source(tool_id: str | None, source_value: str | None) -> None:
     """Get or set the persistent install source for a managed tool.
 
     Without arguments, lists all configured source preferences.
 
-    TOOL_ID can be one of: ai-agent-rules, ai-rules, statusline
+    TOOL_ID can be one of: ai-agent-rules, ai-rules, statusline, recall
 
-    SOURCE_VALUE can be: pypi, github, or reset (to clear the preference)
+    SOURCE_VALUE can be: pypi, github, local:<path>, or reset
 
     Examples:
         ai-agent-rules tool source
         ai-agent-rules tool source statusline github
+        ai-agent-rules tool source recall "local:~/Development/Personal/recall"
         ai-agent-rules tool source statusline reset
     """
     from rich.console import Console
@@ -3619,7 +3641,7 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
         console.print(
             f"[green]✓[/green] Cleared install source preference for [cyan]{canonical_id}[/cyan]"
         )
-    else:
+    elif source_value in ("pypi", "github"):
         Config.set_tool_install_source(canonical_id, source_value)
         console.print(
             f"[green]✓[/green] Set [cyan]{canonical_id}[/cyan] install source to [bold]{source_value}[/bold]"
@@ -3627,6 +3649,24 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
         console.print(
             "[dim]Run 'ai-agent-rules setup' to switch the installed source if needed.[/dim]"
         )
+    elif source_value and source_value.startswith("local:"):
+        local_path = source_value[len("local:") :]
+        resolved = Path(local_path).expanduser().resolve()
+        if not resolved.exists():
+            console.print(f"[red]Error:[/red] Path does not exist: {resolved}")
+            sys.exit(1)
+        Config.set_tool_install_source(canonical_id, source_value)
+        console.print(
+            f"[green]✓[/green] Set [cyan]{canonical_id}[/cyan] install source to [bold]local: {resolved}[/bold]"
+        )
+        console.print(
+            "[dim]Run 'ai-agent-rules install' to install from local path.[/dim]"
+        )
+    else:
+        console.print(
+            f"[red]Error:[/red] Invalid source value '{source_value}'. Use: pypi, github, local:<path>, or reset"
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/ai_rules/cli.py
+++ b/src/ai_rules/cli.py
@@ -2129,7 +2129,11 @@ def info() -> None:
             if configured_source is not None and configured_source != source:
                 source_display = f"{source_str} [yellow](config: {configured} — run 'setup' to switch)[/yellow]"
             elif configured is not None:
-                source_display = f"{source_str} [dim](config)[/dim]"
+                if configured_source == ToolSource.LOCAL:
+                    local_cfg_path = configured[len("local:") :]
+                    source_display = f"{source_str} [dim]({local_cfg_path})[/dim]"
+                else:
+                    source_display = f"{source_str} [dim](config)[/dim]"
             else:
                 source_display = source_str
         else:
@@ -3558,7 +3562,7 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
 
     Without arguments, lists all configured source preferences.
 
-    TOOL_ID can be one of: ai-agent-rules, ai-rules, statusline, recall
+    TOOL_ID can be one of: ai-agent-rules, ai-rules, statusline
 
     SOURCE_VALUE can be: pypi, github, local:<path>, or reset
 
@@ -3577,7 +3581,6 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
     console = Console()
 
     if tool_id is None:
-        # List all configured preferences
         tools = get_updatable_tools()
         table = Table(title="Tool Install Source Preferences", show_header=True)
         table.add_column("Tool", style="cyan")
@@ -3601,7 +3604,6 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
         )
         return
 
-    # Normalize alias (ai-rules → ai-agent-rules)
     canonical_id = _TOOL_ID_ALIASES.get(tool_id, tool_id)
     tools = get_updatable_tools()
     valid_ids = {t.tool_id for t in tools}
@@ -3612,7 +3614,6 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
         sys.exit(1)
 
     if source_value is None:
-        # Show current preference for this tool
         user_pref = Config.get_tool_install_source_from_user_config(canonical_id)
         try:
             effective_pref = Config.load().get_tool_install_source(canonical_id)
@@ -3655,7 +3656,7 @@ def tool_source(tool_id: str | None, source_value: str | None) -> None:
         if not resolved.exists():
             console.print(f"[red]Error:[/red] Path does not exist: {resolved}")
             sys.exit(1)
-        Config.set_tool_install_source(canonical_id, source_value)
+        Config.set_tool_install_source(canonical_id, f"local:{resolved}")
         console.print(
             f"[green]✓[/green] Set [cyan]{canonical_id}[/cyan] install source to [bold]local: {resolved}[/bold]"
         )

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -685,7 +685,7 @@ class Config:
             tool_id: Tool identifier (e.g., "statusline", "ai-agent-rules")
 
         Returns:
-            'pypi', 'github', or None if not configured
+            'pypi', 'github', 'local:<path>', or None if not configured
         """
         sources: dict[str, Any] = self.managed_tools.get("install_sources", {})
         value = sources.get(tool_id)
@@ -711,7 +711,7 @@ class Config:
 
         Args:
             tool_id: Tool identifier (e.g., "statusline", "ai-agent-rules")
-            source: 'pypi', 'github', or None to clear the preference
+            source: 'pypi', 'github', 'local:<path>', or None to clear the preference
         """
         data = Config.load_user_config()
         managed = data.setdefault("managed_tools", {})

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -133,6 +133,80 @@ class TestInstallTool:
         assert success is False
         assert expected_message in message.lower()
 
+    def test_install_from_local_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True
+        )
+
+        captured = []
+
+        def mock_run(cmd, **kwargs):
+            captured.append(cmd)
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = ""
+
+            return Result()
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        success, _ = install_tool("some-package", local_path=str(tmp_path))
+        assert success is True
+        assert str(tmp_path) in captured[0][-1] or str(tmp_path.resolve()) in " ".join(
+            captured[0]
+        )
+
+    def test_local_path_skips_package_name_validation(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True
+        )
+
+        captured = []
+
+        def mock_run(cmd, **kwargs):
+            captured.append(cmd)
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = ""
+
+            return Result()
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        success, _ = install_tool("this-is-invalid!!!name", local_path=str(tmp_path))
+        assert success is True
+
+    def test_local_path_takes_priority_over_github(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True
+        )
+
+        captured = []
+
+        def mock_run(cmd, **kwargs):
+            captured.append(cmd)
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = ""
+
+            return Result()
+
+        monkeypatch.setattr("subprocess.run", mock_run)
+        success, _ = install_tool(
+            "some-package",
+            from_github=True,
+            github_url="git+ssh://git@github.com/owner/repo.git",
+            local_path=str(tmp_path),
+        )
+        assert success is True
+        cmd_str = " ".join(captured[0])
+        assert str(tmp_path.resolve()) in cmd_str
+        assert "github.com" not in cmd_str
+
 
 @pytest.mark.unit
 @pytest.mark.bootstrap
@@ -284,6 +358,32 @@ class TestGetToolSource:
         result = get_tool_source("nonexistent-package")
         assert result is None
 
+    def test_detects_local_installation(self, tmp_path, monkeypatch):
+        """Test that local path installations are detected."""
+        tools_dir = tmp_path / "uv" / "tools" / "test-package"
+        tools_dir.mkdir(parents=True)
+        receipt = tools_dir / "uv-receipt.toml"
+        receipt.write_text(
+            '[tool]\nrequirements = [{ name = "test-package", path = "/home/user/dev/test-package" }]\n'
+        )
+
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        result = get_tool_source("test-package")
+        assert result == ToolSource.LOCAL
+
+    def test_detects_local_directory_installation(self, tmp_path, monkeypatch):
+        """Test that local directory installations are detected."""
+        tools_dir = tmp_path / "uv" / "tools" / "test-package"
+        tools_dir.mkdir(parents=True)
+        receipt = tools_dir / "uv-receipt.toml"
+        receipt.write_text(
+            '[tool]\nrequirements = [{ name = "test-package", directory = "/home/user/dev/test-package" }]\n'
+        )
+
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        result = get_tool_source("test-package")
+        assert result == ToolSource.LOCAL
+
 
 @pytest.mark.unit
 @pytest.mark.bootstrap
@@ -341,39 +441,61 @@ class TestInstallToolGithub:
 class TestGetEffectiveInstallSource:
     """Tests for get_effective_install_source resolver."""
 
-    def test_cli_flag_always_wins(self, monkeypatch):
-        """CLI --github flag overrides everything — no config lookup needed."""
-        # No mocking needed: cli_github_flag=True returns True immediately
-        assert get_effective_install_source("statusline", cli_github_flag=True) is True
+    def test_cli_flag_returns_github(self, monkeypatch):
+        """CLI --github flag overrides everything."""
+        source, local_path = get_effective_install_source(
+            "statusline", cli_github_flag=True
+        )
+        assert source == ToolSource.GITHUB
+        assert local_path is None
 
-    def test_config_github_wins_without_cli_flag(self, monkeypatch):
-        """Persisted 'github' config wins when CLI flag is False."""
+    def test_config_github_returns_github(self, monkeypatch):
+        """Persisted 'github' config returns GITHUB."""
         from ai_rules.config import Config
 
         mock_config = MagicMock()
         mock_config.get_tool_install_source.return_value = "github"
         monkeypatch.setattr(Config, "load", lambda *a, **kw: mock_config)
-        assert get_effective_install_source("statusline", cli_github_flag=False) is True
+        source, local_path = get_effective_install_source(
+            "statusline", cli_github_flag=False
+        )
+        assert source == ToolSource.GITHUB
+        assert local_path is None
 
-    def test_config_pypi_beats_default(self, monkeypatch):
-        """Persisted 'pypi' config returns False even without CLI flag."""
+    def test_config_pypi_returns_pypi(self, monkeypatch):
+        """Persisted 'pypi' config returns PYPI."""
         from ai_rules.config import Config
 
         mock_config = MagicMock()
         mock_config.get_tool_install_source.return_value = "pypi"
         monkeypatch.setattr(Config, "load", lambda *a, **kw: mock_config)
-        assert (
-            get_effective_install_source("statusline", cli_github_flag=False) is False
+        source, local_path = get_effective_install_source(
+            "statusline", cli_github_flag=False
         )
+        assert source == ToolSource.PYPI
+        assert local_path is None
+
+    def test_config_local_returns_local_with_path(self, monkeypatch):
+        """Persisted 'local:~/path' config returns LOCAL with the path."""
+        from ai_rules.config import Config
+
+        mock_config = MagicMock()
+        mock_config.get_tool_install_source.return_value = "local:~/Development/recall"
+        monkeypatch.setattr(Config, "load", lambda *a, **kw: mock_config)
+        source, local_path = get_effective_install_source("recall")
+        assert source == ToolSource.LOCAL
+        assert local_path == "~/Development/recall"
 
     def test_defaults_to_pypi_when_nothing_configured(self, monkeypatch):
-        """Falls back to False (PyPI) when no config and no CLI flag."""
+        """Falls back to PYPI when no config and no CLI flag."""
         from ai_rules.config import Config
 
         mock_config = MagicMock()
         mock_config.get_tool_install_source.return_value = None
         monkeypatch.setattr(Config, "load", lambda *a, **kw: mock_config)
-        assert get_effective_install_source("statusline") is False
+        source, local_path = get_effective_install_source("statusline")
+        assert source == ToolSource.PYPI
+        assert local_path is None
 
     def test_config_load_failure_falls_back_to_pypi(self, monkeypatch):
         """Config load failure is silently ignored and defaults to PyPI."""
@@ -383,4 +505,6 @@ class TestGetEffectiveInstallSource:
             raise RuntimeError("config broke")
 
         monkeypatch.setattr(Config, "load", _raise)
-        assert get_effective_install_source("statusline") is False
+        source, local_path = get_effective_install_source("statusline")
+        assert source == ToolSource.PYPI
+        assert local_path is None

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -337,3 +337,41 @@ class TestCheckToolUpdatesLocalSource:
         )
         result = check_tool_updates(tool)
         assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestPerformToolUpgradeLocalSource:
+    """Tests that LOCAL-sourced tools skip upgrade and return early."""
+
+    def test_local_source_skips_upgrade(self, monkeypatch):
+        """perform_tool_upgrade returns early for LOCAL installs without running subprocess."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.LOCAL,
+        )
+
+        subprocess_called = []
+        original_run = subprocess.run
+
+        def spy_run(*args, **kwargs):
+            subprocess_called.append(args)
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr("subprocess.run", spy_run)
+
+        tool = ToolSpec(
+            tool_id="recall",
+            package_name="recall-mcp-server",
+            display_name="recall",
+            get_version=lambda: "0.1.0",
+            is_installed=lambda: True,
+            github_repo="wpfleger96/recall",
+        )
+        success, message, was_upgraded = perform_tool_upgrade(tool)
+        assert success is True
+        assert was_upgraded is False
+        assert not subprocess_called

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -8,6 +8,7 @@ from ai_rules.bootstrap.installer import UV_NOT_FOUND_ERROR, ToolSource
 from ai_rules.bootstrap.updater import (
     ToolSpec,
     check_index_updates,
+    check_tool_updates,
     get_configured_index_url,
     perform_tool_upgrade,
 )
@@ -313,3 +314,26 @@ class TestPerformToolUpgrade:
 
         assert success is True
         assert was_upgraded is True
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestCheckToolUpdatesLocalSource:
+    """Tests that LOCAL-sourced tools are skipped by check_tool_updates."""
+
+    def test_local_source_returns_none(self, monkeypatch):
+        """check_tool_updates returns None for LOCAL installs — no PyPI query."""
+        tool = ToolSpec(
+            tool_id="recall",
+            package_name="recall-mcp-server",
+            display_name="recall",
+            get_version=lambda: "0.1.0",
+            is_installed=lambda: True,
+            github_repo="wpfleger96/recall",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.LOCAL,
+        )
+        result = check_tool_updates(tool)
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds `ToolSource.LOCAL` alongside `PYPI` and `GITHUB` for all managed tools (ai-agent-rules, statusline, and any future tools)
- `install_tool()` accepts `local_path` parameter — passes expanded path to `uv tool install`
- `get_effective_install_source()` returns `(ToolSource, str | None)` tuple instead of `bool` — carries the local path alongside the source enum
- `tool source` CLI accepts `local:~/path` format with path existence validation
- `check_tool_updates()` skips LOCAL-sourced tools (no remote version to query)
- `ensure_statusline_installed()` handles three-way source switching (PYPI/GITHUB/LOCAL)
- `get_tool_source()` detects LOCAL installs from `uv-receipt.toml` (`path`/`directory` keys)

Enables developing managed tools locally without publishing to PyPI first: `ai-agent-rules tool source recall "local:~/Development/Personal/recall"` then `ai-agent-rules install` picks up the local checkout.