### PR TITLE
fix: use correct dependabot commit-message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     groups:
       minor-patch:
@@ -29,7 +29,7 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     groups:
       minor-patch:


### PR DESCRIPTION
## Summary

- `prefix: "chore(deps)"` combined with `include: "scope"` was producing `chore(deps)(deps):` — Dependabot appends `(scope)` to the prefix, causing a double scope
- Changed prefix to `"chore"` so `include: "scope"` adds `(deps)` naturally, producing the correct `chore(deps):` format