### PR TITLE
refactor: remove dead code and wire up ToolSpec.is_enabled filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ uv run ai-agent-rules profile switch <name>  # Switch to different profile
 
 ```
 src/ai_rules/
-├── cli.py              # Click CLI commands (main, install, status, upgrade, etc.)
+├── cli/                # Click CLI package (commands, groups, components, helpers)
 ├── config.py           # Config loading, path parsing, merging, preserved fields
 ├── profiles.py         # Profile loading and inheritance resolution
 ├── state.py            # State management (active profile tracking)
@@ -114,7 +114,7 @@ tests/
 All AI tools inherit from `Agent` (`agents/base.py`). To add a new tool:
 1. Create `agents/<tool>.py` inheriting from `Agent`
 2. Implement: `name`, `agent_id`, `get_symlinks()`
-3. Register in `cli.py::get_agents()`
+3. Register in `targets/registry.py::TARGET_CLASSES`
 
 ### Config System
 - User config: `~/.ai-agent-rules-config.yaml`
@@ -213,16 +213,16 @@ uv run pytest -m state          # State management tests only
 
 | Task | Files |
 |------|-------|
-| Add CLI command | `cli.py` (main function, command decorators) |
+| Add CLI command | `cli/commands/` (one module per command) or `cli/groups/` (subcommand groups), then register in `cli/__init__.py::_register_commands` |
 | Add skill | Create subdir in `config/skills/` with `SKILL.md` (shared) |
 | Config loading | `config.py` (Config class, load_config) |
-| Profile management | `profiles.py`, `state.py`, `cli.py::profile()` |
+| Profile management | `profiles.py`, `state.py`, `cli/groups/profile.py` |
 | State management | `state.py` (ProfileState class) |
 | Symlink behavior | `symlinks.py` (create_symlink, remove_symlink) |
 | Config files component | `cli/components/config.py` (ConfigComponent — install/status/diff for symlinked config files) |
 | Settings cache component | `cli/components/settings.py` (SettingsComponent — build/rebuild merged settings cache) |
-| Shell completions | `completions.py`, `cli.py::completions()` |
-| New agent | `agents/base.py`, `agents/<new>.py`, `cli.py::get_agents()` |
+| Shell completions | `completions.py`, `cli/groups/completions.py` |
+| New agent | `agents/base.py`, `agents/<new>.py`, `targets/registry.py::TARGET_CLASSES` |
 | Plugin management | `plugins.py`, each `agents/*.py` defines `preserved_fields` |
 | MCP management | `mcp.py` (MCPManager base + subclasses: Claude, Goose, Codex, Gemini, Amp) |
 | Skills management | `skills.py` (SkillManager), `agents/shared.py` |

--- a/Justfile
+++ b/Justfile
@@ -8,10 +8,6 @@ default: sync type-check lint-check format-check
 sync:
     uv sync
 
-# Documentation
-docs:
-    uv run python scripts/generate_cli_docs.py
-
 # Code Quality - Check variants
 type-check:
     uv run mypy .

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ ai-agent-rules upgrade --only statusline  # Upgrade only a specific tool (ai-age
 
 ## Usage
 
-Generate the full CLI reference with `just docs`.
-
 ### Setup and Upgrade
 
 ```bash
@@ -424,7 +422,7 @@ metadata:
 **Add new AI tool:**
 1. Add configs to `src/ai_rules/config/<tool>/`
 2. Implement `src/ai_rules/agents/<tool>.py`
-3. Register in `src/ai_rules/cli.py::get_targets()`
+3. Register in `src/ai_rules/targets/registry.py::TARGET_CLASSES`
 
 ## Safety
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ disable_error_code = ["var-annotated", "type-arg"]
 
 [dependency-groups]
 dev = [
-    "hatch>=1.15.1",
     "jsonschema>=4.23.0",
     "mypy>=1.18.2",
     "pytest>=8.4.2",

--- a/src/ai_rules/agents/base.py
+++ b/src/ai_rules/agents/base.py
@@ -93,30 +93,15 @@ class Agent(ConfigTarget):
         self, force: bool = False, dry_run: bool = False
     ) -> tuple[OperationResult, str, list[str]]:
         """Install MCPs by delegating to the agent's MCPManager."""
-        from ai_rules.mcp import OperationResult
-
         mgr = self.get_mcp_manager()
-        if mgr is None:
-            return (
-                OperationResult.NOT_FOUND,
-                "MCP management not supported for this agent",
-                [],
-            )
+        assert mgr is not None
         return mgr.install_mcps(self.config_dir, self.config, force, dry_run)
 
-    def uninstall_mcps(
-        self, force: bool = False, dry_run: bool = False
-    ) -> tuple[OperationResult, str]:
+    def uninstall_mcps(self) -> tuple[OperationResult, str]:
         """Uninstall MCPs by delegating to the agent's MCPManager."""
-        from ai_rules.mcp import OperationResult
-
         mgr = self.get_mcp_manager()
-        if mgr is None:
-            return (
-                OperationResult.NOT_FOUND,
-                "MCP management not supported for this agent",
-            )
-        return mgr.uninstall_mcps(force, dry_run)
+        assert mgr is not None
+        return mgr.uninstall_mcps()
 
     def get_mcp_status(self) -> MCPStatus | None:
         """Return MCP status, or None if MCP is unsupported for this agent."""

--- a/src/ai_rules/agents/base.py
+++ b/src/ai_rules/agents/base.py
@@ -94,13 +94,15 @@ class Agent(ConfigTarget):
     ) -> tuple[OperationResult, str, list[str]]:
         """Install MCPs by delegating to the agent's MCPManager."""
         mgr = self.get_mcp_manager()
-        assert mgr is not None
+        if mgr is None:
+            raise RuntimeError(f"{type(self).__name__} does not support MCP management")
         return mgr.install_mcps(self.config_dir, self.config, force, dry_run)
 
     def uninstall_mcps(self) -> tuple[OperationResult, str]:
         """Uninstall MCPs by delegating to the agent's MCPManager."""
         mgr = self.get_mcp_manager()
-        assert mgr is not None
+        if mgr is None:
+            raise RuntimeError(f"{type(self).__name__} does not support MCP management")
         return mgr.uninstall_mcps()
 
     def get_mcp_status(self) -> MCPStatus | None:

--- a/src/ai_rules/bootstrap/__init__.py
+++ b/src/ai_rules/bootstrap/__init__.py
@@ -21,19 +21,14 @@ from .installer import (
     uninstall_tool,
 )
 from .updater import (
-    ToolSpec,
-    UpdateInfo,
     check_index_updates,
     check_tool_updates,
     get_tool_by_id,
     get_updatable_tools,
     perform_tool_upgrade,
 )
-from .version import is_newer, parse_version
 
 __all__ = [
-    "is_newer",
-    "parse_version",
     "UV_NOT_FOUND_ERROR",
     "ToolSource",
     "ensure_recall_installed",
@@ -45,8 +40,6 @@ __all__ = [
     "install_tool",
     "is_command_available",
     "uninstall_tool",
-    "ToolSpec",
-    "UpdateInfo",
     "check_index_updates",
     "check_tool_updates",
     "get_tool_by_id",

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -353,12 +353,9 @@ def ensure_statusline_installed(
         "source_switched", "source_switch_needed", "failed"
         Message is only provided in dry_run mode or when upgraded/switched
     """
-    try:
-        from ai_rules.tools.statusline import StatuslineTool
+    from ai_rules.tools.statusline import StatuslineTool
 
-        statusline_spec = StatuslineTool.INSTALL_SPEC
-    except Exception:
-        statusline_spec = None
+    statusline_spec = StatuslineTool.INSTALL_SPEC
 
     if local_path:
         desired_source = ToolSource.LOCAL
@@ -368,7 +365,7 @@ def ensure_statusline_installed(
         desired_source = ToolSource.PYPI
 
     if is_command_available("claude-statusline"):
-        if allow_source_switch and statusline_spec:
+        if allow_source_switch:
             current_source = get_tool_source(statusline_spec.package_name)
             if current_source is not None and current_source != desired_source:
                 if dry_run:
@@ -401,34 +398,27 @@ def ensure_statusline_installed(
                 perform_tool_upgrade,
             )
 
-            if statusline_spec:
-                update_info = check_tool_updates(statusline_spec, timeout=10)
-                if update_info and update_info.has_update:
-                    if dry_run:
-                        return (
-                            "upgrade_available",
-                            f"Would upgrade statusline {update_info.current_version} → {update_info.latest_version}",
-                        )
-                    success, msg, _ = perform_tool_upgrade(statusline_spec)
-                    if success:
-                        return (
-                            "upgraded",
-                            f"{update_info.current_version} → {update_info.latest_version}",
-                        )
+            update_info = check_tool_updates(statusline_spec, timeout=10)
+            if update_info and update_info.has_update:
+                if dry_run:
+                    return (
+                        "upgrade_available",
+                        f"Would upgrade statusline {update_info.current_version} → {update_info.latest_version}",
+                    )
+                success, msg, _ = perform_tool_upgrade(statusline_spec)
+                if success:
+                    return (
+                        "upgraded",
+                        f"{update_info.current_version} → {update_info.latest_version}",
+                    )
         except Exception:
             pass
         return "already_installed", None
 
     try:
-        github_url = (
-            statusline_spec.github_install_url
-            if (from_github and statusline_spec)
-            else None
-        )
+        github_url = statusline_spec.github_install_url if from_github else None
         success, message = install_tool(
-            statusline_spec.package_name
-            if statusline_spec
-            else "claude-code-statusline",
+            statusline_spec.package_name,
             from_github=from_github,
             github_url=github_url,
             local_path=local_path,

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -430,10 +430,7 @@ def get_updatable_tools() -> list[ToolSpec]:
     """Get all updatable tool specs, deriving from registered Tool classes."""
     from ai_rules.tools.statusline import StatuslineTool
 
-    tools: list[ToolSpec] = [_SELF_SPEC]
-    if StatuslineTool.INSTALL_SPEC is not None:
-        tools.append(StatuslineTool.INSTALL_SPEC)
-    tools.append(_RECALL_SPEC)
+    tools: list[ToolSpec] = [_SELF_SPEC, StatuslineTool.INSTALL_SPEC, _RECALL_SPEC]
     return tools
 
 

--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -11,13 +11,8 @@ from ai_rules.utils import is_managed_target
 class ExtensionItem:
     """Status of a single Claude extension (agent, command, skill, or hook)."""
 
-    name: str
-    target_path: Path
     actual_source: Path | None
     expected_source: Path | None
-    is_symlink: bool
-    is_managed: bool
-    is_installed: bool
     is_broken: bool
 
 
@@ -104,7 +99,6 @@ class ClaudeExtensionManager:
         self,
         user_dir: Path,
         pattern: str,
-        is_directory: bool = False,
     ) -> dict[str, Path]:
         """Get symlinks that point to ai-rules but source no longer exists.
 
@@ -112,8 +106,7 @@ class ClaudeExtensionManager:
 
         Args:
             user_dir: Directory containing user symlinks (e.g., ~/.claude/commands)
-            pattern: Glob pattern (e.g., "*.md", "*" for directories)
-            is_directory: True if expecting directory symlinks (skills)
+            pattern: Glob pattern (e.g., "*.md")
 
         Returns:
             dict mapping name -> symlink path for orphaned items
@@ -127,15 +120,13 @@ class ClaudeExtensionManager:
             if not item.is_symlink():
                 continue
 
-            if is_directory and not item.is_dir():
-                continue
-            if not is_directory and item.is_dir():
+            if item.is_dir():
                 continue
 
             try:
                 target = item.resolve()
                 if is_managed_target(target, self.config_dir) and not target.exists():
-                    orphaned[item.stem if not is_directory else item.name] = item
+                    orphaned[item.stem] = item
             except (OSError, RuntimeError):
                 try:
                     raw_target = str(item.readlink())
@@ -144,7 +135,7 @@ class ClaudeExtensionManager:
                         or "ai-agent-rules" in raw_target
                         or "ai-rules" in raw_target
                     ):
-                        orphaned[item.stem if not is_directory else item.name] = item
+                        orphaned[item.stem] = item
                 except (OSError, RuntimeError):
                     pass
 
@@ -226,69 +217,38 @@ class ClaudeExtensionManager:
 
             for name, expected_source in managed_sources.items():
                 if name in installed:
-                    target_path, actual_source, is_broken = installed[name]
+                    _, actual_source, is_broken = installed[name]
 
                     if is_broken:
                         type_status.managed_wrong_target[name] = ExtensionItem(
-                            name=name,
-                            target_path=target_path,
                             actual_source=None,
                             expected_source=expected_source,
-                            is_symlink=True,
-                            is_managed=True,
-                            is_installed=False,
                             is_broken=True,
                         )
                     elif actual_source and actual_source == expected_source.resolve():
                         type_status.managed_installed[name] = ExtensionItem(
-                            name=name,
-                            target_path=target_path,
                             actual_source=actual_source,
                             expected_source=expected_source,
-                            is_symlink=True,
-                            is_managed=True,
-                            is_installed=True,
                             is_broken=False,
                         )
                     else:
                         type_status.managed_wrong_target[name] = ExtensionItem(
-                            name=name,
-                            target_path=target_path,
                             actual_source=actual_source,
                             expected_source=expected_source,
-                            is_symlink=actual_source is not None,
-                            is_managed=True,
-                            is_installed=False,
                             is_broken=False,
                         )
                 else:
-                    if ext_type == "hooks":
-                        filename = f"{name}.py"
-                    else:
-                        filename = f"{name}.md"
-
-                    user_path = self.USER_DIRS[ext_type].expanduser() / filename
                     type_status.managed_pending[name] = ExtensionItem(
-                        name=name,
-                        target_path=user_path,
                         actual_source=None,
                         expected_source=expected_source,
-                        is_symlink=False,
-                        is_managed=True,
-                        is_installed=False,
                         is_broken=False,
                     )
 
-            for name, (target_path, actual_source, is_broken) in installed.items():
+            for name, (_, actual_source, is_broken) in installed.items():
                 if name not in managed_sources:
                     type_status.unmanaged[name] = ExtensionItem(
-                        name=name,
-                        target_path=target_path,
                         actual_source=actual_source,
                         expected_source=None,
-                        is_symlink=actual_source is not None,
-                        is_managed=False,
-                        is_installed=False,
                         is_broken=is_broken,
                     )
 

--- a/src/ai_rules/cli/__init__.py
+++ b/src/ai_rules/cli/__init__.py
@@ -1,7 +1,6 @@
 """Command-line interface for ai-agent-rules."""
 
 import logging
-import os
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
@@ -24,9 +23,6 @@ from ai_rules.cli.helpers import (
 )
 from ai_rules.cli.helpers import (
     get_config_dir as get_config_dir,
-)
-from ai_rules.cli.helpers import (
-    get_git_repo_root as get_git_repo_root,
 )
 from ai_rules.cli.helpers import (
     get_targets as get_targets,
@@ -70,60 +66,6 @@ def _get_plugin_status(config: "Config") -> tuple[Any, Any] | None:
     plugin_status = plugin_manager.get_status(desired_plugins, desired_marketplaces)
 
     return (plugin_manager, plugin_status)
-
-
-def detect_old_config_symlinks() -> list[tuple[Path, Path]]:
-    """Detect symlinks pointing to old config/ location."""
-    from packaging.version import Version
-
-    old_patterns = [
-        "/config/AGENTS.md",
-        "/config/claude/",
-        "/config/codex/",
-        "/config/goose/",
-        "/config/chat_agent_hints.md",
-    ]
-
-    broken_symlinks = []
-
-    check_paths = [
-        Path.home() / ".claude",
-        Path.home() / ".codex",
-        Path.home() / ".config" / "amp",
-        Path.home() / ".config" / "goose",
-        Path.home() / "AGENTS.md",
-    ]
-
-    try:
-        use_fast_check = Version(__version__) >= Version("0.5.0")
-    except Exception:
-        use_fast_check = False
-
-    for base_path in check_paths:
-        if not base_path.exists():
-            continue
-
-        if base_path.is_symlink():
-            try:
-                target = os.readlink(str(base_path))
-                if any(pattern in str(target) for pattern in old_patterns):
-                    if not base_path.resolve().exists():
-                        broken_symlinks.append((base_path, Path(target)))
-            except (OSError, ValueError):
-                pass
-
-        if base_path.is_dir() and not use_fast_check:
-            for item in base_path.rglob("*"):
-                if item.is_symlink():
-                    try:
-                        target = os.readlink(str(item))
-                        if any(pattern in str(target) for pattern in old_patterns):
-                            if not item.resolve().exists():
-                                broken_symlinks.append((item, Path(target)))
-                    except (OSError, ValueError):
-                        pass
-
-    return broken_symlinks
 
 
 def _display_pending_symlink_changes(targets: list["ConfigTarget"]) -> bool:
@@ -343,128 +285,14 @@ def cli_entrypoint() -> None:
     main(complete_var="_AI_AGENT_RULES_COMPLETE")
 
 
-def cleanup_orphaned_symlinks(
-    selected_targets: list["ConfigTarget"],
-    config_dir: Path,
-    config: "Config",
-    force: bool,
-    dry_run: bool,
-) -> int:
-    """Cleanup all orphaned symlinks across all config types.
-
-    Args:
-        selected_targets: List of targets to check
-        config_dir: Path to the config directory
-        config: Config object
-        force: Skip confirmation prompts
-        dry_run: Don't actually remove symlinks
-
-    Returns:
-        Count of removed symlinks
-    """
-    import json
-
-    from rich.console import Console
-    from rich.prompt import Confirm
-
-    from ai_rules.claude_extensions import ClaudeExtensionManager
-    from ai_rules.skills import SkillManager
-
-    console = Console()
-    removed = 0
-
-    ext_manager = ClaudeExtensionManager(config_dir)
-    all_orphaned = ext_manager.get_all_orphaned()
-
-    for ext_type, orphaned in all_orphaned.items():
-        if orphaned:
-            console.print(f"\n[bold yellow]Orphaned {ext_type}:[/bold yellow]")
-            for name, path in sorted(orphaned.items()):
-                console.print(f"  {name} -> {path}")
-
-            if not dry_run:
-                if force or Confirm.ask(f"Remove orphaned {ext_type} symlinks?"):
-                    for _name, path in orphaned.items():
-                        try:
-                            path.unlink()
-                            console.print(f"  [green]✓[/green] Removed {path}")
-                            removed += 1
-                        except OSError as e:
-                            console.print(
-                                f"  [yellow]⚠[/yellow] Could not remove {path}: {e}"
-                            )
-
-    claude_agent = next((a for a in selected_targets if a.target_id == "claude"), None)
-    if claude_agent:
-        base_settings_path = config_dir / "claude" / "settings.json"
-        if base_settings_path.exists():
-            try:
-                with open(base_settings_path) as f:
-                    base_settings = json.load(f)
-                merged_settings = config.merge_settings("claude", base_settings)
-
-                orphaned_hooks = ext_manager.get_orphaned_hooks(merged_settings)
-                if orphaned_hooks:
-                    console.print("\n[bold yellow]Orphaned hooks:[/bold yellow]")
-                    for name, path in sorted(orphaned_hooks.items()):
-                        console.print(f"  {name} -> {path}")
-
-                    if not dry_run:
-                        if force or Confirm.ask("Remove orphaned hook symlinks?"):
-                            for _name, path in orphaned_hooks.items():
-                                try:
-                                    path.unlink()
-                                    console.print(f"  [green]✓[/green] Removed {path}")
-                                    removed += 1
-                                except OSError as e:
-                                    console.print(
-                                        f"  [yellow]⚠[/yellow] Could not remove {path}: {e}"
-                                    )
-            except (json.JSONDecodeError, OSError) as e:
-                console.print(f"[dim]Could not check for orphaned hooks: {e}[/dim]")
-
-    shared_agent = next((a for a in selected_targets if a.target_id == "shared"), None)
-    if shared_agent:
-        from ai_rules.config import AGENT_SKILLS_DIRS
-
-        skill_manager = SkillManager(
-            config_dir=config_dir,
-            agent_id="",
-            user_skills_dirs=list(AGENT_SKILLS_DIRS.values()),
-        )
-        orphaned_skills = skill_manager.get_orphaned_skills()
-
-        if orphaned_skills:
-            console.print("\n[bold yellow]Orphaned skills:[/bold yellow]")
-            for name, paths in sorted(orphaned_skills.items()):
-                for path in paths:
-                    console.print(f"  {name} -> {path}")
-
-            if not dry_run:
-                if force or Confirm.ask("Remove orphaned skill symlinks?"):
-                    for _name, paths in orphaned_skills.items():
-                        for path in paths:
-                            try:
-                                path.unlink()
-                                console.print(f"  [green]✓[/green] Removed {path}")
-                                removed += 1
-                            except OSError as e:
-                                console.print(
-                                    f"  [yellow]⚠[/yellow] Could not remove {path}: {e}"
-                                )
-
-    return removed
-
-
 def cleanup_deprecated_symlinks(
-    selected_targets: list["ConfigTarget"], config_dir: Path, force: bool, dry_run: bool
+    selected_targets: list["ConfigTarget"], config_dir: Path, dry_run: bool
 ) -> int:
     """Remove deprecated symlinks that point to our config files.
 
     Args:
         selected_targets: List of targets to check for deprecated symlinks
         config_dir: Path to the config directory (repo/config)
-        force: Skip confirmation prompts
         dry_run: Don't actually remove symlinks
 
     Returns:
@@ -503,66 +331,6 @@ def cleanup_deprecated_symlinks(
                     removed_count += 1
 
     return removed_count
-
-
-def install_user_symlinks(
-    selected_targets: list["ConfigTarget"], force: bool, dry_run: bool
-) -> dict[str, int]:
-    """Install user-level symlinks for all selected targets.
-
-    Returns dict with keys: created, updated, skipped, excluded, errors
-    """
-    from rich.console import Console
-
-    from ai_rules.symlinks import SymlinkResult, create_symlink
-
-    console = Console()
-    console.print("[bold cyan]User-Level Configuration[/bold cyan]")
-
-    if selected_targets:
-        config_dir = selected_targets[0].config_dir
-        cleanup_deprecated_symlinks(selected_targets, config_dir, force, dry_run)
-
-    created = updated = skipped = excluded = errors = 0
-
-    for agent in selected_targets:
-        console.print(f"\n[bold]{agent.name}[/bold]")
-
-        filtered_symlinks = agent.get_filtered_symlinks()
-        excluded_count = len(agent.symlinks) - len(filtered_symlinks)
-
-        if excluded_count > 0:
-            console.print(
-                f"  [dim]({excluded_count} symlink(s) excluded by config)[/dim]"
-            )
-            excluded += excluded_count
-
-        for target, source in filtered_symlinks:
-            effective_force = force or not dry_run
-            result, message = create_symlink(target, source, effective_force, dry_run)
-
-            if result == SymlinkResult.CREATED:
-                console.print(f"  [green]✓[/green] {target} → {source}")
-                created += 1
-            elif result == SymlinkResult.ALREADY_CORRECT:
-                console.print(f"  [dim]•[/dim] {target} [dim](already correct)[/dim]")
-            elif result == SymlinkResult.UPDATED:
-                console.print(f"  [yellow]↻[/yellow] {target} → {source}")
-                updated += 1
-            elif result == SymlinkResult.SKIPPED:
-                console.print(f"  [yellow]○[/yellow] {target} [dim](skipped)[/dim]")
-                skipped += 1
-            elif result == SymlinkResult.ERROR:
-                console.print(f"  [red]✗[/red] {target}: {message}")
-                errors += 1
-
-    return {
-        "created": created,
-        "updated": updated,
-        "skipped": skipped,
-        "excluded": excluded,
-        "errors": errors,
-    }
 
 
 def _register_commands() -> None:

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 import sys
 
+from typing import TYPE_CHECKING
+
 import click
+
+if TYPE_CHECKING:
+    from ai_rules.bootstrap.updater import ToolSpec
+
+
+def _filter_enabled(tools: list[ToolSpec]) -> list[ToolSpec]:
+    """Drop tools whose ``is_enabled`` callable returns False."""
+    return [t for t in tools if t.is_enabled is None or t.is_enabled()]
 
 
 @click.command()
@@ -56,6 +66,8 @@ def upgrade(
         if resolved_only is None or t.tool_id == resolved_only
     ]
     tools = [t for t in all_tools if t.is_installed()]
+    if resolved_only is None:
+        tools = _filter_enabled(tools)
     missing_tools = [t for t in all_tools if not t.is_installed()]
 
     for tool in missing_tools:

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -19,7 +19,6 @@ def _display_symlink_status(
     target: Path,
     source: Path,
     message: str,
-    agent_label: str | None = None,
 ) -> bool:
     from rich.console import Console
 
@@ -30,7 +29,7 @@ def _display_symlink_status(
     target_str = str(target)
     if source.is_dir():
         target_str = target_str.rstrip("/") + "/"
-    target_display = f"{agent_label} {target.name}" if agent_label else target_str
+    target_display = target_str
 
     if status_code == "correct":
         console.print(f"  [green]✓[/green] {target_display}")
@@ -124,7 +123,7 @@ class ConfigComponent(Component):
                     errors += 1
 
         cleanup_deprecated_symlinks(
-            list(ctx.selected_targets), ctx.config_dir, ctx.yes, ctx.dry_run
+            list(ctx.selected_targets), ctx.config_dir, ctx.dry_run
         )
 
         results = {

--- a/src/ai_rules/cli/components/mcp.py
+++ b/src/ai_rules/cli/components/mcp.py
@@ -163,7 +163,7 @@ class MCPComponent(Component):
             if target.get_mcp_manager() is None:
                 continue
 
-            result, message = target.uninstall_mcps(force=ctx.yes, dry_run=False)
+            result, message = target.uninstall_mcps()
             if result == OperationResult.REMOVED:
                 ctx.console.print(f"  [green]✓[/green] {message}")
                 removed += 1

--- a/src/ai_rules/cli/groups/completions.py
+++ b/src/ai_rules/cli/groups/completions.py
@@ -169,7 +169,6 @@ def completions_status() -> None:
     from ai_rules.completions import (
         detect_shell,
         find_config_file,
-        get_supported_shells,
         is_completion_installed,
     )
 

--- a/src/ai_rules/cli/groups/config.py
+++ b/src/ai_rules/cli/groups/config.py
@@ -154,8 +154,10 @@ def _get_common_exclusions() -> list[tuple[str, str, bool]]:
     """Get list of common exclusion patterns.
 
     Settings-file entries are derived from the registered ConfigTargets so
-    they stay in sync with each agent's ``settings_symlink_target``. A small
-    static list of rules/hints files (which aren't settings files) is appended.
+    they stay in sync with each agent's ``settings_symlink_target``.  Adding
+    a target to ``TARGET_CLASSES`` automatically adds its settings file here.
+    A small static list of rules/hints files (which aren't settings files)
+    is appended.
 
     Returns:
         List of (pattern, description, default) tuples

--- a/src/ai_rules/cli/groups/config.py
+++ b/src/ai_rules/cli/groups/config.py
@@ -143,21 +143,36 @@ def config_edit() -> None:
         sys.exit(1)
 
 
+_COMMON_RULES_EXCLUSIONS: list[tuple[str, str, bool]] = [
+    ("~/.gemini/GEMINI.md", "Gemini rules", True),
+    ("~/.config/goose/.goosehints", "Goose hints", True),
+    ("~/AGENTS.md", "Shared agents file", False),
+]
+
+
 def _get_common_exclusions() -> list[tuple[str, str, bool]]:
     """Get list of common exclusion patterns.
+
+    Settings-file entries are derived from the registered ConfigTargets so
+    they stay in sync with each agent's ``settings_symlink_target``. A small
+    static list of rules/hints files (which aren't settings files) is appended.
 
     Returns:
         List of (pattern, description, default) tuples
     """
-    return [
-        ("~/.claude/settings.json", "Claude Code settings", False),
-        ("~/.codex/config.toml", "Codex CLI config", False),
-        ("~/.gemini/settings.json", "Gemini CLI settings", False),
-        ("~/.gemini/GEMINI.md", "Gemini rules", True),
-        ("~/.config/goose/config.yaml", "Goose config", False),
-        ("~/.config/goose/.goosehints", "Goose hints", True),
-        ("~/AGENTS.md", "Shared agents file", False),
-    ]
+    from ai_rules.config import Config
+
+    settings_entries: list[tuple[str, str, bool]] = []
+    config = Config.load()
+    for target in cli_facade.get_targets(cli_facade.get_config_dir(), config):
+        settings_target = target.settings_symlink_target
+        if settings_target is None:
+            continue
+        settings_entries.append(
+            (str(settings_target), f"{target.name} settings", False)
+        )
+
+    return settings_entries + _COMMON_RULES_EXCLUSIONS
 
 
 def _collect_exclusion_patterns() -> list[str]:

--- a/src/ai_rules/cli/groups/override.py
+++ b/src/ai_rules/cli/groups/override.py
@@ -20,7 +20,6 @@ def _override_set_scalar(
     path_components: list[str | int],
     parsed_value: Any,
     data: dict[str, Any],
-    console: Any,
 ) -> None:
     """Set an override value at a path with no array indices."""
     current = data["settings_overrides"][agent]
@@ -39,7 +38,6 @@ def _override_set_scalar(
 
 def _override_set_with_array_index(
     agent: str,
-    setting: str,
     path_components: list[str | int],
     parsed_value: Any,
     data: dict[str, Any],
@@ -207,10 +205,10 @@ def override_set(key: str, value: str) -> None:
 
     if has_array_index:
         _override_set_with_array_index(
-            agent, setting, path_components, parsed_value, data, console
+            agent, path_components, parsed_value, data, console
         )
     else:
-        _override_set_scalar(agent, path_components, parsed_value, data, console)
+        _override_set_scalar(agent, path_components, parsed_value, data)
 
     Config.save_user_config(data)
 

--- a/src/ai_rules/cli/helpers.py
+++ b/src/ai_rules/cli/helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 
 from importlib.resources import files as resource_files
@@ -18,20 +17,6 @@ if TYPE_CHECKING:
     from ai_rules.config import Config
     from ai_rules.targets.base import ConfigTarget
 
-GIT_SUBPROCESS_TIMEOUT = 5
-
-KNOWN_COMPONENT_IDS: tuple[str, ...] = (
-    "config",
-    "skills",
-    "settings",
-    "mcps",
-    "plugins",
-    "extensions",
-    "completions",
-    "tools",
-    "source-files",
-)
-
 
 def get_user_config_path() -> Path:
     from ai_rules.config import get_user_config_path as _get_user_config_path
@@ -46,26 +31,6 @@ def get_config_dir() -> Path:
         return Path(str(config_resource))
     except Exception:
         return Path(__file__).parents[1] / "config"
-
-
-def get_git_repo_root() -> Path:
-    """Get the git repository root directory for development-mode operations."""
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=GIT_SUBPROCESS_TIMEOUT,
-        )
-        if result.returncode == 0:
-            return Path(result.stdout.strip())
-    except Exception:
-        pass
-
-    raise RuntimeError(
-        "Not in a git repository. For config access, use get_config_dir() instead."
-    )
 
 
 def get_targets(config_dir: Path, config: Config) -> list[ConfigTarget]:
@@ -169,15 +134,14 @@ def complete_components(
     param: click.Parameter,
     incomplete: str,
     *,
-    component_ids: tuple[str, ...] | None = None,
+    component_ids: tuple[str, ...],
 ) -> list[CompletionItem]:
     """Shell completion callback for --only flag."""
     from click.shell_completion import CompletionItem
 
-    ids = component_ids if component_ids is not None else KNOWN_COMPONENT_IDS
     return [
         CompletionItem(component_id)
-        for component_id in ids
+        for component_id in component_ids
         if component_id.startswith(incomplete)
     ]
 

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -77,8 +77,6 @@ _LEGACY_MANAGED_FIELDS_FILE = "ai-rules-managed-fields.json"
 
 def get_user_config_path() -> Path:
     """Get the user config file path, migrating from legacy path if needed."""
-    import sys
-
     home = Path.home()
     new_path = home / _CONFIG_FILE_NAME
     old_path = home / _LEGACY_CONFIG_FILE_NAME

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -376,7 +376,10 @@ class ClaudeMCPManager(MCPManager):
         return result, msg, conflicts
 
     def uninstall_mcps(self) -> tuple[OperationResult, str]:
-        backup = self._create_backup(self._claude_json_path)
+        if self._claude_json_path.exists():
+            backup = self._create_backup(self._claude_json_path)
+        else:
+            backup = None
         result, msg = super().uninstall_mcps()
         if backup:
             msg += f" (backup: {backup})"

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -186,10 +186,6 @@ class MCPManager(ABC):
         shutil.copy2(target, backup_path)
         return backup_path
 
-    def _target_path(self) -> Path:
-        """Return the agent config file path (used for backups by subclasses)."""
-        raise NotImplementedError
-
     def install_mcps(
         self,
         config_dir: Path,
@@ -245,9 +241,7 @@ class MCPManager(ABC):
 
         return (OperationResult.UPDATED, msg, [])
 
-    def uninstall_mcps(
-        self, force: bool = False, dry_run: bool = False
-    ) -> tuple[OperationResult, str]:
+    def uninstall_mcps(self) -> tuple[OperationResult, str]:
         """Uninstall managed MCPs from the agent's config file."""
         current_mcps = self._read_installed()
 
@@ -259,12 +253,6 @@ class MCPManager(ABC):
 
         if not tracked_mcps:
             return (OperationResult.NOT_FOUND, "No tracked MCPs found")
-
-        if dry_run:
-            return (
-                OperationResult.REMOVED,
-                f"Would remove {len(tracked_mcps)} MCPs (dry run)",
-            )
 
         for name in tracked_mcps:
             current_mcps.pop(name, None)
@@ -329,9 +317,6 @@ class ClaudeMCPManager(MCPManager):
     def _claude_json_path(self) -> Path:
         return Path.home() / ".claude.json"
 
-    def _target_path(self) -> Path:
-        return self._claude_json_path
-
     def _read_installed(self) -> dict[str, Any]:
         if not self._claude_json_path.exists():
             return {}
@@ -371,15 +356,6 @@ class ClaudeMCPManager(MCPManager):
                 Path(temp_path).unlink()
             raise
 
-    # Preserve the claude_json cached-property interface used in cli.py
-    @property
-    def claude_json(self) -> dict[str, Any]:
-        if not self._claude_json_path.exists():
-            return {}
-        with open(self._claude_json_path) as f:
-            return cast(dict[str, Any], json.load(f))
-
-    # Backward-compat alias so existing cli.py code still works
     @property
     def CLAUDE_JSON(self) -> Path:
         return self._claude_json_path
@@ -399,16 +375,12 @@ class ClaudeMCPManager(MCPManager):
         )
         return result, msg, conflicts
 
-    def uninstall_mcps(
-        self, force: bool = False, dry_run: bool = False
-    ) -> tuple[OperationResult, str]:
-        if not dry_run:
-            backup = self._create_backup(self._claude_json_path)
-            result, msg = super().uninstall_mcps(force, dry_run)
-            if backup:
-                msg += f" (backup: {backup})"
-            return result, msg
-        return super().uninstall_mcps(force, dry_run)
+    def uninstall_mcps(self) -> tuple[OperationResult, str]:
+        backup = self._create_backup(self._claude_json_path)
+        result, msg = super().uninstall_mcps()
+        if backup:
+            msg += f" (backup: {backup})"
+        return result, msg
 
 
 # ---------------------------------------------------------------------------
@@ -430,9 +402,6 @@ class GooseMCPManager(MCPManager):
     @property
     def _config_path(self) -> Path:
         return Path.home() / ".config" / "goose" / "config.yaml"
-
-    def _target_path(self) -> Path:
-        return self._config_path
 
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():
@@ -504,9 +473,6 @@ class CodexMCPManager(MCPManager):
     @property
     def _config_path(self) -> Path:
         return Path.home() / ".codex" / "config.toml"
-
-    def _target_path(self) -> Path:
-        return self._config_path
 
     def _load_doc(self) -> Any:
         import tomlkit
@@ -627,9 +593,6 @@ class GeminiMCPManager(MCPManager):
     def _config_path(self) -> Path:
         return Path.home() / ".gemini" / "settings.json"
 
-    def _target_path(self) -> Path:
-        return self._config_path
-
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():
             return {}
@@ -692,9 +655,6 @@ class AmpMCPManager(MCPManager):
     @property
     def _config_path(self) -> Path:
         return Path.home() / ".config" / "amp" / "settings.json"
-
-    def _target_path(self) -> Path:
-        return self._config_path
 
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():

--- a/src/ai_rules/plugins.py
+++ b/src/ai_rules/plugins.py
@@ -25,7 +25,6 @@ class PluginStatus:
     pending: list[dict[str, str]] = field(default_factory=list)
     extra: list[str] = field(default_factory=list)
     marketplaces_missing: list[dict[str, str]] = field(default_factory=list)
-    marketplaces_present: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -282,7 +281,6 @@ class PluginManager:
         installed_plugins = installed_data.get("plugins", {})
 
         known_marketplaces = self.load_known_marketplaces()
-        status.marketplaces_present = known_marketplaces
 
         for marketplace in desired_marketplaces:
             if marketplace.name not in known_marketplaces:

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -18,22 +18,15 @@ class SkillMetadata:
 
     name: str
     description: str
-    body: str = ""
 
 
 @dataclass
 class SkillItem:
     """Status of a single skill."""
 
-    name: str
-    target_path: Path
     actual_source: Path | None
     expected_source: Path | None
-    is_symlink: bool
-    is_managed: bool
-    is_installed: bool
     is_broken: bool
-    metadata: SkillMetadata | None = None
 
 
 @dataclass
@@ -53,7 +46,6 @@ class SkillManager:
         self,
         config_dir: Path,
         agent_id: str,
-        user_skills_dir: Path | None = None,
         user_skills_dirs: list[Path] | None = None,
     ):
         """Initialize skill manager.
@@ -61,15 +53,12 @@ class SkillManager:
         Args:
             config_dir: ai-rules config directory
             agent_id: Agent identifier (e.g., 'claude', 'goose', '' for shared)
-            user_skills_dir: Where skills are installed (e.g., ~/.claude/skills/)
-            user_skills_dirs: Multiple directories for shared skills
+            user_skills_dirs: Directories where skills are installed
         """
         self.config_dir = config_dir
         self.agent_id = agent_id
         if user_skills_dirs:
             self.user_skills_dirs = [p.expanduser() for p in user_skills_dirs]
-        elif user_skills_dir:
-            self.user_skills_dirs = [user_skills_dir.expanduser()]
         else:
             self.user_skills_dirs = []
 
@@ -94,16 +83,14 @@ class SkillManager:
             if len(parts) >= 3:
                 try:
                     frontmatter = yaml.safe_load(parts[1])
-                    body = parts[2].strip()
                     return SkillMetadata(
                         name=frontmatter.get("name", skill_dir.name),
                         description=frontmatter.get("description", ""),
-                        body=body,
                     )
                 except yaml.YAMLError:
                     pass
 
-        return SkillMetadata(name=skill_dir.name, description="", body=content)
+        return SkillMetadata(name=skill_dir.name, description="")
 
     def _get_managed_skills(self) -> dict[str, Path]:
         """Get all managed skills from config_dir."""
@@ -200,8 +187,6 @@ class SkillManager:
         installed = self._scan_installed_skills()
 
         for name, expected_source in managed_sources.items():
-            metadata = self.parse_skill_md(expected_source)
-
             if name in installed:
                 installations = installed[name]
                 expected_count = len(self.user_skills_dirs)
@@ -222,66 +207,33 @@ class SkillManager:
                 )
 
                 if synced_count == expected_count and not has_issues:
-                    target_path, actual_source, _ = installations[0]
+                    _, actual_source, _ = installations[0]
                     status.managed_installed[name] = SkillItem(
-                        name=name,
-                        target_path=target_path,
                         actual_source=actual_source,
                         expected_source=expected_source,
-                        is_symlink=True,
-                        is_managed=True,
-                        is_installed=True,
                         is_broken=False,
-                        metadata=metadata,
                     )
                 elif has_issues or actual_count < expected_count:
-                    target_path, actual_source, is_broken = installations[0]
+                    _, actual_source, _ = installations[0]
                     status.managed_wrong_target[name] = SkillItem(
-                        name=name,
-                        target_path=target_path,
                         actual_source=actual_source,
                         expected_source=expected_source,
-                        is_symlink=actual_source is not None,
-                        is_managed=True,
-                        is_installed=False,
                         is_broken=any(ib for _, _, ib in installations),
-                        metadata=metadata,
                     )
             else:
-                user_path = (
-                    self.user_skills_dirs[0] / name
-                    if self.user_skills_dirs
-                    else Path(f"~/.skills/{name}")
-                )
                 status.managed_pending[name] = SkillItem(
-                    name=name,
-                    target_path=user_path,
                     actual_source=None,
                     expected_source=expected_source,
-                    is_symlink=False,
-                    is_managed=True,
-                    is_installed=False,
                     is_broken=False,
-                    metadata=metadata,
                 )
 
         for name, installations in installed.items():
             if name not in managed_sources:
-                target_path, actual_source, is_broken = installations[0]
-                metadata = None
-                if target_path.is_dir():
-                    metadata = self.parse_skill_md(target_path)
-
+                _, actual_source, is_broken = installations[0]
                 status.unmanaged[name] = SkillItem(
-                    name=name,
-                    target_path=target_path,
                     actual_source=actual_source,
                     expected_source=None,
-                    is_symlink=actual_source is not None,
-                    is_managed=False,
-                    is_installed=False,
                     is_broken=is_broken,
-                    metadata=metadata,
                 )
 
         return status

--- a/src/ai_rules/targets/registry.py
+++ b/src/ai_rules/targets/registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TypeAlias
 
 from ai_rules.agents.amp import AmpAgent
 from ai_rules.agents.claude import ClaudeAgent
@@ -15,9 +14,7 @@ from ai_rules.config import Config
 from ai_rules.targets.base import ConfigTarget
 from ai_rules.tools.statusline import StatuslineTool
 
-TargetClass: TypeAlias = type[ConfigTarget]
-
-TARGET_CLASSES: tuple[TargetClass, ...] = (
+TARGET_CLASSES: tuple[type[ConfigTarget], ...] = (
     AmpAgent,
     ClaudeAgent,
     CodexAgent,
@@ -31,8 +28,3 @@ TARGET_CLASSES: tuple[TargetClass, ...] = (
 def get_targets(config_dir: Path, config: Config) -> list[ConfigTarget]:
     """Instantiate all configured targets in lifecycle order."""
     return [target_class(config_dir, config) for target_class in TARGET_CLASSES]
-
-
-def get_target_ids(config_dir: Path, config: Config) -> list[str]:
-    """Return target IDs in registry order."""
-    return [target.target_id for target in get_targets(config_dir, config)]

--- a/src/ai_rules/tools/base.py
+++ b/src/ai_rules/tools/base.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING
 
 from ai_rules.targets.base import ConfigTarget
-
-if TYPE_CHECKING:
-    from ai_rules.bootstrap.updater import ToolSpec
 
 
 class Tool(ConfigTarget):
@@ -27,8 +23,3 @@ class Tool(ConfigTarget):
     @property
     def target_id(self) -> str:
         return self.tool_id
-
-    @property
-    def install_spec(self) -> ToolSpec | None:
-        """ToolSpec for install/upgrade lifecycle, or None if not managed."""
-        return None

--- a/src/ai_rules/tools/statusline.py
+++ b/src/ai_rules/tools/statusline.py
@@ -28,10 +28,6 @@ class StatuslineTool(Tool):
     )
 
     @property
-    def install_spec(self) -> ToolSpec:
-        return self.INSTALL_SPEC
-
-    @property
     def settings_symlink_target(self) -> Path:
         return Path("~/.config/claude-statusline/config.yaml")
 

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -13,11 +13,13 @@ class TestConfigInitCommand:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
+            "n",  # Exclude Amp settings?
             "n",  # Exclude Claude Code settings?
-            "n",  # Exclude Codex CLI config?
+            "n",  # Exclude Codex CLI settings?
             "n",  # Exclude Gemini CLI settings?
+            "n",  # Exclude Goose settings?
+            "n",  # Exclude Statusline settings?
             "n",  # Exclude Gemini rules?
-            "n",  # Exclude Goose config?
             "n",  # Exclude Goose hints?
             "n",  # Exclude Shared agents file?
             "",  # Custom exclusions (empty to finish)
@@ -41,11 +43,13 @@ class TestConfigInitCommand:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         inputs = [
+            "n",  # Exclude Amp settings?
             "y",  # Exclude Claude Code settings?
-            "n",  # Exclude Codex CLI config?
+            "n",  # Exclude Codex CLI settings?
             "n",  # Exclude Gemini CLI settings?
+            "n",  # Exclude Goose settings?
+            "n",  # Exclude Statusline settings?
             "n",  # Exclude Gemini rules?
-            "n",  # Exclude Goose config?
             "y",  # Exclude Goose hints?
             "n",  # Exclude Shared agents file?
             "~/.custom/pattern.txt",  # Custom exclusion
@@ -77,7 +81,9 @@ class TestConfigInitCommand:
             "n",
             "n",
             "n",
-            "n",  # Skip exclusions (Claude, Codex, Gemini settings, Gemini rules, Goose config, Goose hints, Shared)
+            "n",
+            "n",
+            "n",  # Skip 9 exclusions (Amp, Claude, Codex, Gemini, Goose, Statusline settings; Gemini rules, Goose hints, Shared)
             "",  # No custom exclusions
             "y",  # Override settings?
             "2",  # Choose claude (amp=1, claude=2, codex=3, gemini=4, goose=5, statusline=6, done=7)
@@ -134,7 +140,9 @@ class TestConfigInitCommand:
             "n",
             "n",
             "n",
-            "n",  # Skip exclusions (Claude, Codex, Gemini settings, Gemini rules, Goose config, Goose hints, Shared)
+            "n",
+            "n",
+            "n",  # Skip 9 exclusions
             "",  # No custom exclusions
             "n",  # Override settings?
             "y",  # Save configuration?
@@ -161,7 +169,9 @@ class TestConfigInitCommand:
             "n",
             "n",
             "n",
-            "n",  # Skip exclusions (Claude, Codex, Gemini settings, Gemini rules, Goose config, Goose hints, Shared)
+            "n",
+            "n",
+            "n",  # Skip 9 exclusions
             "",  # No custom exclusions
             "n",  # Override settings?
             "n",  # Configure projects?

--- a/tests/integration/test_status_command.py
+++ b/tests/integration/test_status_command.py
@@ -135,7 +135,7 @@ class TestStatusCacheValidation:
     def test_status_detects_stale_cache_when_base_settings_newer(
         self, test_repo, mock_home, runner, monkeypatch
     ):
-        """Test that status detects stale cache when base settings are modified."""
+        """Test that status detects stale cache and suggests --rebuild-cache."""
         import ai_rules.cli
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
@@ -165,6 +165,7 @@ class TestStatusCacheValidation:
         result = runner.invoke(main, ["status"], catch_exceptions=False)
         assert result.exit_code == 1
         assert "Cached settings are stale" in result.output
+        assert "--rebuild-cache" in result.output
 
     def test_status_detects_stale_cache_when_user_config_newer(
         self, test_repo, mock_home, runner, monkeypatch
@@ -202,34 +203,6 @@ class TestStatusCacheValidation:
         assert result.exit_code == 1
         assert "Cached settings are stale" in result.output
 
-    def test_status_suggests_rebuild_cache_when_cache_stale(
-        self, test_repo, mock_home, runner, monkeypatch
-    ):
-        """Test that status suggests --rebuild-cache flag when cache is stale."""
-        import ai_rules.cli
-
-        monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
-
-        user_config_path = mock_home / ".ai-agent-rules-config.yaml"
-        user_config = {
-            "version": 1,
-            "settings_overrides": {"claude": {"test_override": "value"}},
-        }
-        with open(user_config_path, "w") as f:
-            yaml.dump(user_config, f)
-
-        config = Config.load()
-        ClaudeAgent(test_repo, config).build_merged_settings()
-
-        time.sleep(0.01)
-
-        base_settings_path = test_repo / "claude" / "settings.json"
-        base_settings_path.write_text('{"test": "updated"}')
-
-        result = runner.invoke(main, ["status"], catch_exceptions=False)
-        assert result.exit_code == 1
-        assert "--rebuild-cache" in result.output
-
     def test_status_passes_when_cache_fresh(
         self, test_repo, mock_home, runner, monkeypatch
     ):
@@ -237,11 +210,6 @@ class TestStatusCacheValidation:
         import ai_rules.cli
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
-        monkeypatch.setattr(
-            ai_rules.cli,
-            "get_git_repo_root",
-            lambda: (_ for _ in ()).throw(RuntimeError("Not in git repo")),
-        )
 
         user_config_path = mock_home / ".ai-agent-rules-config.yaml"
         user_config = {
@@ -282,11 +250,6 @@ class TestStatusCacheValidation:
         import ai_rules.cli
 
         monkeypatch.setattr(ai_rules.cli, "get_config_dir", lambda: test_repo)
-        monkeypatch.setattr(
-            ai_rules.cli,
-            "get_git_repo_root",
-            lambda: (_ for _ in ()).throw(RuntimeError("Not in git repo")),
-        )
 
         config = Config.load()
         config.plugins = []

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -416,3 +416,17 @@ class TestIsEnabledFiltering:
 
         tools = [self._make_tool("statusline", is_enabled=None)]
         assert len(_filter_enabled(tools)) == 1
+
+    def test_disabled_tool_included_when_explicitly_targeted(self):
+        """--only=<tool> bypasses the is_enabled check."""
+        resolved_only = "recall"
+        tools = [self._make_tool("recall", is_enabled=lambda: False)]
+        tools = [
+            t for t in tools if resolved_only is None or t.tool_id == resolved_only
+        ]
+        tools = [t for t in tools if t.is_installed()]
+        if resolved_only is None:
+            from ai_rules.cli.commands.upgrade import _filter_enabled
+
+            tools = _filter_enabled(tools)
+        assert len(tools) == 1

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -399,27 +399,20 @@ class TestIsEnabledFiltering:
             is_enabled=is_enabled,
         )
 
-    def test_disabled_tool_excluded_in_default_upgrade(self):
+    def test_disabled_tool_excluded(self):
+        from ai_rules.cli.commands.upgrade import _filter_enabled
+
         tools = [self._make_tool("recall", is_enabled=lambda: False)]
-        tools = [t for t in tools if t.is_installed()]
-        tools = [t for t in tools if t.is_enabled is None or t.is_enabled()]
-        assert len(tools) == 0
+        assert _filter_enabled(tools) == []
 
     def test_enabled_tool_included(self):
-        tools = [self._make_tool("recall", is_enabled=lambda: True)]
-        tools = [t for t in tools if t.is_installed()]
-        tools = [t for t in tools if t.is_enabled is None or t.is_enabled()]
-        assert len(tools) == 1
+        from ai_rules.cli.commands.upgrade import _filter_enabled
 
-    def test_disabled_tool_still_included_when_explicitly_targeted(self):
-        """When user passes --only=recall, is_enabled is not checked."""
-        resolved_only = "recall"
-        tools = [self._make_tool("recall", is_enabled=lambda: False)]
-        tools = [
-            t for t in tools if resolved_only is None or t.tool_id == resolved_only
-        ]
-        tools = [t for t in tools if t.is_installed()]
-        # is_enabled check only runs when resolved_only is None
-        if resolved_only is None:
-            tools = [t for t in tools if t.is_enabled is None or t.is_enabled()]
-        assert len(tools) == 1
+        tools = [self._make_tool("recall", is_enabled=lambda: True)]
+        assert len(_filter_enabled(tools)) == 1
+
+    def test_tool_without_is_enabled_included(self):
+        from ai_rules.cli.commands.upgrade import _filter_enabled
+
+        tools = [self._make_tool("statusline", is_enabled=None)]
+        assert len(_filter_enabled(tools)) == 1

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -136,34 +136,6 @@ def test_run_install_aborts_if_infrastructure_not_ok(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_run_install_semantic_respects_component_filter(tmp_path: Path) -> None:
-    class ConfigComponent(FakeComponent):
-        component_id = "config"
-
-    class SettingsComponent(FakeComponent):
-        component_id = "settings"
-
-    config_comp = ConfigComponent("config", ComponentResult())
-    settings_comp = SettingsComponent("settings", ComponentResult())
-
-    ctx = CliContext(
-        console=Console(file=StringIO()),
-        config_dir=tmp_path,
-        config=Config(),
-        profile_name=None,
-        all_targets=(),
-        selected_targets=(),
-        yes=True,
-        component_filter=("config",),
-    )
-
-    run_install([], [config_comp, settings_comp], ctx)
-
-    assert config_comp.calls == 1
-    assert settings_comp.calls == 0
-
-
-@pytest.mark.unit
 def test_run_install_skips_confirmation_when_yes(tmp_path: Path) -> None:
     infra = InfraComponent("infra", ComponentResult())
     semantic = FakeComponent("semantic", ComponentResult())

--- a/tests/unit/test_component_filtering.py
+++ b/tests/unit/test_component_filtering.py
@@ -77,18 +77,6 @@ def make_context(
 
 
 @pytest.mark.unit
-def test_run_components_no_filter_runs_all(tmp_path: Path) -> None:
-    first = FakeComponent("first", "config")
-    second = FakeComponent("second", "settings")
-    ctx = make_context(tmp_path, component_filter=None)
-
-    run_components([first, second], "install", ctx)
-
-    assert first.calls == 1
-    assert second.calls == 1
-
-
-@pytest.mark.unit
 def test_run_components_filter_skips_non_matching(tmp_path: Path) -> None:
     matching = FakeComponent("matching", "config")
     skipped = FakeComponent("skipped", "settings")
@@ -142,20 +130,6 @@ def test_select_components_returns_valid_tuple(tmp_path: Path) -> None:
     result = select_components(components, "config,settings")
 
     assert result == ("config", "settings")
-
-
-@pytest.mark.unit
-def test_complete_components_filters_by_prefix() -> None:
-    ctx = MagicMock()
-    param = MagicMock()
-
-    results = complete_components(ctx, param, "co")
-
-    completion_values = [item.value for item in results]
-    assert all(v.startswith("co") for v in completion_values)
-    assert "config" in completion_values
-    assert "completions" in completion_values
-    assert "settings" not in completion_values
 
 
 @pytest.mark.unit

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -124,7 +124,7 @@ def test_uninstall_mcps(manager, mock_home, test_repo):
     config = Config()
     manager.install_mcps(test_repo, config, force=True)
 
-    result, message = manager.uninstall_mcps(force=True)
+    result, message = manager.uninstall_mcps()
     assert result == OperationResult.REMOVED
     assert "Removed" in message
 
@@ -148,7 +148,7 @@ def test_uninstall_preserves_user_mcps(manager, mock_home, test_repo):
     with open(manager.CLAUDE_JSON, "w") as f:
         json.dump(data, f)
 
-    manager.uninstall_mcps(force=True)
+    manager.uninstall_mcps()
 
     with open(manager.CLAUDE_JSON) as f:
         data = json.load(f)

--- a/tests/unit/test_mcp_exclusion.py
+++ b/tests/unit/test_mcp_exclusion.py
@@ -2,34 +2,30 @@
 
 from io import StringIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from rich.console import Console
 
+from ai_rules.agents.base import Agent
 from ai_rules.cli.components.mcp import MCPComponent
 from ai_rules.cli.context import CliContext
 from ai_rules.config import Config
 from ai_rules.mcp import OperationResult
 
 
-def _make_agent(is_excluded: bool, has_mcp_manager: bool = True) -> MagicMock:
-    agent = MagicMock()
+def _make_agent(is_excluded: bool) -> MagicMock:
+    agent = MagicMock(spec=Agent)
     agent.is_settings_file_excluded = is_excluded
-
-    if has_mcp_manager:
-        mgr = MagicMock()
-        agent.get_mcp_manager.return_value = mgr
-        agent.install_mcps.return_value = (
-            OperationResult.ALREADY_INSTALLED,
-            "already up to date",
-            [],
-        )
-        agent.get_mcp_status.return_value = None
-    else:
-        agent.get_mcp_manager.return_value = None
-
+    mgr = MagicMock()
+    agent.get_mcp_manager.return_value = mgr
+    agent.install_mcps.return_value = (
+        OperationResult.ALREADY_INSTALLED,
+        "already up to date",
+        [],
+    )
+    agent.get_mcp_status.return_value = None
     return agent
 
 
@@ -50,8 +46,7 @@ def test_mcp_install_skips_excluded_target(tmp_path: Path) -> None:
     excluded_agent = _make_agent(is_excluded=True)
     ctx = make_context(tmp_path, (excluded_agent,))
 
-    with patch("ai_rules.cli.components.mcp.isinstance", return_value=True):
-        MCPComponent().install(ctx)
+    MCPComponent().install(ctx)
 
     excluded_agent.install_mcps.assert_not_called()
 
@@ -61,8 +56,7 @@ def test_mcp_status_skips_excluded_target(tmp_path: Path) -> None:
     excluded_agent = _make_agent(is_excluded=True)
     ctx = make_context(tmp_path, (excluded_agent,))
 
-    with patch("ai_rules.cli.components.mcp.isinstance", return_value=True):
-        MCPComponent().status(ctx)
+    MCPComponent().status(ctx)
 
     excluded_agent.get_mcp_status.assert_not_called()
 
@@ -72,7 +66,6 @@ def test_mcp_install_processes_non_excluded_target(tmp_path: Path) -> None:
     normal_agent = _make_agent(is_excluded=False)
     ctx = make_context(tmp_path, (normal_agent,))
 
-    with patch("ai_rules.cli.components.mcp.isinstance", return_value=True):
-        MCPComponent().install(ctx)
+    MCPComponent().install(ctx)
 
     normal_agent.install_mcps.assert_called_once()

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -94,7 +94,6 @@ class TestParseSkillMd:
         assert result is not None
         assert result.name == "my-skill"
         assert result.description == "A test skill"
-        assert result.body == "Body content"
 
     def test_handles_no_frontmatter(self, tmp_path):
         d = tmp_path / "plain"
@@ -105,7 +104,6 @@ class TestParseSkillMd:
 
         assert result is not None
         assert result.name == "plain"
-        assert result.body == "Just markdown"
 
     def test_returns_none_for_missing_file(self, tmp_path):
         d = tmp_path / "empty"

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -238,7 +238,7 @@ class TestCleanupDeprecatedSymlinks:
         config = Config(exclude_symlinks=[])
         agent = ClaudeAgent(test_repo, config)
         removed = cleanup_deprecated_symlinks(
-            [agent], test_repo / "config", force=True, dry_run=False
+            [agent], test_repo / "config", dry_run=False
         )
 
         assert removed == 1
@@ -265,7 +265,7 @@ class TestCleanupDeprecatedSymlinks:
         config = Config(exclude_symlinks=[])
         agent = ClaudeAgent(test_repo, config)
         removed = cleanup_deprecated_symlinks(
-            [agent], test_repo / "config", force=True, dry_run=False
+            [agent], test_repo / "config", dry_run=False
         )
 
         assert removed == 0
@@ -295,7 +295,7 @@ class TestCleanupDeprecatedSymlinks:
         config = Config(exclude_symlinks=[])
         agent = ClaudeAgent(test_repo, config)
         removed = cleanup_deprecated_symlinks(
-            [agent], test_repo / "config", force=True, dry_run=False
+            [agent], test_repo / "config", dry_run=False
         )
 
         assert removed == 0
@@ -321,7 +321,7 @@ class TestCleanupDeprecatedSymlinks:
         config = Config(exclude_symlinks=[])
         agent = ClaudeAgent(test_repo, config)
         removed = cleanup_deprecated_symlinks(
-            [agent], test_repo / "config", force=True, dry_run=True
+            [agent], test_repo / "config", dry_run=True
         )
 
         assert removed == 1

--- a/tests/unit/test_target_registry.py
+++ b/tests/unit/test_target_registry.py
@@ -3,46 +3,25 @@ from pathlib import Path
 import pytest
 
 from ai_rules.config import Config
-from ai_rules.targets.registry import TARGET_CLASSES, get_target_ids, get_targets
+from ai_rules.targets.registry import TARGET_CLASSES, get_targets
 
 
 @pytest.mark.unit
-def test_target_registry_returns_targets_in_lifecycle_order(tmp_path: Path) -> None:
-    config = Config()
-
-    targets = get_targets(tmp_path, config)
-
-    assert [target.target_id for target in targets] == [
-        "amp",
-        "claude",
-        "codex",
-        "gemini",
-        "goose",
-        "shared",
-        "statusline",
-    ]
-
-
-@pytest.mark.unit
-def test_get_target_ids_matches_registry_order(tmp_path: Path) -> None:
-    config = Config()
-
-    assert get_target_ids(tmp_path, config) == [
-        "amp",
-        "claude",
-        "codex",
-        "gemini",
-        "goose",
-        "shared",
-        "statusline",
-    ]
-
-
-@pytest.mark.unit
-def test_target_registry_has_unique_target_ids(tmp_path: Path) -> None:
+def test_target_registry_returns_unique_targets_in_lifecycle_order(
+    tmp_path: Path,
+) -> None:
     config = Config()
 
     target_ids = [target.target_id for target in get_targets(tmp_path, config)]
 
+    assert target_ids == [
+        "amp",
+        "claude",
+        "codex",
+        "gemini",
+        "goose",
+        "shared",
+        "statusline",
+    ]
     assert len(target_ids) == len(set(target_ids))
     assert len(TARGET_CLASSES) == len(target_ids)

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-agent-rules"
-version = "0.47.6"
+version = "0.47.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -22,7 +22,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "hatch" },
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
@@ -44,27 +43,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "hatch", specifier = ">=1.15.1" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.3" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -112,170 +96,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "backports-tarfile"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
-]
-
-[[package]]
-name = "backports-zstd"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/05/480d439b482edf59b786bc19b474d990c61942e372f5de3dc14acac8154d/backports_zstd-1.5.0.tar.gz", hash = "sha256:a5e622a82eb183b4fbe18032755ce0a15fa9a82f2adb9b621620b91247aaedb7", size = 998556, upload-time = "2026-05-11T19:54:24.923Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/6e/bc24b45e16381272db45bfe627c1762600fc5fbcd39cef3723c89425129e/backports_zstd-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09045a00d9dad12dab49e029b26c197637b882cf4adc737a373404ba2aaabbca", size = 436832, upload-time = "2026-05-11T19:51:54.343Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/87/85bc9b98bd0bbbe76af0aa19d423eb93906467110e4cdd4741fd8d26def5/backports_zstd-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e51edd66db6855bee020c951ca5c2e816777bfe77f87742fbbfae9a32d482fec", size = 363217, upload-time = "2026-05-11T19:51:56.359Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/61/b461cf3620ee3a55e20d885ef61c5ab56a3745ccc0d422f74968337777ca/backports_zstd-1.5.0-cp310-cp310-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:73ff4ceb7e28538455e0a44f53e05a731bbdb9bfe2cab4a1637dd1f0093732e3", size = 507163, upload-time = "2026-05-11T19:51:57.957Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cb/4e0063bf90d6fd17329ff271e131758d5d96a73061b6d45577a8be6ebf42/backports_zstd-1.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9526d69c8fbef03e04d74b33946e23f806399cb49e51550bb21d757fb2ce869", size = 476728, upload-time = "2026-05-11T19:51:59.822Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4a/ee0c81e24789781fcc8399817e5c82121001293dbbaf17629833ff0d34e8/backports_zstd-1.5.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5e24ee1e1bbb4549a2ad63695b4a5776596aa171fdaf7c1e178e61e351faf0a9", size = 582391, upload-time = "2026-05-11T19:52:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/aa/3c2c28492656af005ed9602beab4c20813346b53257413ae57bf88adbd41/backports_zstd-1.5.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ebfbf7307d618d68deef905d3d6655339d4ce187e176023bff8fbd44ec1e20d0", size = 642040, upload-time = "2026-05-11T19:52:03.396Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/9070e691597657bd3b983d8c8ba46bc6ee4d394608e7be969f2060f16899/backports_zstd-1.5.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b82506a4da0977754335c727752411bbba1fe476a8662d96161218f275fba859", size = 492266, upload-time = "2026-05-11T19:52:05.16Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ec/7222e9e8ca899cf9d538468b0fb6386da93dae94f6e60625a7ef99281672/backports_zstd-1.5.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4cf8355cdfa7a2cba9c51655d56e6be39c751799286b142640be30fef2301a70", size = 566215, upload-time = "2026-05-11T19:52:07.037Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f8/bf880d87cfb71ad9753142d2ad0802015ee4a343b8c080ea6f0eb6b05bfb/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f7de15f3871d21d6e761c5a309618b069fee5f225e64e4406956ac0209dc6917", size = 482662, upload-time = "2026-05-11T19:52:08.726Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ed/fc7144651682744b32de1e624bcad6d0bb72d6359e37a5d9e980f3d5a45b/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:624825b9c290e6089cd9955d88da04b085528fe213adf3e4e8be5c0fffef6c65", size = 510592, upload-time = "2026-05-11T19:52:10.244Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/40/436ee1aa915fa310d0e83c361f25757960f96ef798f532948351637125fd/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7088a75f96d8f6b0d3523ec3a99d1472ce03c3524b2f7b485b80e115ef20055f", size = 586713, upload-time = "2026-05-11T19:52:12.153Z" },
-    { url = "https://files.pythonhosted.org/packages/55/9b/16573be05e8fe54cb356d9aa9aeb84d1e14fd49fe23ea7f261027e2e7f25/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:97f4d29e99538b11313cbc7a6d9b3c2ce0d69fdc497699ab74953d0d5949ab88", size = 564032, upload-time = "2026-05-11T19:52:13.864Z" },
-    { url = "https://files.pythonhosted.org/packages/95/33/7cf01fb8b4cff1ea6c7fee19d64de8a1a8dec7b18703af2aca79c8f87864/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8b4e17632759a45a7d0c4cf31968d8d033eefbe1a3d81d8aaf519558371c3359", size = 632604, upload-time = "2026-05-11T19:52:15.469Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/03/547b4e0abf8e1c2f29314e1e3ed7a3e2054b22560b2bad843423fbb99140/backports_zstd-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0075195c79c0508bc7313a3402b187bd9d27d4f9a376e8e2caac0fc2baeacbdf", size = 496272, upload-time = "2026-05-11T19:52:17.064Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ff/28c94189774b62c26ddf65ee54ec3591f6f0217d9545d20854f8600541b0/backports_zstd-1.5.0-cp310-cp310-win32.whl", hash = "sha256:11c694c9eef69c19a52df94466d4fd5c8b1bdfbaad350e95adc883b40d8b3be2", size = 289665, upload-time = "2026-05-11T19:52:18.946Z" },
-    { url = "https://files.pythonhosted.org/packages/18/0e/579f193d023c099ecaf560aae72701bfa6bacc5486cf57f91236b9c1404e/backports_zstd-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:c1ea900765329a515020e4e66c65a826657cc1f110770cac3f71ec01b43f2d25", size = 314698, upload-time = "2026-05-11T19:52:20.734Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/f7/1cfc87f0171268ffb3eb479f0b8ef936164cbb6bddd1fbf1457e1ac8aecb/backports_zstd-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:0c473387025e233d123f401d09a17a57e0b9af2ec2423aae7f50f1c806887cb3", size = 291362, upload-time = "2026-05-11T19:52:22.486Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bc/083c0ebee316f4863ed288c4a5eaa1e98be115e82deb8855da8bab1c7701/backports_zstd-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fbaa5502617dc4f04327c7a2951f0fcdca7aaef93ddf32c15dc8b620208174fa", size = 436838, upload-time = "2026-05-11T19:52:24.349Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/e5/bf778667fff6598dbd0791745123ed964aee94753ae8e4e92aa1e07417b6/backports_zstd-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:204f00d62e95aab987c7c019452b2373bdefb17252443765f2ede7f15b6e669a", size = 363215, upload-time = "2026-05-11T19:52:25.887Z" },
-    { url = "https://files.pythonhosted.org/packages/63/a5/4fae78734dbefcb4b5386137c807e2107c4bc94e85c0d9eaae79206dde84/backports_zstd-1.5.0-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:2c77c0d4c330afd26d2a98f3d689ab922ec3f046014a1614ddcaad437666ac05", size = 507161, upload-time = "2026-05-11T19:52:27.48Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ec/b64409f0cf56fb65181d6f5d9130058f19d5c3c9f8c581a5e2bd62642630/backports_zstd-1.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6bb2f2d2c07358edeaa251cf804b993e9f0d5d93af8a7ea2414d80ff3c105e95", size = 476728, upload-time = "2026-05-11T19:52:29.182Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/10/4c1693cb4e129585a6e4cb565106cad7347e61c43c8375b9e9cadb00eb06/backports_zstd-1.5.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89f554abcebcb2c487024e63be8059083775c5fd351fec0cc2dc3e9f528714", size = 582388, upload-time = "2026-05-11T19:52:30.908Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b9/dc748a0e7d21ce2228241f6e8af96d297c80ab69c4c49429309b8fa3beb8/backports_zstd-1.5.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea969758af743000d822fc3a69dc9de059bbbb8d07d2f13e06ff49ac63cce74f", size = 642091, upload-time = "2026-05-11T19:52:32.397Z" },
-    { url = "https://files.pythonhosted.org/packages/de/5f/02366ddae6e008d53df71605e4e3ca8dcea5d1dfcba29040b46883a23127/backports_zstd-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:775ad82d268923639bc924013fc61561df376c148506b241f0f80718b5bb3a2f", size = 492256, upload-time = "2026-05-11T19:52:34.441Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/c7/c5e7824c17abc87dbb24c7c90dc43054d701533cf04d3531cb9b7105cdac/backports_zstd-1.5.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:663128370bbc2ebcc436b8977bc434a7bf29919d92d91fee05ed6fb0fa807646", size = 566214, upload-time = "2026-05-11T19:52:35.962Z" },
-    { url = "https://files.pythonhosted.org/packages/12/7b/ee7368c4ad8f5e00b3fd84fc566fb7714aa766c5672500793990e19efa00/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:572c76832e9a24da4084befa52c23f4c03fede2aa250ae6250cbc5a11b980f69", size = 482666, upload-time = "2026-05-11T19:52:37.675Z" },
-    { url = "https://files.pythonhosted.org/packages/77/36/2826f9f04b6c91d5f707f49188ac6f5ec7487b36d73caedfa20db3307826/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9410bcbcd3afd787a15a276d68f954d1703788c780faa421183a61d39da8b862", size = 510594, upload-time = "2026-05-11T19:52:39.501Z" },
-    { url = "https://files.pythonhosted.org/packages/84/3b/95342baf0e301b7d06c6862389f8520a9d71f073a6c1a5b86182e7d89148/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0fab15e6895bef621041dd82d6306ffa24889257dd902c4b98b88e4260b3465d", size = 586713, upload-time = "2026-05-11T19:52:41.461Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/32/73d2b8f572960307406b084bb8932f4ebd9fcedb05d1502e04fecf25970a/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ffde637b6d0082f1c3356657002469cf199c7c12d50d9822a55b13425c778d3", size = 564037, upload-time = "2026-05-11T19:52:43.15Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a4/6e319fa7fa5851c3ca9701cbded9522c16018432a01a33a95cc0fccb6b4a/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c01d377c1489cb2230bf6a9ff01c73c42863cc96ee648c49923d4f6d4ea4e2d5", size = 632626, upload-time = "2026-05-11T19:52:45.017Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5c/10df0444db05f9276b286d230a3d6948ad47c593fc22925b8fe551d34b26/backports_zstd-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4080bb9c8a51bb2bf8caf8018d78278cd49eb924cb06a54f56a411095e2ac912", size = 496270, upload-time = "2026-05-11T19:52:46.558Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ad/6cd1de5cd858ac653833098f13a4643a4c9db484072350d3dbf299cc46f1/backports_zstd-1.5.0-cp311-cp311-win32.whl", hash = "sha256:9f4fe3fd82c8c6e8a9fdc5c71f92f9fe2442d02e7f59fddef25a955e189e3f38", size = 289754, upload-time = "2026-05-11T19:52:48.232Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/1b/df94ad1cb79705d717f7e1063da642c538a6d7ce6443c8e60355fa507ea4/backports_zstd-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:e7c0372fa036751109604c70a8c87e59faaacc195d519c8cb9e0e527ee2b5478", size = 314829, upload-time = "2026-05-11T19:52:50.031Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e7/24e60da7cc89b9ed1c5b474678e316dd0ddfe7cd1de39b23d04452ca5946/backports_zstd-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:264a66137555bb4648f7e64cfc514d820758072684f373269fcdd2e8d4a90306", size = 291497, upload-time = "2026-05-11T19:52:51.729Z" },
-    { url = "https://files.pythonhosted.org/packages/24/71/29ed213344f8f62b7520745d7df3752d88db456aff9d8b706bdf5eb99a3c/backports_zstd-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1858cacdb3e50105a1b60acdc3dd5b18650077d12dce243e19d5c88e8172bd71", size = 437170, upload-time = "2026-05-11T19:52:53.204Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/e3/a58a3eb8fc54d4e3e4f684ed7b1f688da02e5bda5ae5e2809e94cf2ead2f/backports_zstd-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ccffc0a1974ecc2cc42afa4c15f56d036a4b2bae0abc46e6ba9b3358d9b1c037", size = 363265, upload-time = "2026-05-11T19:52:55.153Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/03/9d13840d206dec1c4698c803f61c58379b3578cb9dc6140ba5fa4ce2f31d/backports_zstd-1.5.0-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ab3430ab4d4ac3fb1bc1e4174d137731e51363b6abd5e51a1599690fe9c7d61d", size = 507527, upload-time = "2026-05-11T19:52:57.256Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8f/8dc4b5736dca218cbca9609549a8f6dc202990abdb49afdc6112442f5360/backports_zstd-1.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c737c1cb4a10c2d0f6cba9a347522858094f0a737b4558c67a777bcaa4a795cd", size = 477352, upload-time = "2026-05-11T19:52:59.425Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2c/65a66976a761b5b62eacbaed5ed418c694b24b5c480399315d799751de62/backports_zstd-1.5.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0379c66510681a6b2780d3f3ef2cff54d01204b52448d64bde1855d40f856a04", size = 582799, upload-time = "2026-05-11T19:53:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/e9/ee93a66cd28cb3ad7f3c04d1105325a5428671b18bd41ba9ed8b43bc44cf/backports_zstd-1.5.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c7474b291e264c9609358d3875cf539623f7a65339c2b533020992b1a4c095b", size = 641530, upload-time = "2026-05-11T19:53:03.082Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/4b/2cecd4d6679f175f28ae02022bd2050ff4023e38902fae104dbe2e231911/backports_zstd-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb73c22444617bc5a3abf32dd27b3f2085898cfe3b95e6855300e9189898a3bd", size = 495324, upload-time = "2026-05-11T19:53:05.005Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/20/ee21e4e791e31f38f7a70b3961eb64b350d9be802a335e7a04c02b41b197/backports_zstd-1.5.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6cd7f6c33afd89354f74469e315e72754e3040f91f7b685061e225d9e36e3e8e", size = 569796, upload-time = "2026-05-11T19:53:07.011Z" },
-    { url = "https://files.pythonhosted.org/packages/76/da/86c9a2ea384885b60638b3e47113198449568d0e36ef3834d1f969623092/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2106309071f279b38d3663c55c7fed192733b4f332b50eb3fa707e54bad6967a", size = 483367, upload-time = "2026-05-11T19:53:08.674Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f0/c95c6e4dd28fc314547782a482839e422283d62c2aaf45d30672109a4a1e/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:56fffa80be74cb11ac843333bbdc56e466c87967706886b3efd6b16d83830d90", size = 510976, upload-time = "2026-05-11T19:53:10.339Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/a2/72777b7e1872228a13b09b0bf77ae6cf626008d462cc2e1a0ae64721fd55/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5e8b8251eec80e67e30ec79dfc5b3b1ada069b9ac48b56b102f3e2c6f8281062", size = 587190, upload-time = "2026-05-11T19:53:12.205Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/a1/db5d1aee59da308eadeaa189764a4ec68e98495c309a13dcb8da5718fef1/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f334dd17ffead361aa9090e40151bd123507ce213a62733121b7145c6711cbde", size = 567395, upload-time = "2026-05-11T19:53:14.245Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0f/39ca1a6e8c5c2dc81da9e06c44d1990cc464f4b16dae214e877afd7adfc0/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:78cbfd061255fef6de5070a54e0f9c00e8aabad5c99dd2ad884a3a7d1acc09ae", size = 632048, upload-time = "2026-05-11T19:53:16.234Z" },
-    { url = "https://files.pythonhosted.org/packages/73/fd/a438ee4fc615016dbe96112b709b6805ee19eb215f46e208c8fbce086d8d/backports_zstd-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2f55d70df44f49d599e20033013bc1ae705202735c45d4bca8eb963b225e15fd", size = 499833, upload-time = "2026-05-11T19:53:17.85Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/42/f544fde4de32687e28c514288ae3c11106ba644e9dd580992cbd704bbb49/backports_zstd-1.5.0-cp312-cp312-win32.whl", hash = "sha256:a8b096e0383a3bcab34f8c97b79e1a52051189d11258bbc2bc1145997a15dd1d", size = 289876, upload-time = "2026-05-11T19:53:19.486Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/31/9c29cd3175892e5ee909f5e8d14707fa07815301ff24b5c697d1cea62a77/backports_zstd-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:e2802899ba4ef1a062ffe4bb1292c5df32011a54b4c3004c54f46ec975f39554", size = 314933, upload-time = "2026-05-11T19:53:20.942Z" },
-    { url = "https://files.pythonhosted.org/packages/11/ee/1a50acd6446c0d57c4f93ad6ce68e1a631ad920737a6b2d0bbbc47de7f42/backports_zstd-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:3c0353e66942afbd45518788cfbd1e9e117828ceb390fa50517f46f291850d8e", size = 291665, upload-time = "2026-05-11T19:53:22.686Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/e6/252521e3a847eb200bc0a1d528542d651b9c8dc7953e231c39ed2890d5ff/backports_zstd-1.5.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:02a57ee8598dd863c0b11c7af00042ce6bc045bf6f4249fa4c322c62614ca1fd", size = 400134, upload-time = "2026-05-11T19:53:24.28Z" },
-    { url = "https://files.pythonhosted.org/packages/36/43/27ef105ffa2da3d52218d4a7b2e14037974283953b3ee790358af6e9b4df/backports_zstd-1.5.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:c56c11eb3173d540e1fb0216f7ab477cbd3a204eca41f5f329059ee8a5d2ad47", size = 454225, upload-time = "2026-05-11T19:53:25.874Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c9/cdcba1244347500d00567ce2cd6bf04c92d1b0fb6405fb8e13c07715eb46/backports_zstd-1.5.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:ef98f632026aa8e6ce05d786977092798efbe78677aa71219f22d31787809c90", size = 357229, upload-time = "2026-05-11T19:53:27.661Z" },
-    { url = "https://files.pythonhosted.org/packages/df/da/cea04dab3ffb940bde9a59866bde6f2594a7b3ef2948a63fb3898f73d311/backports_zstd-1.5.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:c3712300b18f9d07f788b03594b2f34dfad89d77df96938a640c5007522a6b69", size = 365907, upload-time = "2026-05-11T19:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c4/6a71df2e65033f9b7d8017d77ea2bb572fc2ebc814ea383fdcda4187597a/backports_zstd-1.5.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:bdbc75d1f54df70b65bcfbc8aa0cac21475f79665bb045960af606dc07b56090", size = 446453, upload-time = "2026-05-11T19:53:30.888Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e7/f98ad1a6a249c27884df9d28cf6ebc3c368e0e3288a741c1d51a572bb3d7/backports_zstd-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93d306300d25e59f1cbe98cda494bf295be03a20e8b2c5602ee5ddc03ded29f2", size = 436634, upload-time = "2026-05-11T19:53:32.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/42/d0393ecc64e2ab6ae1b5ca7edbe26e3fe5196885f15d6cc4bce7254e29cd/backports_zstd-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:305d2e4ae9a595d0fd9d5bea5a7a2163306c6c4dcc5eec35ecd5008219d4580e", size = 362867, upload-time = "2026-05-11T19:53:34.385Z" },
-    { url = "https://files.pythonhosted.org/packages/41/fe/87aa9404763bada695d06e5cb9d0575bae033cbf3a2e4e3bd648760178f7/backports_zstd-1.5.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:c8f0967bf8d806b250fb1e905a6b8190e7ae83656d5308989243f84e01fa3774", size = 506844, upload-time = "2026-05-11T19:53:36.023Z" },
-    { url = "https://files.pythonhosted.org/packages/56/94/3af7ce637d148e0b0acb1298b61afe9a934ed425bad9ff05e87afbf6766d/backports_zstd-1.5.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76b7314ca9a253171e3e9524960e9e6411997323cf10aecbbc330faa7a90278d", size = 476975, upload-time = "2026-05-11T19:53:37.885Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/6c/dc2aa1b48296ac6effc3bacb5a3061d40ed74bf73082dfe38eed2ba8362b/backports_zstd-1.5.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b1d0bf16bba86b1071731ced389f184e8de61c1afcafa584244f7f726632f92f", size = 582496, upload-time = "2026-05-11T19:53:39.812Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/38/dd49d3dd27eda9b165ccd63d70538fea016a3e9e42923bbbc1d89fae8a43/backports_zstd-1.5.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:96709d27d406008575ef759405169d538040156704b457d8c0ac035127a46b67", size = 643257, upload-time = "2026-05-11T19:53:41.819Z" },
-    { url = "https://files.pythonhosted.org/packages/59/75/78e819272450aec2462f97a1bceb90bde481f9dba435bf9e76d580b4dec4/backports_zstd-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5737402c29b2bd5bc661d4cde08aed531ed326f2b59a7ad98dc07650dc99a2c9", size = 491958, upload-time = "2026-05-11T19:53:43.501Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/d860f9cf21cb59d583a12166353bf71a439538e2b669f4a7736e400ca596/backports_zstd-1.5.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b65f37ddd375114dbf84658e7dd168e10f5a93394940bfefa7fafc2d3234450", size = 567198, upload-time = "2026-05-11T19:53:45.226Z" },
-    { url = "https://files.pythonhosted.org/packages/38/7c/b175d4c9ff60f964c8f6dd43211de905227cfde5a41eb5f654df58483025/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fae7825dde4f81c28b4c66b1e997f893e296c3f1668351952b3ed085eb9f8cd", size = 482792, upload-time = "2026-05-11T19:53:47.323Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e3/f7b50cf891a10da5f9c412ed4a9c4a772df4d4186d98a41e75c9b462f148/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3aa10e77c0e712d2dfb950910b50591c2fb11f0f1328814e23acc0b4950766df", size = 510363, upload-time = "2026-05-11T19:53:49.523Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/e7841fd4a65661d527697a0e2dab97295868965ccd4e3e12474472719a60/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:518b2ef54ce0fee6d29379cfd64ef66e639456f1b18943466e929b19677f135f", size = 586917, upload-time = "2026-05-11T19:53:51.741Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/7c/57e985dbd621f0307b8c57cabb258eb976793f2aeaf8a5bc020e15b4a793/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:673a1e5fdaa6cb0c7a967eb33066b6dd564871b3498a93e11e2972998047d11f", size = 565004, upload-time = "2026-05-11T19:53:53.774Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/8f/855ffcd1ee0fcf44c3fe62e36db8e7362292d450cc7c4b3f43edccbcd37a/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1277c07ff2d731586aa05aebd946a1b30184620d886a735dd5d5bf94a4a1061e", size = 633737, upload-time = "2026-05-11T19:53:56.036Z" },
-    { url = "https://files.pythonhosted.org/packages/20/39/c4129a03d268699200dfebe1ccab97c7c332d2794571afb372a62e4ed098/backports_zstd-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aff334c7c38b4aea2a899f3138a99c1d58f0686ad7815c74bff506ecf4333296", size = 496309, upload-time = "2026-05-11T19:53:57.591Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/33/34152316dd244dcd43d5300ded3cf6e1b46d343e4e92620c23e533fa91df/backports_zstd-1.5.0-cp313-cp313-win32.whl", hash = "sha256:b932834c4d85360f46d1e7fbf3eee1e26ba594e0eb5c3ee1281e89bc1d48d06f", size = 289560, upload-time = "2026-05-11T19:53:59.274Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c5/f759bc87fd77c88f4fdad2d878535fb7e9537c6a05876d206e6690bf33c6/backports_zstd-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:c71dfbeced720326a8917a6edf921c568dc2396228c6432205c6d7e7fe7f3707", size = 314812, upload-time = "2026-05-11T19:54:00.909Z" },
-    { url = "https://files.pythonhosted.org/packages/47/96/d7970dbb2fef34b549b34146090f48f41903cc7268b1ed1c7542eaa1852e/backports_zstd-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:7b5798b20ffff71ee4620a01f56fe0b50271724b4251db08c90a069446cc4752", size = 291411, upload-time = "2026-05-11T19:54:02.541Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/35/294ce0d818455191ee9a0f21d987d6061d4f844ca34ca44a8b1daaaba3ca/backports_zstd-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:9685586eb67fa2e59eab8027d48e8275ce90e404b6dc737b508f741853ba6cb7", size = 410912, upload-time = "2026-05-11T19:54:04.031Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/5c/99fba38e6d57cf238362d4ac568823b1fb75e20f75b58cd062a3da4d9a7a/backports_zstd-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1a68ab446d007d34e12f5a812e6f7d1c120a3d15cb5d4e62b7568926a6da6fb7", size = 340429, upload-time = "2026-05-11T19:54:05.632Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/bc/146fdb7b0bf39817e1b706e34be46f2cf11d5465668e1912747dd45fd71b/backports_zstd-1.5.0-pp310-pypy310_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:627973d4375a42500a66cc2ea912f6223249a6cdfeb56cc340b0d20b5a3475d0", size = 421477, upload-time = "2026-05-11T19:54:07.499Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/2e/6e43d94a3414d0113439c5e9ae6b04311797cfef5d04dc1d3aa0bcbff057/backports_zstd-1.5.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c077639e99de02a679dca9c6a189f60a76e7d0096977c0ebd070c31de8df57a", size = 395021, upload-time = "2026-05-11T19:54:09.171Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/41/d599f31e5152f43397f837c6911bffee8626d6d079bcaafab04d1a8a07ad/backports_zstd-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ac2b3895fc9b1f0b0e71bffa179b48930dc27643b7e4885869afd295e7dfe1e", size = 414986, upload-time = "2026-05-11T19:54:10.986Z" },
-    { url = "https://files.pythonhosted.org/packages/26/62/006a63d5a13a04384b9cd35e35f78944a75c975f5a71c25e81cc766d53d7/backports_zstd-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41b23cbd72f503aedcaaaa23d55d2d98d449e5938154d2b3f57832c73b286cee", size = 300853, upload-time = "2026-05-11T19:54:12.593Z" },
-    { url = "https://files.pythonhosted.org/packages/89/92/8e8769e1e3ebec16d39f455e317a0f137a191b1f122853d0377c660666ce/backports_zstd-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0ca2d4ac4901eada2cfb86fda692e5d4a1e09485d9f2ec5777dc6cd3154b3b46", size = 410809, upload-time = "2026-05-11T19:54:14.117Z" },
-    { url = "https://files.pythonhosted.org/packages/63/5c/741a2923020c45b85cad4dffffcb86dbfa2d4aaed27f18ee793428ef4c24/backports_zstd-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:20796211a623ec6e0061cef4d7cca760e9e0a0a951bb30dc9ba89ed4a3fea5e4", size = 340342, upload-time = "2026-05-11T19:54:16.165Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/3b/68c4fe8a551d3f47ed75ddcf15dc7c777bb9d869fc0e0f5b7cacc9f158f5/backports_zstd-1.5.0-pp311-pypy311_pp73-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:5232cd2a58c60da4ceb0e09e42dbc579b92dda4a9301a756af0c738223a23487", size = 421476, upload-time = "2026-05-11T19:54:17.709Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/4d/ab5dcd6ab9a7ac02ec42c4507211da7dadb9498abb655115c296077e2b8b/backports_zstd-1.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:012d88a9ae08f331e1adc03dfbda4ff2ae7f76ea62455975827b215677a11aec", size = 395020, upload-time = "2026-05-11T19:54:19.566Z" },
-    { url = "https://files.pythonhosted.org/packages/55/aa/ec512a0d14552bbb4e75693f7065434b865956abd045ceb67f0574146241/backports_zstd-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbb7d79f8e43b6e0e17616961e425b9f8b32d9933e1db69242baa6e21f44a978", size = 414985, upload-time = "2026-05-11T19:54:21.136Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/31/759d077aa680555e17c9d2bb09edf4c3428d895fe5d35a8df67684401b84/backports_zstd-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6172dcdd664ef243e55a35e6b45f1c866767c61043f0ddcd908abd14df662065", size = 300853, upload-time = "2026-05-11T19:54:23.1Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2026.4.22"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
-    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
-    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
-    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
 ]
 
 [[package]]
@@ -418,64 +238,6 @@ toml = [
 ]
 
 [[package]]
-name = "cryptography"
-version = "48.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
-    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
-    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
-    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -497,181 +259,12 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.29.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "hatch"
-version = "1.16.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
-    { name = "click" },
-    { name = "hatchling" },
-    { name = "httpx" },
-    { name = "hyperlink" },
-    { name = "keyring" },
-    { name = "packaging" },
-    { name = "pexpect" },
-    { name = "platformdirs" },
-    { name = "pyproject-hooks" },
-    { name = "python-discovery" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "tomli-w" },
-    { name = "tomlkit" },
-    { name = "userpath" },
-    { name = "uv" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/02/ce9c4c439fa3f195b21b4b5bb18b44d1076297c86477ef7e3d2de6064ec3/hatch-1.16.5.tar.gz", hash = "sha256:57bdeeaa72577859ce37091a5449583875331c06f9cb6af9077947ad40b3a1de", size = 5220741, upload-time = "2026-02-27T18:45:31.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/8a/11ae7e271870f0ad8fa0012e4265982bebe0fdc21766b161fb8b8fc3aefc/hatch-1.16.5-py3-none-any.whl", hash = "sha256:d9b8047f2cd10d3349eb6e8f278ad728a04f91495aace305c257d5c2747188fb", size = 141269, upload-time = "2026-02-27T18:45:29.573Z" },
-]
-
-[[package]]
-name = "hatchling"
-version = "1.29.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl", hash = "sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0", size = 76356, upload-time = "2026-02-23T19:42:05.197Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "hyperlink"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.15'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jaraco-classes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
-]
-
-[[package]]
-name = "jaraco-context"
-version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
-]
-
-[[package]]
-name = "jaraco-functools"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
-]
-
-[[package]]
-name = "jeepney"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -699,24 +292,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "keyring"
-version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -826,15 +401,6 @@ wheels = [
 ]
 
 [[package]]
-name = "more-itertools"
-version = "11.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
-]
-
-[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -921,27 +487,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -951,39 +496,12 @@ wheels = [
 ]
 
 [[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyproject-hooks"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
@@ -1029,28 +547,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
-]
-
-[[package]]
-name = "python-discovery"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
-]
-
-[[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1292,28 +788,6 @@ wheels = [
 ]
 
 [[package]]
-name = "secretstorage"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1386,82 +860,10 @@ wheels = [
 ]
 
 [[package]]
-name = "trove-classifiers"
-version = "2026.5.7.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/68/175e7c07c5be13200387d5c0995b0da1e198e360047c08eb17d1002fcd92/trove_classifiers-2026.5.7.17.tar.gz", hash = "sha256:a04a48f8f0a787cb996514d3969ac7608aa3c60cb15d073c1e02801e60533e80", size = 17041, upload-time = "2026-05-07T17:48:01.931Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/e3/d81b065a2d866a33a541ac63a2a4cc5737e03ce2379ac3191c98bb8867e3/trove_classifiers-2026.5.7.17-py3-none-any.whl", hash = "sha256:5ec0800de5e2ddbd7c663cb4c0c15328f132dc168813897c18866c5c7b93db33", size = 14201, upload-time = "2026-05-07T17:48:00.488Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "userpath"
-version = "1.9.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz", hash = "sha256:6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815", size = 11140, upload-time = "2024-02-29T21:39:08.742Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/99/3ec6335ded5b88c2f7ed25c56ffd952546f7ed007ffb1e1539dc3b57015a/userpath-1.9.2-py3-none-any.whl", hash = "sha256:2cbf01a23d655a1ff8fc166dfb78da1b641d1ceabf0fe5f970767d380b14e89d", size = 9065, upload-time = "2024-02-29T21:39:07.551Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.11.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/3c/463dc85baffc8dda4183b31ba2546204740c0cbac5c01d3671c4eb52819c/uv-0.11.13.tar.gz", hash = "sha256:c30889b6a4417f94a0315371ec5bf8af151f062406ad3fb4b2cbf13d645d825c", size = 4124451, upload-time = "2026-05-11T01:37:54.367Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/e6/78a0092e303dd8edf5a3ea74442b17b2ed8c1e9f82e97c7359045cefccdc/uv-0.11.13-py3-none-linux_armv6l.whl", hash = "sha256:4e56623a9ff6d7372290963cd21777bcb52aacbff6619d58a2659ee8240f8fed", size = 23545030, upload-time = "2026-05-11T01:38:23.367Z" },
-    { url = "https://files.pythonhosted.org/packages/60/7e/e48c24814e5a2cbf2bb9ccf55d9327813fe3074ada9526851914663dc380/uv-0.11.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:72ad50ae5ce446f6887be842adffd1770b8e138caccc972f333915e524b323ac", size = 23076867, upload-time = "2026-05-11T01:38:02.308Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f6/0dcbc43f83e90626981a10b179769b25c0a218717a4331f928c26b6e13a2/uv-0.11.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e5913805ee60b4e331dd7322ae95e18ceb110f6a5baae608d71a532ed1115e75", size = 21710719, upload-time = "2026-05-11T01:37:47.115Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c7/348575ae1ea6f312860915a60c1c7c4cf591339164ee321824ba9143a2c4/uv-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:eb4fe81624bc92894c59aaf88a57cb1fcaf7da95dc3cf2ef1ed86847f0a7e9f6", size = 23300489, upload-time = "2026-05-11T01:37:57.718Z" },
-    { url = "https://files.pythonhosted.org/packages/31/3c/78a8afbb98a50db65f4096025bbeff7aac67af8a4d3329f4f9bd8b5acc42/uv-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:64dd1c36893d0da363d4c8e91c5d554d01a30061c83302eb93c75ca91b0f7eb3", size = 23077624, upload-time = "2026-05-11T01:37:43.197Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/30/d68cfdcaa88ad5a2bd1b149818ef51d970518ddd39001dd62ff5e4709d11/uv-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a3551cb18aaa75f50153877a4988e718ba365ba998563c390a99e207aeeadd0d", size = 23107411, upload-time = "2026-05-11T01:38:06.838Z" },
-    { url = "https://files.pythonhosted.org/packages/02/2c/2311a29f32e1d404dc2fbc516e5febdf4567fcc3cfdd94e398bf5566b515/uv-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd454d4f40e232355fa96937bae41e91b16279e2526034050576da5a2d8a7f40", size = 24551248, upload-time = "2026-05-11T01:37:23.403Z" },
-    { url = "https://files.pythonhosted.org/packages/15/cc/ecb7174b11f64079ab9ec8ec0443aeaf69b86c6e6ad213b094d61ac71205/uv-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4356e97a0e3e4d3ab53fd15415af12764a979759e37a3124372e3e6755e9a0c", size = 25455493, upload-time = "2026-05-11T01:38:10.814Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0d/44031030724a5128efb06be62a701fe36a1664f91aee346ffaf6f0432d39/uv-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a714e866853c72cb2b7a18187cf3db4a1475a2032f3bd00e1c98ccf214c31d0", size = 24562712, upload-time = "2026-05-11T01:38:14.979Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ad/dfb82224e73031c71dc70eb4513a6f4f6af66da35c3c955e28d75fe03d1c/uv-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e23ddb47f7a317979cf1945cf9ed89d2639f60f7d06164f9ff1ad292c4cc5b3c", size = 24662925, upload-time = "2026-05-11T01:37:31.646Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/6cd9b920dcc83f0866e842caad5575cc3d5ca6604facbf5582950bbfc68c/uv-0.11.13-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:00efc945dd0392d7ac571cde402936e13ffba855121de79f42b3de9ee2f6a69a", size = 23398601, upload-time = "2026-05-11T01:37:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a9/291ff99b1dce9ec14b5a0358ad7d384485471d6ee4ecd7d98e05ef570da5/uv-0.11.13-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:b0807d1e9bc84c902cba9bb0b23627f6c980c54167c999e502571974fcfe2d6e", size = 24138999, upload-time = "2026-05-11T01:38:19.294Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/88/8eabfbe745371696d09d08e47e637d567413071eb02c7e2324a919ba4f87/uv-0.11.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:bea50519b30c1bc4e4a331dcc1d55253cd8d886d243d3506ec00f34cdf030eff", size = 24196974, upload-time = "2026-05-11T01:37:35.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/bf/9ab0db9d7f8d7b52382d70eb26bbd9e84dbe6cfce709ec7bf31895991a0a/uv-0.11.13-py3-none-musllinux_1_1_i686.whl", hash = "sha256:d714e4a09e28198664758576542c7cedb054677ab3cdec60207a75ed74f82235", size = 23822126, upload-time = "2026-05-11T01:38:31.829Z" },
-    { url = "https://files.pythonhosted.org/packages/72/d9/dc2d1eb6b4181e5485cd36ecdb1c2f4fbec9b4078bb2b7266ef5481d2433/uv-0.11.13-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:bf067fc357e1f75783c343e731c3bf4f8ca531917eafd6d9f18cd477ddaee158", size = 24868862, upload-time = "2026-05-11T01:38:27.595Z" },
-    { url = "https://files.pythonhosted.org/packages/94/94/de37ee6b07459780de695e6c57e158ce1307de075f40718740a981132d9e/uv-0.11.13-py3-none-win32.whl", hash = "sha256:79c3f501bbf849bc566e108545891abfbc15e4e85c22d8875bfe405c1e2efc42", size = 22581531, upload-time = "2026-05-11T01:37:39.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/89/01f90839cd1204e7a328cc36da27a09bc8b1a9692d3f9b79cee0a0945e1b/uv-0.11.13-py3-none-win_amd64.whl", hash = "sha256:974ec55646a7e680f91cdf4f77fbc6e2a71157240cd0efa387d458709b63ab04", size = 25194788, upload-time = "2026-05-11T01:37:51.372Z" },
-    { url = "https://files.pythonhosted.org/packages/63/99/4d75ad86221363a277c3be4e36e928e84f0dff256413e83e58d8af8c0e2c/uv-0.11.13-py3-none-win_arm64.whl", hash = "sha256:35aaca82115b8dc747f22b8c76b1026e707f4c9a59fe39ab3c21be111a65fa44", size = 23589361, upload-time = "2026-05-11T01:37:27.755Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "21.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "python-discovery" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
- Drop zero-caller helpers/exports (KNOWN_COMPONENT_IDS, get_git_repo_root,
  detect_old_config_symlinks, cleanup_orphaned_symlinks, install_user_symlinks,
  Tool.install_spec, ClaudeMCPManager.claude_json, MCPManager._target_path,
  ExtensionItem/SkillItem fields, SkillMetadata.body, PluginStatus.marketplaces_present,
  bootstrap facade re-exports).
- Drop unused kwargs: force/dry_run from MCPManager.uninstall_mcps, force from
  cleanup_deprecated_symlinks, agent_label from _display_symlink_status,
  console/setting from override helpers, is_directory from get_orphaned_symlinks,
  user_skills_dir from SkillManager.
- Inline dead guards in installer.py statusline flow and bootstrap/updater.py
  StatuslineTool.INSTALL_SPEC branch.
- Derive _get_common_exclusions settings entries dynamically from
  ConfigTarget.settings_symlink_target, keep rules/hints files as a small static list.
- Filter ToolSpec.is_enabled in upgrade.py when no --only is set; extract
  _filter_enabled helper and rewrite TestIsEnabledFiltering to exercise it.
- Refresh README.md and AGENTS.md to point at the cli/ package layout and
  targets/registry.py::TARGET_CLASSES; drop broken `just docs` recipe and
  hatch dev-dependency.

https://claude.ai/code/session_01MVcKVzGge4eZ3MQ9z4hWq7