### PR TITLE
chore: migrate release workflow to GitHub App token auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Git tag to publish (e.g., v0.4.1)'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -16,73 +12,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.inputs.tag }}
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
 
-    - name: Fetch all tags from remote
-      run: |
-        echo "Fetching all tags from remote..."
-        git fetch --tags --force
-        echo "Recent tags:"
-        git tag -l | tail -10
-        echo "Current commit: $(git rev-parse HEAD)"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
 
-    - name: Check if release tag exists
-      id: check_tag
-      run: |
-        echo "Checking for release tag on commit $(git rev-parse HEAD)"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
 
-        if TAG=$(git describe --exact-match HEAD 2>/dev/null); then
-          echo "Found tag: $TAG"
+      - name: Install dependencies and build
+        run: |
+          uv sync
+          uv build
 
-          if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "has_tag=true" >> $GITHUB_OUTPUT
-            echo "tag=$TAG" >> $GITHUB_OUTPUT
-            echo "✓ Release tag found: $TAG"
-          else
-            echo "has_tag=false" >> $GITHUB_OUTPUT
-            echo "✗ Tag exists but doesn't match version pattern: $TAG"
-          fi
-        else
-          echo "has_tag=false" >> $GITHUB_OUTPUT
-          echo "✗ No tag found on current commit"
-          echo "Available tags on recent commits:"
-          git log --oneline --decorate -5
-        fi
-
-    - name: Set up Python
-      if: steps.check_tag.outputs.has_tag == 'true'
-      uses: actions/setup-python@v5
-      with:
-        python-version-file: .python-version
-
-    - name: Install uv
-      if: steps.check_tag.outputs.has_tag == 'true'
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: "latest"
-
-    - name: Install dependencies and build
-      if: steps.check_tag.outputs.has_tag == 'true'
-      run: |
-        uv sync
-        uv build
-
-    - name: Publish to PyPI
-      if: steps.check_tag.outputs.has_tag == 'true'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        verify-metadata: true
-
-    - name: Publish summary
-      if: always()
-      run: |
-        if [ "${{ steps.check_tag.outputs.has_tag }}" == "true" ]; then
-          echo "Published version ${{ steps.check_tag.outputs.tag }} to PyPI"
-        else
-          echo "Skipped - no new release tag found"
-        fi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verify-metadata: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   release:
@@ -21,11 +20,18 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.GH_ACTIONS_PRIVATE_KEY }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -47,11 +53,4 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.21.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Trigger Publish Workflow
-        if: steps.release.outputs.released == 'true'
-        run: |
-          gh workflow run publish.yml -f tag=${{ steps.release.outputs.tag }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Migrate release automation from SSH deploy key + `GITHUB_TOKEN` to a GitHub App (`wpfleger-release-bot`) with repository ruleset bypass. Classic branch protection couldn't grant bypass actors on personal repos — repository rulesets (May 2026 update) now support this, letting the App push version commits and tags directly to `main`.

Also simplifies the publish pipeline: the `workflow_dispatch` trigger in `publish.yml` was a workaround for unreliable `on: workflow_run`. Replaced with `on: release: types: [published]`, which fires reliably when PSR creates a GitHub Release via the API — eliminating the explicit dispatch step in `release.yml` and all the tag validation boilerplate in `publish.yml`.

- `release.yml`: add `actions/create-github-app-token@v2` step, replace `ssh-key` checkout with App token, pass App token to PSR, remove `Trigger Publish Workflow` step and `actions: write` permission
- `publish.yml`: replace `workflow_dispatch` with `on: release`, checkout via `github.event.release.tag_name`, remove tag fetch/validation/summary steps, rename job ID `deploy` → `publish`