### PR TITLE
fix: remove [skip ci] from release commit template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ version_toml = ["pyproject.toml:project.version"]
 tag_format = "v{version}"
 branch = "main"
 commit_parser = "conventional"
-commit_message = "chore(release): {version} [skip ci]"
+commit_message = "chore(release): {version}"
 allow_zero_version = true
 
 [tool.semantic_release.commit_parser_opts]


### PR DESCRIPTION
## Summary

- `[skip ci]` in PSR's release commit template (`chore(release): {version} [skip ci]`) was poisoning CI for any PR that updates from main
- GitHub skips `pull_request` workflows when **any** commit in the push range contains `[skip ci]` — not just the HEAD commit
- This caused CI to silently not trigger on PR #18 after rebasing onto main, leaving it stuck waiting on checks
- The extra CI run + no-op Release workflow per release is negligible cost compared to silently broken PR checks