### PR TITLE
fix: enable recall KB write-back with Stop hook and imperative AGENTS.md

### DIFF
--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -179,7 +179,13 @@ Three similar lines > premature abstraction | No helpers for one-time ops | Only
 
 When the recall MCP is configured, it provides a persistent markdown knowledge base at `~/.recall/` with FTS5 full-text search and BM25 ranking. Knowledge persists across sessions, repos, and machines via git sync.
 
-**Write-back loop:** When recall tools are available and you synthesize a useful answer, debug a non-obvious issue, or the user corrects a false assumption, consider persisting it via `write_note`. Search first to avoid duplicates. Invoke the `/kb` skill for formatting conventions.
+**Write-back (mandatory when recall tools are available):** Persist to the KB when any of these occur:
+- You debugged a non-obvious issue or discovered a workaround not in the codebase docs
+- The user corrected a false assumption you made (write with `[misconception]` tag)
+- You synthesized a useful answer combining knowledge from multiple sources
+- The user says "remember this" or "save this"
+
+Search first (`search_notes`) to avoid duplicates. If a related note exists, `edit_note` to add the insight rather than rewriting the whole note. Invoke the `/kb` skill for formatting conventions.
 
 **Quality conventions:** Use `[GAP: ...]` annotations for unverified claims. Use `[misconception]` tags to document what is NOT true (prevents confident false assertions). Use `[promote]` to flag patterns worth promoting to AGENTS.md rules.
 

--- a/src/ai_rules/config/claude/hooks/recall_stop.py
+++ b/src/ai_rules/config/claude/hooks/recall_stop.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Stop hook safety net for recall KB write-back.
+
+Conservative gatekeeper: blocks the stop ONLY when the transcript contains
+strong signals that the agent should have persisted knowledge but didn't.
+The main Claude session (which has full MCP access) does the actual
+evaluation and writing.
+
+Signals checked:
+  - User explicitly asked to remember/save/persist something
+  - User corrected the agent and the correction wasn't persisted
+
+Everything else is left to inline agent judgment via AGENTS.md instructions.
+This hook is a safety net, not the primary write-back mechanism.
+"""
+
+import json
+import re
+import sys
+
+from pathlib import Path
+
+PERSIST_PATTERNS = re.compile(
+    r"\b(remember\s+this|save\s+this|persist\s+this|"
+    r"add\s+(this\s+)?to\s+(the\s+)?(kb|knowledge\s+base|recall)|"
+    r"write\s+(this\s+)?(to|in)\s+(the\s+)?(kb|knowledge\s+base|recall)|"
+    r"don'?t\s+forget\s+(this|that))\b",
+    re.IGNORECASE,
+)
+
+CORRECTION_PATTERNS = re.compile(
+    r"\b(that'?s\s+(wrong|incorrect|not\s+right|not\s+true|inaccurate)|"
+    r"no[,.]?\s+(that'?s|it'?s|actually)|"
+    r"you'?re\s+wrong|"
+    r"incorrect[,.]|"
+    r"actually[,.]?\s+(it|that|the)\s+(is|was|should))\b",
+    re.IGNORECASE,
+)
+
+RECALL_WRITE_TOOLS = {"mcp__recall__write_note", "mcp__recall__edit_note"}
+
+BLOCK_REASON = (
+    "The session contains knowledge that should be persisted to the recall KB "
+    "but wasn't written yet. Evaluate what's worth persisting: search recall "
+    "first to avoid duplicates, then call write_note or edit_note. "
+    "Invoke /kb for formatting conventions."
+)
+
+
+def parse_transcript(path: str) -> list[dict]:
+    """Parse transcript JSONL into a list of message records."""
+    messages = []
+    transcript = Path(path)
+    if not transcript.exists():
+        return messages
+    with transcript.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+                if "message" in record:
+                    record = record["message"]
+                messages.append(record)
+            except json.JSONDecodeError:
+                continue
+    return messages
+
+
+def recall_already_wrote(messages: list[dict]) -> bool:
+    """Check if recall write tools were called in recent messages."""
+    for msg in messages:
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    if block.get("name") in RECALL_WRITE_TOOLS:
+                        return True
+    return False
+
+
+def extract_user_text(messages: list[dict]) -> list[str]:
+    """Extract text from user messages."""
+    texts = []
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            texts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(block.get("text", ""))
+    return texts
+
+
+def has_persist_signal(user_texts: list[str]) -> bool:
+    """Check if user explicitly asked to persist knowledge."""
+    return any(PERSIST_PATTERNS.search(text) for text in user_texts)
+
+
+def has_correction_signal(user_texts: list[str]) -> bool:
+    """Check if user corrected the agent."""
+    return any(CORRECTION_PATTERNS.search(text) for text in user_texts)
+
+
+def main() -> None:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    if hook_input.get("stop_hook_active"):
+        sys.exit(0)
+
+    transcript_path = hook_input.get("transcript_path", "")
+    if not transcript_path:
+        sys.exit(0)
+
+    messages = parse_transcript(transcript_path)
+    if not messages:
+        sys.exit(0)
+
+    if recall_already_wrote(messages):
+        sys.exit(0)
+
+    user_texts = extract_user_text(messages)
+
+    if has_persist_signal(user_texts) or has_correction_signal(user_texts):
+        sys.stderr.write(BLOCK_REASON)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_rules/config/claude/hooks/recall_stop.py
+++ b/src/ai_rules/config/claude/hooks/recall_stop.py
@@ -8,7 +8,7 @@ evaluation and writing.
 
 Signals checked:
   - User explicitly asked to remember/save/persist something
-  - User corrected the agent and the correction wasn't persisted
+  - User corrected the agent (directed at the agent, not third-party systems)
 
 Everything else is left to inline agent judgment via AGENTS.md instructions.
 This hook is a safety net, not the primary write-back mechanism.
@@ -30,21 +30,26 @@ PERSIST_PATTERNS = re.compile(
 )
 
 CORRECTION_PATTERNS = re.compile(
-    r"\b(that'?s\s+(wrong|incorrect|not\s+right|not\s+true|inaccurate)|"
-    r"no[,.]?\s+(that'?s|it'?s|actually)|"
-    r"you'?re\s+wrong|"
-    r"incorrect[,.]|"
-    r"actually[,.]?\s+(it|that|the)\s+(is|was|should))\b",
+    r"\b(you'?re\s+(wrong|incorrect|mistaken)|"
+    r"you\s+(got|have)\s+(that|it|this)\s+wrong|"
+    r"that'?s\s+not\s+(right|correct|true|accurate)|"
+    r"no[,.]?\s+that'?s\s+(wrong|incorrect|not\s+right))\b",
     re.IGNORECASE,
 )
 
 RECALL_WRITE_TOOLS = {"mcp__recall__write_note", "mcp__recall__edit_note"}
+RECALL_MCP_TOOLS = {"mcp__recall__search_notes", "mcp__recall__recall_status"}
 
-BLOCK_REASON = (
-    "The session contains knowledge that should be persisted to the recall KB "
-    "but wasn't written yet. Evaluate what's worth persisting: search recall "
-    "first to avoid duplicates, then call write_note or edit_note. "
-    "Invoke /kb for formatting conventions."
+BLOCK_REASON_PERSIST = (
+    "The user asked to persist knowledge to the recall KB but no write happened. "
+    "Evaluate what they wanted saved: search recall first to avoid duplicates, "
+    "then call write_note or edit_note. Invoke /kb for formatting conventions."
+)
+
+BLOCK_REASON_CORRECTION = (
+    "The user corrected an error but the correction wasn't persisted to recall. "
+    "Write the correction as a note with a [misconception] tag. Search recall "
+    "first to avoid duplicates. Invoke /kb for formatting conventions."
 )
 
 
@@ -61,50 +66,69 @@ def parse_transcript(path: str) -> list[dict[str, Any]]:
                 continue
             try:
                 record = json.loads(line)
+                if not isinstance(record, dict):
+                    continue
                 if "message" in record:
                     record = record["message"]
-                messages.append(record)
+                if isinstance(record, dict):
+                    messages.append(record)
             except json.JSONDecodeError:
                 continue
     return messages
 
 
-def recall_already_wrote(messages: list[dict[str, Any]]) -> bool:
-    """Check if recall write tools were called in recent messages."""
+def has_recall_mcp(messages: list[dict[str, Any]]) -> bool:
+    """Check if recall MCP tools were used, indicating recall is available."""
+    all_tools = RECALL_WRITE_TOOLS | RECALL_MCP_TOOLS
     for msg in messages:
         content = msg.get("content", [])
         if isinstance(content, list):
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "tool_use":
-                    if block.get("name") in RECALL_WRITE_TOOLS:
+                    if block.get("name") in all_tools:
                         return True
     return False
 
 
-def extract_user_text(messages: list[dict[str, Any]]) -> list[str]:
-    """Extract text from user messages."""
-    texts = []
-    for msg in messages:
+def has_unaddressed_signal(messages: list[dict[str, Any]]) -> str | None:
+    """Scan transcript backward for signals not followed by a recall write.
+
+    Returns the block reason if an unaddressed signal is found, None otherwise.
+    Each turn gets independent evaluation — a write at turn 1 doesn't satisfy
+    a "remember this" at turn 10.
+    """
+    latest_signal: str | None = None
+
+    for msg in reversed(messages):
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    if block.get("name") in RECALL_WRITE_TOOLS:
+                        return None
+
         if msg.get("role") != "user":
             continue
-        content = msg.get("content", "")
-        if isinstance(content, str):
-            texts.append(content)
-        elif isinstance(content, list):
-            for block in content:
+
+        text_parts: list[str] = []
+        raw = msg.get("content", "")
+        if isinstance(raw, str):
+            text_parts.append(raw)
+        elif isinstance(raw, list):
+            for block in raw:
                 if isinstance(block, dict) and block.get("type") == "text":
-                    texts.append(block.get("text", ""))
-    return texts
+                    text_parts.append(block.get("text", ""))
 
+        for text in text_parts:
+            if PERSIST_PATTERNS.search(text):
+                latest_signal = BLOCK_REASON_PERSIST
+            elif CORRECTION_PATTERNS.search(text):
+                latest_signal = BLOCK_REASON_CORRECTION
 
-def has_persist_signal(user_texts: list[str]) -> bool:
-    """Check if user explicitly asked to persist knowledge."""
-    return any(PERSIST_PATTERNS.search(text) for text in user_texts)
+        if latest_signal:
+            return latest_signal
 
-
-def has_correction_signal(user_texts: list[str]) -> bool:
-    """Check if user corrected the agent."""
-    return any(CORRECTION_PATTERNS.search(text) for text in user_texts)
+    return None
 
 
 def main() -> None:
@@ -124,13 +148,12 @@ def main() -> None:
     if not messages:
         sys.exit(0)
 
-    if recall_already_wrote(messages):
+    if not has_recall_mcp(messages):
         sys.exit(0)
 
-    user_texts = extract_user_text(messages)
-
-    if has_persist_signal(user_texts) or has_correction_signal(user_texts):
-        sys.stderr.write(BLOCK_REASON)
+    block_reason = has_unaddressed_signal(messages)
+    if block_reason:
+        sys.stderr.write(block_reason)
         sys.exit(2)
 
     sys.exit(0)

--- a/src/ai_rules/config/claude/hooks/recall_stop.py
+++ b/src/ai_rules/config/claude/hooks/recall_stop.py
@@ -19,6 +19,7 @@ import re
 import sys
 
 from pathlib import Path
+from typing import Any
 
 PERSIST_PATTERNS = re.compile(
     r"\b(remember\s+this|save\s+this|persist\s+this|"
@@ -47,9 +48,9 @@ BLOCK_REASON = (
 )
 
 
-def parse_transcript(path: str) -> list[dict]:
+def parse_transcript(path: str) -> list[dict[str, Any]]:
     """Parse transcript JSONL into a list of message records."""
-    messages = []
+    messages: list[dict[str, Any]] = []
     transcript = Path(path)
     if not transcript.exists():
         return messages
@@ -68,7 +69,7 @@ def parse_transcript(path: str) -> list[dict]:
     return messages
 
 
-def recall_already_wrote(messages: list[dict]) -> bool:
+def recall_already_wrote(messages: list[dict[str, Any]]) -> bool:
     """Check if recall write tools were called in recent messages."""
     for msg in messages:
         content = msg.get("content", [])
@@ -80,7 +81,7 @@ def recall_already_wrote(messages: list[dict]) -> bool:
     return False
 
 
-def extract_user_text(messages: list[dict]) -> list[str]:
+def extract_user_text(messages: list[dict[str, Any]]) -> list[str]:
     """Extract text from user messages."""
     texts = []
     for msg in messages:

--- a/src/ai_rules/config/claude/settings.json
+++ b/src/ai_rules/config/claude/settings.json
@@ -141,5 +141,17 @@
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
   "skipAutoPermissionPrompt": true,
-  "hooks": {}
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/recall_stop.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/ai_rules/config/claude/settings.json
+++ b/src/ai_rules/config/claude/settings.json
@@ -141,17 +141,5 @@
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
   "skipAutoPermissionPrompt": true,
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 ~/.claude/hooks/recall_stop.py",
-            "timeout": 30
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/src/ai_rules/config/profiles/personal.yaml
+++ b/src/ai_rules/config/profiles/personal.yaml
@@ -4,6 +4,12 @@ extends: default
 settings_overrides:
   claude:
     model: opusplan
+    hooks:
+      Stop:
+        - hooks:
+            - type: command
+              command: "python3 ~/.claude/hooks/recall_stop.py"
+              timeout: 30
   statusline:
     terminal_title:
       enabled: true

--- a/src/ai_rules/targets/base.py
+++ b/src/ai_rules/targets/base.py
@@ -298,9 +298,30 @@ class ConfigTarget(ABC):
 
         current_copy = copy.deepcopy(current_settings)
         expected_copy = copy.deepcopy(expected_settings)
-        for field in self._effective_preserved_fields:
+
+        static_preserved = set(self.preserved_fields)
+        effective_preserved = set(self._effective_preserved_fields)
+        mcp_preserved = effective_preserved - static_preserved
+
+        for field in mcp_preserved:
             current_copy.pop(field, None)
             expected_copy.pop(field, None)
+
+        for field in static_preserved:
+            profile_value = expected_copy.get(field)
+            cache_value = current_copy.get(field)
+
+            if isinstance(profile_value, dict) and isinstance(cache_value, dict):
+                current_copy[field] = {
+                    k: cache_value[k] for k in profile_value if k in cache_value
+                }
+                expected_copy[field] = profile_value
+                if current_copy[field] == expected_copy[field]:
+                    current_copy.pop(field, None)
+                    expected_copy.pop(field, None)
+            else:
+                current_copy.pop(field, None)
+                expected_copy.pop(field, None)
 
         if current_copy == expected_copy:
             return None

--- a/src/ai_rules/targets/base.py
+++ b/src/ai_rules/targets/base.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from ai_rules.config import Config
+from ai_rules.utils import deep_merge
 
 
 class ConfigTarget(ABC):
@@ -177,7 +178,14 @@ class ConfigTarget(ABC):
 
                     for field in preserved:
                         if field in existing:
-                            merged[field] = existing[field]
+                            if isinstance(merged.get(field), dict) and isinstance(
+                                existing[field], dict
+                            ):
+                                merged[field] = deep_merge(
+                                    merged[field], existing[field]
+                                )
+                            else:
+                                merged[field] = existing[field]
                 except CONFIG_PARSE_ERRORS:
                     pass
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -463,6 +463,200 @@ settings_overrides:
         assert result["hooks"]["Stop"] == profile_hook
         assert result["hooks"]["PreCompact"] == user_hook
 
+    def test_get_cache_diff_shows_profile_hooks_missing_from_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """get_cache_diff shows diff when profile contributes hooks not in cache."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
+        config = Config(settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}})
+        agent = ClaudeAgent(config_dir, config)
+        diff = agent.get_cache_diff()
+
+        assert diff is not None
+        assert "Stop" in diff
+
+    def test_get_cache_diff_none_when_cache_has_profile_hooks(
+        self, tmp_path, monkeypatch
+    ):
+        """get_cache_diff returns None when cache already has matching profile hooks."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
+        user_hook = [{"hooks": [{"type": "command", "command": "user_hook.sh"}]}]
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "settings.json").write_text(
+            json.dumps(
+                {
+                    "model": "base",
+                    "hooks": {"Stop": stop_hook, "PreCompact": user_hook},
+                }
+            )
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        config = Config(settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}})
+        agent = ClaudeAgent(config_dir, config)
+        diff = agent.get_cache_diff()
+
+        assert diff is None
+
+    def test_get_cache_diff_shows_changed_profile_hook(self, tmp_path, monkeypatch):
+        """get_cache_diff shows diff when profile hook changed but cache has old value."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        old_hook = [{"hooks": [{"type": "command", "command": "old_script.py"}]}]
+        new_hook = [{"hooks": [{"type": "command", "command": "new_script.py"}]}]
+
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {"Stop": old_hook}})
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        config = Config(settings_overrides={"claude": {"hooks": {"Stop": new_hook}}})
+        agent = ClaudeAgent(config_dir, config)
+        diff = agent.get_cache_diff()
+
+        assert diff is not None
+        assert "old_script.py" in diff
+        assert "new_script.py" in diff
+
+    def test_get_cache_diff_ignores_user_only_hooks(self, tmp_path, monkeypatch):
+        """User-added hooks not in profile don't appear as changes in diff."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        user_hook = [{"hooks": [{"type": "command", "command": "user_hook.sh"}]}]
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {"PreCompact": user_hook}})
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        config = Config(settings_overrides={"claude": {"model": "base"}})
+        agent = ClaudeAgent(config_dir, config)
+        diff = agent.get_cache_diff()
+
+        assert diff is None
+
+    def test_is_cache_stale_via_preserved_field_diff(self, tmp_path, monkeypatch):
+        """is_cache_stale returns True when profile hooks differ from cache content."""
+        import json
+        import os
+        import time
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "settings.json"
+        cache_file.write_text(json.dumps({"model": "base", "hooks": {}}))
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        base = claude_dir / "settings.json"
+        base.write_text(json.dumps({"model": "base", "hooks": {}}))
+
+        # Make cache newer than all sources so mtime checks don't trigger
+        time.sleep(0.02)
+        future = time.time() + 100
+        os.utime(str(cache_file), (future, future))
+
+        stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
+        config = Config(settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}})
+        agent = ClaudeAgent(config_dir, config)
+
+        assert agent.is_cache_stale() is True
+
+    def test_get_cache_diff_none_after_force_rebuild(self, tmp_path, monkeypatch):
+        """After force_rebuild with profile hooks, get_cache_diff returns None."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        user_hook = [{"hooks": [{"type": "command", "command": "user_hook.sh"}]}]
+        (cache_dir / "settings.json").write_text(
+            json.dumps({"model": "old", "hooks": {"PreCompact": user_hook}})
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
+        config = Config(
+            settings_overrides={
+                "claude": {"model": "base", "hooks": {"Stop": stop_hook}}
+            }
+        )
+        agent = ClaudeAgent(config_dir, config)
+
+        agent.build_merged_settings(force_rebuild=True)
+        diff = agent.get_cache_diff()
+
+        assert diff is None
+
     def test_build_merged_settings_includes_managed_mcps(self, tmp_path, monkeypatch):
         """build_merged_settings merges managed MCPs into the cache for agents that store MCPs in settings."""
         import json

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -390,6 +390,81 @@ settings_overrides:
         assert result["model"] == "new"
         assert result["enabledPlugins"] == {"my-plugin@marketplace": True}
 
+    def test_build_merged_settings_preserves_profile_hooks_over_empty_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """Profile-contributed hooks survive when existing cache has empty hooks."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "settings.json"
+        cache_file.write_text(json.dumps({"model": "old", "hooks": {}}))
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
+        config = Config(
+            settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}}
+        )
+        agent = ClaudeAgent(config_dir, config)
+        result_path = agent.build_merged_settings(force_rebuild=True)
+
+        assert result_path is not None
+        with open(result_path) as f:
+            result = json.load(f)
+        assert "Stop" in result["hooks"]
+        assert result["hooks"]["Stop"] == stop_hook
+
+    def test_build_merged_settings_merges_profile_and_user_hooks(
+        self, tmp_path, monkeypatch
+    ):
+        """Profile hooks and user-added hooks coexist in merged output."""
+        import json
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        user_hook = [{"hooks": [{"type": "command", "command": "user_hook.sh"}]}]
+        cache_dir = home / ".ai-agent-rules" / "cache" / "claude"
+        cache_dir.mkdir(parents=True)
+        cache_file = cache_dir / "settings.json"
+        cache_file.write_text(
+            json.dumps({"model": "old", "hooks": {"PreCompact": user_hook}})
+        )
+
+        config_dir = tmp_path / "config"
+        claude_dir = config_dir / "claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"model": "base", "hooks": {}})
+        )
+
+        profile_hook = [{"hooks": [{"type": "command", "command": "profile_hook.py"}]}]
+        config = Config(
+            settings_overrides={"claude": {"hooks": {"Stop": profile_hook}}}
+        )
+        agent = ClaudeAgent(config_dir, config)
+        result_path = agent.build_merged_settings(force_rebuild=True)
+
+        assert result_path is not None
+        with open(result_path) as f:
+            result = json.load(f)
+        assert "Stop" in result["hooks"]
+        assert "PreCompact" in result["hooks"]
+        assert result["hooks"]["Stop"] == profile_hook
+        assert result["hooks"]["PreCompact"] == user_hook
+
     def test_build_merged_settings_includes_managed_mcps(self, tmp_path, monkeypatch):
         """build_merged_settings merges managed MCPs into the cache for agents that store MCPs in settings."""
         import json

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -413,9 +413,7 @@ settings_overrides:
         )
 
         stop_hook = [{"hooks": [{"type": "command", "command": "python3 test.py"}]}]
-        config = Config(
-            settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}}
-        )
+        config = Config(settings_overrides={"claude": {"hooks": {"Stop": stop_hook}}})
         agent = ClaudeAgent(config_dir, config)
         result_path = agent.build_merged_settings(force_rebuild=True)
 

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -472,10 +472,10 @@ def test_codex_install_and_uninstall(mock_home, test_repo):
     with open(config_path) as f:
         doc = tomlkit.load(f)
 
-    mcp_servers = dict(doc["mcp_servers"])  # type: ignore[arg-type]
+    mcp_servers = dict(doc["mcp_servers"])
     assert "recall" in mcp_servers
     managed_section = doc["_ai_agent_rules_managed"]
-    managed_names = list(managed_section["names"])  # type: ignore[index,arg-type]
+    managed_names = list(managed_section["names"])
     assert "recall" in managed_names
 
     result, message = mgr.uninstall_mcps()
@@ -508,7 +508,7 @@ def test_codex_preserves_non_mcp_keys(mock_home, test_repo):
 
     assert doc["model"] == "gpt-5.2-codex"
     assert doc["approval_policy"] == "on-request"
-    assert "mcp-a" in dict(doc["mcp_servers"])  # type: ignore[arg-type]
+    assert "mcp-a" in dict(doc["mcp_servers"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_recall_stop_hook.py
+++ b/tests/unit/test_recall_stop_hook.py
@@ -254,13 +254,18 @@ class TestBlockContent:
 class TestMain:
     def test_stop_hook_active_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
-            "sys.stdin", type("", (), {"read": lambda self: json.dumps({"stop_hook_active": True})})()
+            "sys.stdin",
+            type(
+                "", (), {"read": lambda self: json.dumps({"stop_hook_active": True})}
+            )(),
         )
         with pytest.raises(SystemExit) as exc:
             recall_stop.main()
         assert exc.value.code == 0
 
-    def test_missing_transcript_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_missing_transcript_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(
             "sys.stdin", type("", (), {"read": lambda self: json.dumps({})})()
         )
@@ -275,7 +280,11 @@ class TestMain:
         _write_transcript(transcript, [_user_msg("remember this")])
         monkeypatch.setattr(
             "sys.stdin",
-            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+            type(
+                "",
+                (),
+                {"read": lambda self: json.dumps({"transcript_path": str(transcript)})},
+            )(),
         )
         with pytest.raises(SystemExit) as exc:
             recall_stop.main()
@@ -294,7 +303,11 @@ class TestMain:
         )
         monkeypatch.setattr(
             "sys.stdin",
-            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+            type(
+                "",
+                (),
+                {"read": lambda self: json.dumps({"transcript_path": str(transcript)})},
+            )(),
         )
         with pytest.raises(SystemExit) as exc:
             recall_stop.main()
@@ -313,7 +326,11 @@ class TestMain:
         )
         monkeypatch.setattr(
             "sys.stdin",
-            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+            type(
+                "",
+                (),
+                {"read": lambda self: json.dumps({"transcript_path": str(transcript)})},
+            )(),
         )
         with pytest.raises(SystemExit) as exc:
             recall_stop.main()

--- a/tests/unit/test_recall_stop_hook.py
+++ b/tests/unit/test_recall_stop_hook.py
@@ -1,0 +1,328 @@
+"""Tests for the recall Stop hook safety net (recall_stop.py)."""
+
+# Import the hook module directly since it's a standalone script
+import importlib.util
+import json
+
+from pathlib import Path
+
+import pytest
+
+_HOOK_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "ai_rules"
+    / "config"
+    / "claude"
+    / "hooks"
+    / "recall_stop.py"
+)
+_spec = importlib.util.spec_from_file_location("recall_stop", _HOOK_PATH)
+assert _spec and _spec.loader
+recall_stop = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(recall_stop)
+
+
+def _write_transcript(path: Path, messages: list[dict]) -> None:
+    """Write a list of message dicts as JSONL transcript."""
+    with path.open("w") as f:
+        for msg in messages:
+            f.write(json.dumps({"message": msg}) + "\n")
+
+
+def _user_msg(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _user_msg_blocks(texts: list[str]) -> dict:
+    return {
+        "role": "user",
+        "content": [{"type": "text", "text": t} for t in texts],
+    }
+
+
+def _assistant_msg(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _tool_use_msg(tool_name: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "name": tool_name, "input": {}},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestParseTranscript:
+    def test_parses_wrapped_messages(self, tmp_path: Path) -> None:
+        path = tmp_path / "t.jsonl"
+        _write_transcript(path, [_user_msg("hello")])
+        msgs = recall_stop.parse_transcript(str(path))
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        msgs = recall_stop.parse_transcript(str(tmp_path / "nope.jsonl"))
+        assert msgs == []
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "t.jsonl"
+        path.write_text('not json\n{"message": {"role": "user", "content": "hi"}}\n')
+        msgs = recall_stop.parse_transcript(str(path))
+        assert len(msgs) == 1
+
+    def test_skips_non_dict_json_values(self, tmp_path: Path) -> None:
+        path = tmp_path / "t.jsonl"
+        path.write_text('"just a string"\n42\n[1,2,3]\n')
+        msgs = recall_stop.parse_transcript(str(path))
+        assert msgs == []
+
+    def test_handles_empty_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "t.jsonl"
+        path.write_text('\n\n{"message": {"role": "user", "content": "hi"}}\n\n')
+        msgs = recall_stop.parse_transcript(str(path))
+        assert len(msgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# has_recall_mcp
+# ---------------------------------------------------------------------------
+
+
+class TestHasRecallMcp:
+    def test_detects_recall_tool_use(self) -> None:
+        msgs = [_tool_use_msg("mcp__recall__search_notes")]
+        assert recall_stop.has_recall_mcp(msgs) is True
+
+    def test_detects_recall_write(self) -> None:
+        msgs = [_tool_use_msg("mcp__recall__write_note")]
+        assert recall_stop.has_recall_mcp(msgs) is True
+
+    def test_no_recall_tools(self) -> None:
+        msgs = [_tool_use_msg("Bash"), _user_msg("hello")]
+        assert recall_stop.has_recall_mcp(msgs) is False
+
+    def test_empty_messages(self) -> None:
+        assert recall_stop.has_recall_mcp([]) is False
+
+
+# ---------------------------------------------------------------------------
+# has_unaddressed_signal — persist patterns
+# ---------------------------------------------------------------------------
+
+
+class TestPersistSignals:
+    def test_remember_this_triggers(self) -> None:
+        msgs = [_user_msg("hey remember this for later")]
+        result = recall_stop.has_unaddressed_signal(msgs)
+        assert result is not None
+        assert "persist" in result.lower()
+
+    def test_save_this_triggers(self) -> None:
+        msgs = [_user_msg("save this to the knowledge base")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_add_to_kb_triggers(self) -> None:
+        msgs = [_user_msg("add this to the kb")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_write_to_recall_triggers(self) -> None:
+        msgs = [_user_msg("write this to recall")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_dont_forget_triggers(self) -> None:
+        msgs = [_user_msg("don't forget this")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_no_signal_returns_none(self) -> None:
+        msgs = [_user_msg("how does this function work?")]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+
+# ---------------------------------------------------------------------------
+# has_unaddressed_signal — correction patterns
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectionSignals:
+    def test_youre_wrong_triggers(self) -> None:
+        msgs = [_user_msg("you're wrong about that")]
+        result = recall_stop.has_unaddressed_signal(msgs)
+        assert result is not None
+        assert "correction" in result.lower()
+
+    def test_thats_not_right_triggers(self) -> None:
+        msgs = [_user_msg("that's not right")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_you_got_that_wrong_triggers(self) -> None:
+        msgs = [_user_msg("you got that wrong")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_thats_incorrect_triggers(self) -> None:
+        msgs = [_user_msg("no, that's incorrect")]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_no_false_positive_on_affirmation(self) -> None:
+        """'no, that's exactly what I wanted' should NOT trigger."""
+        msgs = [_user_msg("no, that's exactly what I wanted")]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+    def test_no_false_positive_on_third_party(self) -> None:
+        """Corrections about external systems should NOT trigger."""
+        msgs = [_user_msg("the API response is incorrect sometimes")]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+    def test_no_false_positive_on_actually_positive(self) -> None:
+        """'actually it is working great' should NOT trigger."""
+        msgs = [_user_msg("actually it is working great now")]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+
+# ---------------------------------------------------------------------------
+# has_unaddressed_signal — temporal ordering
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalOrdering:
+    def test_write_after_signal_clears_it(self) -> None:
+        """A recall write AFTER a persist signal means it was addressed."""
+        msgs = [
+            _user_msg("remember this pattern"),
+            _tool_use_msg("mcp__recall__write_note"),
+        ]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+    def test_write_before_signal_does_not_clear(self) -> None:
+        """A recall write BEFORE a persist signal doesn't satisfy it."""
+        msgs = [
+            _tool_use_msg("mcp__recall__write_note"),
+            _user_msg("also remember this other thing"),
+        ]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_multiple_signals_last_one_addressed(self) -> None:
+        msgs = [
+            _user_msg("remember this"),
+            _user_msg("save this too"),
+            _tool_use_msg("mcp__recall__write_note"),
+        ]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+    def test_multiple_signals_first_addressed_second_not(self) -> None:
+        msgs = [
+            _user_msg("remember this"),
+            _tool_use_msg("mcp__recall__write_note"),
+            _user_msg("also save this other thing"),
+        ]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_edit_note_also_clears(self) -> None:
+        msgs = [
+            _user_msg("you're wrong about that"),
+            _tool_use_msg("mcp__recall__edit_note"),
+        ]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+
+# ---------------------------------------------------------------------------
+# has_unaddressed_signal — block-delimited content
+# ---------------------------------------------------------------------------
+
+
+class TestBlockContent:
+    def test_signal_in_content_blocks(self) -> None:
+        msgs = [_user_msg_blocks(["some context", "remember this"])]
+        assert recall_stop.has_unaddressed_signal(msgs) is not None
+
+    def test_no_signal_in_content_blocks(self) -> None:
+        msgs = [_user_msg_blocks(["just a question", "about code"])]
+        assert recall_stop.has_unaddressed_signal(msgs) is None
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_stop_hook_active_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.stdin", type("", (), {"read": lambda self: json.dumps({"stop_hook_active": True})})()
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 0
+
+    def test_missing_transcript_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.stdin", type("", (), {"read": lambda self: json.dumps({})})()
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 0
+
+    def test_no_recall_mcp_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(transcript, [_user_msg("remember this")])
+        monkeypatch.setattr(
+            "sys.stdin",
+            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 0
+
+    def test_signal_with_recall_mcp_blocks(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(
+            transcript,
+            [
+                _tool_use_msg("mcp__recall__search_notes"),
+                _user_msg("remember this pattern"),
+            ],
+        )
+        monkeypatch.setattr(
+            "sys.stdin",
+            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 2
+
+    def test_no_signal_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        _write_transcript(
+            transcript,
+            [
+                _tool_use_msg("mcp__recall__search_notes"),
+                _user_msg("how does this work?"),
+            ],
+        )
+        monkeypatch.setattr(
+            "sys.stdin",
+            type("", (), {"read": lambda self: json.dumps({"transcript_path": str(transcript)})})(),
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 0
+
+    def test_malformed_stdin_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.stdin", type("", (), {"read": lambda self: "not json"})()
+        )
+        with pytest.raises(SystemExit) as exc:
+            recall_stop.main()
+        assert exc.value.code == 0


### PR DESCRIPTION
Recall MCP has been running for 10 days with zero new notes written despite the server, installation, and git sync all working correctly.

Root cause: the `AGENTS.md` write-back instruction used advisory language ("consider persisting") that the agent consistently deprioritized, and there was no automated safety net. Research into Block's ADR-182 world model, Karpathy's llm-wiki, and community knowledge-persistence patterns informed a three-layer approach: inline agent judgment as primary mechanism, a conservative Stop hook as safety net, and eval-driven writes as a future layer.

- Strengthened `AGENTS.md` write-back language from advisory ("consider") to mandatory with four explicit trigger conditions
- Added `recall_stop.py` — a `type: "command"` Stop hook that acts as a conservative safety net, blocking only on strong signals (explicit persist requests or user corrections) that the agent missed; the main session does all semantic evaluation and MCP tool calls
- Registered the hook in `personal.yaml` `settings_overrides` (not the shared template) since it depends on the recall MCP which is profile-specific; work profile inherits via `extends: personal`
- Fixed `preserved_fields` cache bug in `base.py` — dict fields like `hooks` were unconditionally overwritten by the cached value, silently discarding profile-contributed hooks when the existing cache had `hooks: {}`; changed to `deep_merge` for dict-type preserved fields
- Fixed `get_cache_diff()` to show profile-contributed changes to preserved dict fields — previously stripped all preserved fields from the comparison, making profile hooks invisible in `ai-rules status` and `ai-rules diff`; now distinguishes MCP-managed fields (still stripped, handled by MCP component) from static preserved dict fields (diffed against profile-contributed keys only)
- 43 new tests covering hook transcript parsing, signal detection, temporal ordering, false-positive rejection, preserved_fields merge, and cache diff visibility