### PR TITLE
fix: auto-create dependencies label in automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   auto-merge:
@@ -14,6 +15,11 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Ensure dependencies label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh label create dependencies --description "Dependency updates" --color 0075ca 2>/dev/null || true
+
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v2


### PR DESCRIPTION
Dependabot doesn't auto-create labels referenced in `dependabot.yml` — it skips labeling and leaves a comment asking you to create it manually. This breaks the zero-setup golden path for new repos.

Added a self-healing step to the automerge workflow that runs `gh label create` before processing the PR. Idempotent — silently no-ops if the label already exists. Requires `issues: write` permission for the labels API.

- Add `issues: write` to workflow permissions
- Add `Ensure dependencies label exists` step before metadata fetch