### PR TITLE
fix: prevent cascading CI/release runs on version commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ version_toml = ["pyproject.toml:project.version"]
 tag_format = "v{version}"
 branch = "main"
 commit_parser = "conventional"
-commit_message = "chore(release): {version}"
+commit_message = "chore(release): {version} [skip ci]"
 
 [tool.semantic_release.commit_parser_opts]
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]


### PR DESCRIPTION
PSR's release commit pushed to `main` triggers CI → CI completion triggers another Automated Release run → PSR sees no unreleased commits → no-op. Harmless but wasteful.

Adding `[skip ci]` to the PSR commit message template prevents the cascade at the source. GitHub natively skips workflows for commits containing `[skip ci]`, so the release commit never triggers CI in the first place. Safe because PSR only modifies `pyproject.toml` version and the changelog.

- Add `[skip ci]` to `commit_message` in `[tool.semantic_release]` config