### PR TITLE
Add cross-agent session search shared skill

### DIFF
--- a/src/ai_rules/config/skills/session-search/SKILL.md
+++ b/src/ai_rules/config/skills/session-search/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: session-search
+description: >
+  Use this skill to find, locate, or search previous coding agent sessions or
+  conversations. Triggers on requests to search session transcripts or
+  conversation history, recover commands or outputs from earlier sessions,
+  compare recent sessions for a repository, or search across Claude Code,
+  Codex CLI, Gemini CLI, Goose, or Amp session history.
+---
+
+## Context
+
+- Current directory: !`pwd`
+- Git repo root: !`git rev-parse --show-toplevel 2>/dev/null || echo "NOT_IN_GIT"`
+- Repo name: !`basename $(git rev-parse --show-toplevel 2>/dev/null) 2>/dev/null || echo "UNKNOWN"`
+
+# Session Search
+
+Searches session transcripts across all detected coding agents: Claude Code, Codex CLI, Gemini CLI, Goose, and Amp. Results are ranked by current repo match, then by recency.
+
+## Quick Start
+
+Resolve `<skill-dir>` as the directory containing this SKILL.md file.
+
+```bash
+# Find sessions mentioning a topic
+uv run python <skill-dir>/scripts/session_search find "authentication refactor"
+
+# Search transcript content for a regex pattern
+uv run python <skill-dir>/scripts/session_search grep "BaseModel" --limit-sessions 20
+
+# List recent sessions for the current repo
+uv run python <skill-dir>/scripts/session_search list --limit 10
+```
+
+## Context Hygiene
+
+For broad or exploratory searches, delegate to a subagent and return only IDs, titles, timestamps, cwd values, paths, and short snippets. Never dump raw transcripts into the main context window — a single session file can be hundreds of kilobytes.
+
+When returning results to the user, summarize what was found and offer to retrieve specific sessions on request.
+
+## Find Sessions
+
+```bash
+# Look up a session by ID fragment
+uv run python <skill-dir>/scripts/session_search find "3f8a"
+
+# Search by topic across all repos
+uv run python <skill-dir>/scripts/session_search find "database migration" --all-repos
+
+# List sessions for a specific repo
+uv run python <skill-dir>/scripts/session_search list --repo my-service
+
+# Restrict to one agent
+uv run python <skill-dir>/scripts/session_search find "webhook handler" --agent claude
+
+# Sessions since a date
+uv run python <skill-dir>/scripts/session_search list --since 2026-04-01
+```
+
+## Grep Sessions
+
+```bash
+# Regex search across recent sessions (default: current repo)
+uv run python <skill-dir>/scripts/session_search grep "TODO|FIXME" --limit-sessions 25
+
+# Search within a specific session by ID fragment
+uv run python <skill-dir>/scripts/session_search grep "import requests" --id 3f8a
+
+# Case-insensitive search, wider output, capped matches
+uv run python <skill-dir>/scripts/session_search grep "config" -i --max-matches 20 --width 200
+
+# Broader search across all repos
+uv run python <skill-dir>/scripts/session_search grep "pg_dump" --all-repos --limit-sessions 50
+```
+
+`--limit-sessions` controls how many session files are scanned. `--max-matches` controls output volume. Prefer lower values for exploratory searches; increase when a specific pattern is known to be rare.
+
+## Scoped Search
+
+If `rg` is needed for low-level transcript inspection, first use `find` or `list` to get candidate session file paths, then scope `rg` to those specific files. Never run an unscoped recursive grep from `~` or `/` — session stores can contain gigabytes of transcript data.
+
+```bash
+# Step 1: get candidate paths
+uv run python <skill-dir>/scripts/session_search find "auth flow" --json | jq -r '.[].path'
+
+# Step 2: grep only those files
+rg "Bearer token" /path/to/session1.jsonl /path/to/session2.jsonl
+```
+
+## Common Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--agent {claude,codex,gemini,goose,amp}` | Restrict to one agent |
+| `--all-repos` | Search beyond current repo |
+| `--since YYYY-MM-DD` | Lower bound on session date |
+| `--until YYYY-MM-DD` | Upper bound on session date |
+| `--oldest` | Reverse sort (oldest first) |
+| `--limit N` | Max sessions returned |
+| `--json` | Machine-readable JSON output |
+| `--cwd DIR` | Treat DIR as the working directory for ranking |
+| `--repo NAME` | Filter by repo name |
+
+## Ranking
+
+Sessions are ranked in this order:
+
+1. Exact current `cwd` match
+2. Same git repository root
+3. Same repository name
+4. Recency (newest first by default)
+
+Use `--all-repos` to include sessions from unrelated repositories.
+
+## Agent Storage Notes
+
+| Agent | Storage location |
+|-------|----------------|
+| Claude Code | `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` |
+| Codex CLI | `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl` |
+| Gemini CLI | `~/.gemini/tmp/<project-slug>/chats/session-*.jsonl` |
+| Goose | `~/.local/share/goose/sessions/sessions.db` (SQLite) |
+| Amp | `~/.local/share/amp/threads/T-<uuid>.json` |

--- a/src/ai_rules/config/skills/session-search/SKILL.md
+++ b/src/ai_rules/config/skills/session-search/SKILL.md
@@ -23,14 +23,14 @@ Searches session transcripts across all detected coding agents: Claude Code, Cod
 Resolve `<skill-dir>` as the directory containing this SKILL.md file.
 
 ```bash
-# Find sessions mentioning a topic
-uv run python <skill-dir>/scripts/session_search find "authentication refactor"
+# Find sessions by title, ID fragment, or cwd (metadata only — use grep for content)
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search find "authentication"
 
 # Search transcript content for a regex pattern
-uv run python <skill-dir>/scripts/session_search grep "BaseModel" --limit-sessions 20
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search grep "authentication refactor" --limit-sessions 20
 
 # List recent sessions for the current repo
-uv run python <skill-dir>/scripts/session_search list --limit 10
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search list --limit 10
 ```
 
 ## Context Hygiene
@@ -43,35 +43,35 @@ When returning results to the user, summarize what was found and offer to retrie
 
 ```bash
 # Look up a session by ID fragment
-uv run python <skill-dir>/scripts/session_search find "3f8a"
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search find "3f8a"
 
-# Search by topic across all repos
-uv run python <skill-dir>/scripts/session_search find "database migration" --all-repos
+# Find by title/cwd keyword across all repos
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search find "database migration" --all-repos
 
 # List sessions for a specific repo
-uv run python <skill-dir>/scripts/session_search list --repo my-service
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search list --repo my-service
 
 # Restrict to one agent
-uv run python <skill-dir>/scripts/session_search find "webhook handler" --agent claude
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search find "webhook handler" --agent claude
 
 # Sessions since a date
-uv run python <skill-dir>/scripts/session_search list --since 2026-04-01
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search list --since 2026-04-01
 ```
 
 ## Grep Sessions
 
 ```bash
 # Regex search across recent sessions (default: current repo)
-uv run python <skill-dir>/scripts/session_search grep "TODO|FIXME" --limit-sessions 25
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search grep "TODO|FIXME" --limit-sessions 25
 
 # Search within a specific session by ID fragment
-uv run python <skill-dir>/scripts/session_search grep "import requests" --id 3f8a
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search grep "import requests" --id 3f8a
 
 # Case-insensitive search, wider output, capped matches
-uv run python <skill-dir>/scripts/session_search grep "config" -i --max-matches 20 --width 200
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search grep "config" -i --max-matches 20 --width 200
 
 # Broader search across all repos
-uv run python <skill-dir>/scripts/session_search grep "pg_dump" --all-repos --limit-sessions 50
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search grep "pg_dump" --all-repos --limit-sessions 50
 ```
 
 `--limit-sessions` controls how many session files are scanned. `--max-matches` controls output volume. Prefer lower values for exploratory searches; increase when a specific pattern is known to be rare.
@@ -82,7 +82,7 @@ If `rg` is needed for low-level transcript inspection, first use `find` or `list
 
 ```bash
 # Step 1: get candidate paths
-uv run python <skill-dir>/scripts/session_search find "auth flow" --json | jq -r '.[].path'
+PYTHONPATH=<skill-dir>/scripts uv run python -m session_search find "auth flow" --json | jq -r '.[].path'
 
 # Step 2: grep only those files
 rg "Bearer token" /path/to/session1.jsonl /path/to/session2.jsonl

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/__init__.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-agent session search: find and grep transcripts across coding agents."""

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/__main__.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/__main__.py
@@ -1,0 +1,206 @@
+"""CLI entry point for cross-agent session search."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+from session_search.core import (
+    in_date_window,
+    matches_term,
+    print_sessions,
+    sorted_sessions,
+    warn,
+)
+from session_search.readers import iter_all_sessions, search_sessions
+
+
+def add_common_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--agent",
+        choices=["claude", "codex", "gemini", "goose", "amp"],
+        help="Restrict to a single agent.",
+    )
+    parser.add_argument(
+        "--cwd",
+        default=os.getcwd(),
+        help="Working directory used for repo bias.",
+    )
+    parser.add_argument(
+        "--repo",
+        help="Override detected repo name for ranking.",
+    )
+    parser.add_argument(
+        "--all-repos",
+        action="store_true",
+        help="Disable same-repo ranking bias.",
+    )
+    parser.add_argument(
+        "--since",
+        help="Only include sessions on/after YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--until",
+        help="Only include sessions on/before YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--oldest",
+        action="store_true",
+        help="Sort oldest first instead of newest first.",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Search session transcripts across coding agents."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser(
+        "list", help="List recent sessions, repo-biased by default."
+    )
+    add_common_flags(list_parser)
+    list_parser.add_argument(
+        "--limit",
+        type=int,
+        default=12,
+        help="Number of sessions to print; 0 means all.",
+    )
+    list_parser.add_argument(
+        "--json", action="store_true", help="Print JSON."
+    )
+
+    find_parser = subparsers.add_parser(
+        "find",
+        help="Find sessions by ID fragment, title, path, cwd, or repo.",
+    )
+    add_common_flags(find_parser)
+    find_parser.add_argument(
+        "term", nargs="?", default="", help="ID fragment or search phrase."
+    )
+    find_parser.add_argument(
+        "--limit",
+        type=int,
+        default=12,
+        help="Number of sessions to print; 0 means all.",
+    )
+    find_parser.add_argument(
+        "--json", action="store_true", help="Print JSON."
+    )
+
+    grep_parser = subparsers.add_parser(
+        "grep", help="Regex search across session transcripts."
+    )
+    add_common_flags(grep_parser)
+    grep_parser.add_argument(
+        "pattern", help="Python regular expression to search for."
+    )
+    grep_parser.add_argument(
+        "--id",
+        help="Restrict search to sessions matching this ID fragment.",
+    )
+    grep_parser.add_argument(
+        "--limit-sessions",
+        type=int,
+        default=25,
+        help="Candidate sessions to search; 0 means all.",
+    )
+    grep_parser.add_argument(
+        "--max-matches",
+        type=int,
+        default=40,
+        help="Maximum matches to print; 0 means all.",
+    )
+    grep_parser.add_argument(
+        "--ignore-case",
+        "-i",
+        action="store_true",
+        help="Case-insensitive search.",
+    )
+    grep_parser.add_argument(
+        "--width",
+        type=int,
+        default=280,
+        help="Truncate rendered match lines to this width.",
+    )
+
+    return parser
+
+
+def cmd_grep(args: argparse.Namespace) -> int:
+    sessions = iter_all_sessions(args)
+    if args.id:
+        sessions = [s for s in sessions if matches_term(s, args.id)]
+    ranked = sorted_sessions(sessions, args.oldest)
+    if args.limit_sessions > 0:
+        ranked = ranked[: args.limit_sessions]
+
+    flags = re.IGNORECASE if args.ignore_case else 0
+    try:
+        pattern = re.compile(args.pattern, flags)
+    except re.error as exc:
+        warn(f"invalid regex: {exc}")
+        return 2
+
+    match_count = search_sessions(ranked, pattern, args)
+
+    if match_count == 0 and not args.all_repos and not args.id:
+        searched = {s.id for s in ranked}
+        from session_search.core import date_key
+
+        fallback = [
+            s
+            for s in sorted(
+                sessions,
+                key=lambda s: date_key(s.sort_time),
+                reverse=not args.oldest,
+            )
+            if s.id not in searched
+        ]
+        if args.limit_sessions > 0:
+            fallback = fallback[: args.limit_sessions]
+        if fallback:
+            print(
+                "\nNo matches in repo-biased candidates; "
+                "checking remaining recent sessions."
+            )
+            match_count = search_sessions(fallback, pattern, args)
+
+    if match_count == 0:
+        print("No matches.")
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list":
+        sessions = iter_all_sessions(args)
+        print_sessions(
+            sorted_sessions(sessions, args.oldest), args.limit, args.json
+        )
+        return 0
+
+    if args.command == "find":
+        sessions = iter_all_sessions(args)
+        hits = [
+            s for s in sessions if not args.term or matches_term(s, args.term)
+        ]
+        print_sessions(
+            sorted_sessions(hits, args.oldest), args.limit, args.json
+        )
+        return 0 if hits else 1
+
+    if args.command == "grep":
+        return cmd_grep(args)
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/__main__.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/__main__.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import sys
 
 from session_search.core import (
-    in_date_window,
     matches_term,
     print_sessions,
     sorted_sessions,
@@ -68,9 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=12,
         help="Number of sessions to print; 0 means all.",
     )
-    list_parser.add_argument(
-        "--json", action="store_true", help="Print JSON."
-    )
+    list_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     find_parser = subparsers.add_parser(
         "find",
@@ -86,17 +82,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=12,
         help="Number of sessions to print; 0 means all.",
     )
-    find_parser.add_argument(
-        "--json", action="store_true", help="Print JSON."
-    )
+    find_parser.add_argument("--json", action="store_true", help="Print JSON.")
 
     grep_parser = subparsers.add_parser(
         "grep", help="Regex search across session transcripts."
     )
     add_common_flags(grep_parser)
-    grep_parser.add_argument(
-        "pattern", help="Python regular expression to search for."
-    )
+    grep_parser.add_argument("pattern", help="Python regular expression to search for.")
     grep_parser.add_argument(
         "--id",
         help="Restrict search to sessions matching this ID fragment.",
@@ -162,10 +154,7 @@ def cmd_grep(args: argparse.Namespace) -> int:
         if args.limit_sessions > 0:
             fallback = fallback[: args.limit_sessions]
         if fallback:
-            print(
-                "\nNo matches in repo-biased candidates; "
-                "checking remaining recent sessions."
-            )
+            print("\nNo matches in top candidates; checking older sessions.")
             match_count = search_sessions(fallback, pattern, args)
 
     if match_count == 0:
@@ -180,19 +169,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "list":
         sessions = iter_all_sessions(args)
-        print_sessions(
-            sorted_sessions(sessions, args.oldest), args.limit, args.json
-        )
+        print_sessions(sorted_sessions(sessions, args.oldest), args.limit, args.json)
         return 0
 
     if args.command == "find":
         sessions = iter_all_sessions(args)
-        hits = [
-            s for s in sessions if not args.term or matches_term(s, args.term)
-        ]
-        print_sessions(
-            sorted_sessions(hits, args.oldest), args.limit, args.json
-        )
+        hits = [s for s in sessions if not args.term or matches_term(s, args.term)]
+        print_sessions(sorted_sessions(hits, args.oldest), args.limit, args.json)
         return 0 if hits else 1
 
     if args.command == "grep":

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
@@ -1,0 +1,206 @@
+"""Shared data model, repo scoring, ranking, and date filtering."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class Session:
+    id: str
+    agent: str
+    path: Path
+    timestamp: str
+    updated_at: str
+    title: str
+    cwd: str
+    repo_score: int
+    repo_reason: str
+
+    @property
+    def sort_time(self) -> str:
+        return self.updated_at or self.timestamp
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def date_key(value: str) -> datetime:
+    parsed = parse_iso(value)
+    if parsed is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Repo scoring
+# ---------------------------------------------------------------------------
+
+
+def git_root(cwd: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    root = result.stdout.strip()
+    return Path(root).resolve() if root else None
+
+
+def repo_name_from_path(path_text: str) -> str:
+    if not path_text:
+        return ""
+    return Path(path_text).name
+
+
+def repo_context(
+    cwd_text: str, explicit_repo: str | None
+) -> tuple[str, str, str]:
+    cwd = Path(cwd_text).expanduser().resolve()
+    root = git_root(cwd)
+    root_text = str(root) if root else str(cwd)
+    repo_name = explicit_repo or repo_name_from_path(root_text)
+    return str(cwd), root_text, repo_name
+
+
+def repo_score(
+    session_cwd: str,
+    current_cwd: str,
+    current_root: str,
+    repo_name: str,
+) -> tuple[int, str]:
+    if not session_cwd:
+        return 0, ""
+    session_path = str(Path(session_cwd).expanduser())
+    if session_path == current_cwd or session_path == current_root:
+        return 3, "exact-cwd"
+    if current_root and session_path.startswith(
+        current_root.rstrip("/") + "/"
+    ):
+        return 3, "same-root"
+    session_repo = repo_name_from_path(session_path)
+    if repo_name and session_repo == repo_name:
+        return 2, "same-repo"
+    if repo_name and f"/{repo_name}" in session_path:
+        return 1, "repo-name-in-path"
+    return 0, ""
+
+
+# ---------------------------------------------------------------------------
+# Filtering and sorting
+# ---------------------------------------------------------------------------
+
+
+def in_date_window(session: Session, args: argparse.Namespace) -> bool:
+    value = date_key(session.sort_time)
+    if args.since:
+        since = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+        if value < since:
+            return False
+    if args.until:
+        until = datetime.fromisoformat(args.until).replace(tzinfo=timezone.utc)
+        if value.date() > until.date():
+            return False
+    return True
+
+
+def sorted_sessions(
+    sessions: Iterable[Session], oldest: bool
+) -> list[Session]:
+    return sorted(
+        sessions,
+        key=lambda s: (s.repo_score, date_key(s.sort_time), s.title, s.id),
+        reverse=not oldest,
+    )
+
+
+def matches_term(session: Session, term: str) -> bool:
+    needle = term.lower()
+    haystacks = [
+        session.id,
+        session.path.name,
+        str(session.path),
+        session.title,
+        session.cwd,
+        session.agent,
+    ]
+    return any(needle in value.lower() for value in haystacks if value)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def truncate(text: str, width: int = 280) -> str:
+    compact = " ".join(text.split())
+    if len(compact) <= width:
+        return compact
+    return compact[: width - 1] + "..."
+
+
+def session_to_json(session: Session) -> dict[str, Any]:
+    return {
+        "id": session.id,
+        "agent": session.agent,
+        "title": session.title,
+        "timestamp": session.timestamp,
+        "updated_at": session.updated_at,
+        "cwd": session.cwd,
+        "path": str(session.path),
+        "repo_score": session.repo_score,
+        "repo_reason": session.repo_reason,
+    }
+
+
+def print_sessions(
+    sessions: list[Session], limit: int, json_output: bool
+) -> None:
+    shown = sessions if limit <= 0 else sessions[:limit]
+    if json_output:
+        print(json.dumps([session_to_json(s) for s in shown], indent=2))
+        return
+    for i, session in enumerate(shown, 1):
+        label = f" [{session.repo_reason}]" if session.repo_reason else ""
+        agent_tag = f"[{session.agent}]"
+        title_part = f" - {session.title}" if session.title else ""
+        print(f"{i}. {agent_tag} {session.id}{label}{title_part}")
+        print(f"   time: {session.sort_time or session.timestamp}")
+        print(f"   cwd:  {session.cwd or '(unknown)'}")
+        print(f"   path: {session.path}")
+    if len(sessions) > len(shown):
+        print(
+            f"... {len(sessions) - len(shown)} more matches; "
+            "rerun with --limit 0 for all."
+        )
+
+
+def warn(msg: str) -> None:
+    print(f"[warn] {msg}", file=sys.stderr)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
+
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -80,9 +81,7 @@ def repo_name_from_path(path_text: str) -> str:
     return Path(path_text).name
 
 
-def repo_context(
-    cwd_text: str, explicit_repo: str | None
-) -> tuple[str, str, str]:
+def repo_context(cwd_text: str, explicit_repo: str | None) -> tuple[str, str, str]:
     cwd = Path(cwd_text).expanduser().resolve()
     root = git_root(cwd)
     root_text = str(root) if root else str(cwd)
@@ -101,9 +100,7 @@ def repo_score(
     session_path = str(Path(session_cwd).expanduser())
     if session_path == current_cwd or session_path == current_root:
         return 3, "exact-cwd"
-    if current_root and session_path.startswith(
-        current_root.rstrip("/") + "/"
-    ):
+    if current_root and session_path.startswith(current_root.rstrip("/") + "/"):
         return 3, "same-root"
     session_repo = repo_name_from_path(session_path)
     if repo_name and session_repo == repo_name:
@@ -131,14 +128,14 @@ def in_date_window(session: Session, args: argparse.Namespace) -> bool:
     return True
 
 
-def sorted_sessions(
-    sessions: Iterable[Session], oldest: bool
-) -> list[Session]:
-    return sorted(
-        sessions,
-        key=lambda s: (s.repo_score, date_key(s.sort_time), s.title, s.id),
-        reverse=not oldest,
-    )
+def sorted_sessions(sessions: Iterable[Session], oldest: bool) -> list[Session]:
+    # Two-pass stable sort: date first (direction from oldest), then repo_score
+    # descending. This keeps high-relevance sessions at the top regardless of
+    # whether --oldest is set.
+    lst = list(sessions)
+    lst.sort(key=lambda s: (date_key(s.sort_time), s.title, s.id), reverse=not oldest)
+    lst.sort(key=lambda s: s.repo_score, reverse=True)
+    return lst
 
 
 def matches_term(session: Session, term: str) -> bool:
@@ -180,9 +177,7 @@ def session_to_json(session: Session) -> dict[str, Any]:
     }
 
 
-def print_sessions(
-    sessions: list[Session], limit: int, json_output: bool
-) -> None:
+def print_sessions(sessions: list[Session], limit: int, json_output: bool) -> None:
     shown = sessions if limit <= 0 else sessions[:limit]
     if json_output:
         print(json.dumps([session_to_json(s) for s in shown], indent=2))

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/__init__.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/__init__.py
@@ -1,0 +1,70 @@
+"""Reader dispatcher: auto-detect installed agents and aggregate sessions."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from typing import TYPE_CHECKING
+
+from session_search.core import Session, warn
+
+if TYPE_CHECKING:
+    pass
+
+# Lazy imports to avoid import errors when an agent's deps are missing.
+# Each reader module exports: AGENT_NAME, detect, iter_sessions,
+# iter_search_text, display_text
+
+
+def _load_readers() -> list:
+    from session_search.readers import amp, claude, codex, gemini, goose
+
+    return [codex, claude, gemini, goose, amp]
+
+
+def iter_all_sessions(args: argparse.Namespace) -> list[Session]:
+    requested = getattr(args, "agent", None)
+    sessions: list[Session] = []
+    for reader in _load_readers():
+        if requested and reader.AGENT_NAME != requested:
+            continue
+        if not reader.detect():
+            if requested:
+                warn(
+                    f"{reader.AGENT_NAME}: data directory not found — "
+                    "no sessions available"
+                )
+            continue
+        try:
+            sessions.extend(reader.iter_sessions(args))
+        except Exception as exc:
+            warn(f"skipping {reader.AGENT_NAME}: {exc}")
+    return sessions
+
+
+def search_sessions(
+    sessions: list[Session],
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+) -> int:
+    """Grep across session files/records. Returns match count."""
+    from session_search.readers import amp, claude, codex, gemini, goose
+
+    reader_map = {
+        r.AGENT_NAME: r for r in [codex, claude, gemini, goose, amp]
+    }
+    matches = 0
+    for session in sessions:
+        reader = reader_map.get(session.agent)
+        if reader is None:
+            continue
+        try:
+            count = reader.search_session(session, pattern, args)
+        except Exception as exc:
+            warn(f"error searching {session.agent} session {session.id}: {exc}")
+            continue
+        matches += count
+        if args.max_matches > 0 and matches >= args.max_matches:
+            break
+    return matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/__init__.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
-from typing import TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Any
 
 from session_search.core import Session, warn
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 # iter_search_text, display_text
 
 
-def _load_readers() -> list:
+def _load_readers() -> list[Any]:
     from session_search.readers import amp, claude, codex, gemini, goose
 
     return [codex, claude, gemini, goose, amp]
@@ -51,20 +51,27 @@ def search_sessions(
     """Grep across session files/records. Returns match count."""
     from session_search.readers import amp, claude, codex, gemini, goose
 
-    reader_map = {
-        r.AGENT_NAME: r for r in [codex, claude, gemini, goose, amp]
-    }
-    matches = 0
+    reader_map = {r.AGENT_NAME: r for r in [codex, claude, gemini, goose, amp]}
+    total_matches = 0
     for session in sessions:
         reader = reader_map.get(session.agent)
         if reader is None:
             continue
         try:
-            count = reader.search_session(session, pattern, args)
+            if args.max_matches > 0:
+                remaining = args.max_matches - total_matches
+                if remaining <= 0:
+                    break
+                session_args_dict = dict(vars(args))
+                session_args_dict["max_matches"] = remaining
+                session_args = argparse.Namespace(**session_args_dict)
+            else:
+                session_args = args
+            count = reader.search_session(session, pattern, session_args)
         except Exception as exc:
             warn(f"error searching {session.agent} session {session.id}: {exc}")
             continue
-        matches += count
-        if args.max_matches > 0 and matches >= args.max_matches:
+        total_matches += count
+        if args.max_matches > 0 and total_matches >= args.max_matches:
             break
-    return matches
+    return total_matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
@@ -1,0 +1,263 @@
+"""Amp (Sourcegraph) session reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from session_search.core import (
+    Session,
+    in_date_window,
+    repo_context,
+    repo_score,
+    truncate,
+    warn,
+)
+
+AGENT_NAME: str = "amp"
+
+_AMP_THREADS = Path("~/.local/share/amp/threads")
+_FORMAT_VERSION_MAX = 100
+
+
+def detect() -> bool:
+    return _AMP_THREADS.expanduser().is_dir()
+
+
+def _epoch_ms_to_iso(epoch_ms: Any) -> str:
+    if not isinstance(epoch_ms, (int, float)):
+        return ""
+    try:
+        dt = datetime.fromtimestamp(epoch_ms / 1000.0, tz=timezone.utc)
+        return dt.isoformat()
+    except (OSError, OverflowError, ValueError):
+        return ""
+
+
+def _extract_cwd(data: dict[str, Any]) -> str:
+    try:
+        env = data.get("env")
+        if not isinstance(env, dict):
+            return ""
+        initial = env.get("initial")
+        if isinstance(initial, str):
+            parsed = json.loads(initial)
+        elif isinstance(initial, dict):
+            parsed = initial
+        else:
+            return ""
+        trees = parsed.get("trees")
+        if not isinstance(trees, list) or not trees:
+            return ""
+        uri = trees[0].get("uri") if isinstance(trees[0], dict) else None
+        if not isinstance(uri, str) or not uri:
+            return ""
+        if uri.startswith("file://"):
+            return uri[len("file://"):]
+        return uri
+    except (json.JSONDecodeError, AttributeError, TypeError, KeyError):
+        return ""
+
+
+def iter_sessions(args: argparse.Namespace) -> list[Session]:
+    threads_dir = _AMP_THREADS.expanduser()
+
+    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_root = ""
+    repo_name = getattr(args, "repo", None) or ""
+    if current_cwd:
+        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+
+    sessions: list[Session] = []
+
+    for path in threads_dir.glob("T-*.json"):
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            warn(f"cannot read {path}: {exc}")
+            continue
+
+        if not isinstance(data, dict):
+            continue
+
+        fmt_version = data.get("v")
+        if isinstance(fmt_version, int) and fmt_version > _FORMAT_VERSION_MAX:
+            warn(f"{path.name}: format version {fmt_version} exceeds known max {_FORMAT_VERSION_MAX}; format may have changed")
+
+        session_id = str(data.get("id") or path.stem)
+        created_ms = data.get("created")
+        timestamp = _epoch_ms_to_iso(created_ms)
+
+        title = data.get("title") or ""
+        if not isinstance(title, str):
+            title = ""
+
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            messages = []
+
+        updated_at = ""
+        if messages:
+            last_msg = messages[-1]
+            if isinstance(last_msg, dict):
+                meta = last_msg.get("meta")
+                if isinstance(meta, dict):
+                    sent_at = meta.get("sentAt")
+                    updated_at = _epoch_ms_to_iso(sent_at)
+        if not updated_at:
+            updated_at = timestamp
+
+        cwd = _extract_cwd(data)
+
+        score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
+        if not getattr(args, "all_repos", False) and current_cwd and score == 0:
+            continue
+
+        session = Session(
+            id=session_id,
+            agent=AGENT_NAME,
+            path=path,
+            timestamp=timestamp,
+            updated_at=updated_at,
+            title=title,
+            cwd=cwd,
+            repo_score=score,
+            repo_reason=reason,
+        )
+        if not in_date_window(session, args):
+            continue
+        sessions.append(session)
+
+    return sessions
+
+
+def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
+    content = record.get("content")
+    if not isinstance(content, list):
+        return
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+
+        if block_type == "text":
+            text = str(block.get("text") or "")
+            if text:
+                yield text
+
+        elif block_type == "tool_use":
+            name = str(block.get("name") or "")
+            if name:
+                yield name
+            inp = block.get("input")
+            if inp is not None:
+                try:
+                    yield json.dumps(inp, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    pass
+
+        elif block_type == "tool_result":
+            result_content = block.get("content")
+            if isinstance(result_content, list):
+                for item in result_content:
+                    if isinstance(item, dict):
+                        text = str(item.get("text") or "")
+                        if text:
+                            yield text
+
+        elif block_type == "thinking":
+            thinking = str(block.get("thinking") or "")
+            if thinking:
+                yield thinking
+
+
+def display_text(record: dict[str, Any], raw: str) -> str:
+    role = str(record.get("role") or "")
+    content = record.get("content")
+    if not isinstance(content, list):
+        return json.dumps({"role": role}, ensure_ascii=False)
+
+    parts: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+
+        if block_type == "text":
+            text = str(block.get("text") or "")
+            parts.append({"role": role, "text": text})
+
+        elif block_type == "tool_use":
+            name = str(block.get("name") or "")
+            inp = block.get("input")
+            parts.append({"role": role, "tool": name, "input": inp})
+
+        elif block_type == "tool_result":
+            result_content = block.get("content")
+            texts: list[str] = []
+            if isinstance(result_content, list):
+                for item in result_content:
+                    if isinstance(item, dict):
+                        t = str(item.get("text") or "")
+                        if t:
+                            texts.append(t)
+            parts.append({"role": role, "tool_result": "\n".join(texts)})
+
+    if not parts:
+        return json.dumps({"role": role}, ensure_ascii=False)
+    if len(parts) == 1:
+        return json.dumps(parts[0], ensure_ascii=False)
+    return json.dumps(parts, ensure_ascii=False)
+
+
+def search_session(
+    session: Session, pattern: re.Pattern[str], args: argparse.Namespace
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    width = getattr(args, "width", 280)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        warn(f"cannot read {session.path}: {exc}")
+        return 0
+
+    if not isinstance(data, dict):
+        return 0
+
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return 0
+
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            continue
+
+        searchable_parts = list(iter_search_text(msg, ""))
+        combined = "\n".join(searchable_parts)
+        if not combined or not pattern.search(combined):
+            continue
+
+        if not header_printed:
+            label = f" [{session.repo_reason}]" if session.repo_reason else ""
+            title_part = f" - {session.title}" if session.title else ""
+            print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+            print(f"    {session.path}")
+            header_printed = True
+
+        rendered = display_text(msg, "")
+        print(f"[msg {idx}] {truncate(rendered, width)}")
+        matches += 1
+        if max_matches > 0 and matches >= max_matches:
+            return matches
+
+    return matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
+
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from session_search.core import (
     Session,
@@ -57,7 +59,7 @@ def _extract_cwd(data: dict[str, Any]) -> str:
         if not isinstance(uri, str) or not uri:
             return ""
         if uri.startswith("file://"):
-            return uri[len("file://"):]
+            return uri[len("file://") :]
         return uri
     except (json.JSONDecodeError, AttributeError, TypeError, KeyError):
         return ""
@@ -66,7 +68,9 @@ def _extract_cwd(data: dict[str, Any]) -> str:
 def iter_sessions(args: argparse.Namespace) -> list[Session]:
     threads_dir = _AMP_THREADS.expanduser()
 
-    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_cwd = (
+        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    )
     current_root = ""
     repo_name = getattr(args, "repo", None) or ""
     if current_cwd:
@@ -87,7 +91,9 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
 
         fmt_version = data.get("v")
         if isinstance(fmt_version, int) and fmt_version > _FORMAT_VERSION_MAX:
-            warn(f"{path.name}: format version {fmt_version} exceeds known max {_FORMAT_VERSION_MAX}; format may have changed")
+            warn(
+                f"{path.name}: format version {fmt_version} exceeds known max {_FORMAT_VERSION_MAX}; format may have changed"
+            )
 
         session_id = str(data.get("id") or path.stem)
         created_ms = data.get("created")
@@ -115,8 +121,6 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
         cwd = _extract_cwd(data)
 
         score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
-        if not getattr(args, "all_repos", False) and current_cwd and score == 0:
-            continue
 
         session = Session(
             id=session_id,

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/claude.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/claude.py
@@ -1,0 +1,328 @@
+"""Claude Code (Anthropic) session reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from session_search.core import (
+    Session,
+    in_date_window,
+    repo_context,
+    repo_score,
+    truncate,
+    warn,
+)
+
+AGENT_NAME: str = "claude"
+
+_DEFAULT_PASS2_LIMIT = 50
+
+
+def _config_dir() -> Path:
+    env = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path("~/.claude").expanduser()
+
+
+def detect() -> bool:
+    return (_config_dir() / "projects").is_dir()
+
+
+def _projects_dir() -> Path:
+    return _config_dir() / "projects"
+
+
+def _dir_contains_repo(dir_name: str, repo_name: str) -> bool:
+    return repo_name.lower() in dir_name.lower()
+
+
+def _parse_tail_records(tail_bytes: bytes) -> dict:
+    text = tail_bytes.decode("utf-8", errors="replace")
+    result: dict = {}
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        rtype = record.get("type")
+        if rtype == "custom-title" and "customTitle" not in result:
+            title = record.get("customTitle") or record.get("title")
+            if title:
+                result["customTitle"] = title
+        elif rtype == "ai-title" and "aiTitle" not in result:
+            title = record.get("aiTitle") or record.get("title")
+            if title:
+                result["aiTitle"] = title
+    return result
+
+
+def _read_head_record(path: Path) -> dict:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                rtype = record.get("type")
+                if rtype in ("user", "assistant") and record.get("cwd"):
+                    return record
+    except OSError:
+        pass
+    return {}
+
+
+def iter_sessions(args: argparse.Namespace) -> list[Session]:
+    projects = _projects_dir()
+    requested_agent = getattr(args, "agent", None)
+    if requested_agent and requested_agent != AGENT_NAME:
+        return []
+
+    current_cwd_text = os.getcwd()
+    current_cwd, current_root, repo_name = repo_context(
+        current_cwd_text, getattr(args, "repo", None)
+    )
+
+    # Pass 1: stat-only scan
+    candidates: list[tuple[int, float, Path, str]] = []  # (hint_score, mtime, path, dir_name)
+    try:
+        project_entries = list(projects.iterdir())
+    except OSError as exc:
+        warn(f"cannot read {projects}: {exc}")
+        return []
+
+    for project_dir in project_entries:
+        if not project_dir.is_dir():
+            continue
+        dir_name = project_dir.name
+        hint = 1 if (repo_name and _dir_contains_repo(dir_name, repo_name)) else 0
+        try:
+            jsonl_entries = list(project_dir.iterdir())
+        except OSError:
+            continue
+        for entry in jsonl_entries:
+            if not entry.is_file() or not entry.name.endswith(".jsonl"):
+                continue
+            try:
+                st = os.stat(entry)
+            except OSError:
+                continue
+            candidates.append((hint, st.st_mtime, entry, dir_name))
+
+    candidates.sort(key=lambda x: (x[0], x[1]), reverse=True)
+
+    # Build preliminary Session objects with mtime-derived timestamps
+    preliminary: list[Session] = []
+    for hint_score, mtime, path, dir_name in candidates:
+        session_id = path.stem
+        updated_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+        session = Session(
+            id=session_id,
+            agent=AGENT_NAME,
+            path=path,
+            timestamp=updated_at,
+            updated_at=updated_at,
+            title="",
+            cwd="",
+            repo_score=hint_score,
+            repo_reason="repo-name-in-path" if hint_score else "",
+        )
+        preliminary.append(session)
+
+    # Date filtering on preliminary sessions before Pass 2
+    after_date = [s for s in preliminary if in_date_window(s, args)]
+
+    limit = getattr(args, "limit", 0)
+    pass2_count = max(limit, _DEFAULT_PASS2_LIMIT) if limit and limit > 0 else max(len(after_date), _DEFAULT_PASS2_LIMIT)
+
+    refined: list[Session] = []
+    for i, session in enumerate(after_date):
+        if i < pass2_count:
+            head = _read_head_record(session.path)
+            try:
+                size = os.path.getsize(session.path)
+                with open(session.path, "rb") as fh:
+                    fh.seek(max(0, size - 2048))
+                    tail_bytes = fh.read()
+            except OSError:
+                tail_bytes = b""
+
+            tail_data = _parse_tail_records(tail_bytes)
+            session_cwd = head.get("cwd", "")
+            slug = head.get("slug", "")
+            timestamp = head.get("timestamp", session.timestamp)
+
+            title = (
+                tail_data.get("customTitle")
+                or tail_data.get("aiTitle")
+                or slug
+                or ""
+            )
+
+            if session_cwd:
+                score, reason = repo_score(
+                    session_cwd, current_cwd, current_root, repo_name
+                )
+            else:
+                score, reason = session.repo_score, session.repo_reason
+
+            refined.append(
+                Session(
+                    id=session.id,
+                    agent=AGENT_NAME,
+                    path=session.path,
+                    timestamp=timestamp,
+                    updated_at=session.updated_at,
+                    title=title,
+                    cwd=session_cwd,
+                    repo_score=score,
+                    repo_reason=reason,
+                )
+            )
+        else:
+            refined.append(session)
+
+    return refined
+
+
+def iter_search_text(record: dict, raw: str) -> Iterable[str]:
+    rtype = record.get("type")
+
+    if rtype == "user":
+        content = record.get("message", {}).get("content")
+        if isinstance(content, str):
+            yield content
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    if text:
+                        yield text
+                elif isinstance(block, dict) and block.get("type") == "tool_result":
+                    inner = block.get("content", [])
+                    if isinstance(inner, list):
+                        for inner_block in inner:
+                            if isinstance(inner_block, dict) and inner_block.get("type") == "text":
+                                t = inner_block.get("text", "")
+                                if t:
+                                    yield t
+
+    elif rtype == "assistant":
+        content = record.get("message", {}).get("content")
+        if isinstance(content, str):
+            yield content
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    text = block.get("text", "")
+                    if text:
+                        yield text
+                elif btype == "tool_use":
+                    name = block.get("name", "")
+                    inp = block.get("input", {})
+                    yield f"{name} {json.dumps(inp)}"
+
+    elif rtype == "summary":
+        text = record.get("summary", "")
+        if text:
+            yield text
+
+
+def display_text(record: dict, raw: str) -> str:
+    rtype = record.get("type")
+
+    if rtype == "user":
+        parts = list(iter_search_text(record, raw))
+        text = " ".join(parts)
+        return json.dumps({"role": "user", "text": text})
+
+    elif rtype == "assistant":
+        content = record.get("message", {}).get("content")
+        blocks = content if isinstance(content, list) else []
+        rendered: list[str] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                text = block.get("text", "")
+                if text:
+                    rendered.append(json.dumps({"role": "assistant", "text": text}))
+            elif btype == "tool_use":
+                name = block.get("name", "")
+                inp = block.get("input", {})
+                rendered.append(
+                    json.dumps({"role": "assistant", "tool": name, "input": inp})
+                )
+        if not rendered and isinstance(content, str) and content:
+            return json.dumps({"role": "assistant", "text": content})
+        return "\n".join(rendered) if rendered else raw.strip()
+
+    elif rtype == "summary":
+        text = record.get("summary", "")
+        return json.dumps({"summary": text})
+
+    return raw.strip()
+
+
+def search_session(
+    session: Session, pattern: re.Pattern, args: argparse.Namespace
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    width = getattr(args, "width", 280)
+
+    match_count = 0
+    header_printed = False
+
+    try:
+        fh = open(session.path, encoding="utf-8", errors="replace")
+    except OSError as exc:
+        warn(f"cannot open {session.path}: {exc}")
+        return 0
+
+    with fh:
+        for raw in fh:
+            raw_stripped = raw.strip()
+            if not raw_stripped:
+                continue
+            try:
+                record = json.loads(raw_stripped)
+            except json.JSONDecodeError:
+                continue
+
+            searchable = " ".join(iter_search_text(record, raw_stripped))
+            if not pattern.search(searchable):
+                continue
+
+            if not header_printed:
+                agent_tag = f"[{AGENT_NAME}]"
+                title_part = f" - {session.title}" if session.title else ""
+                cwd_part = session.cwd or "(unknown)"
+                print(f"\n=== {agent_tag} {session.id}{title_part}")
+                print(f"    cwd: {cwd_part}")
+                header_printed = True
+
+            rendered = display_text(record, raw_stripped)
+            print(truncate(rendered, width))
+
+            match_count += 1
+            if max_matches > 0 and match_count >= max_matches:
+                break
+
+    return match_count

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/claude.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/claude.py
@@ -6,9 +6,11 @@ import argparse
 import json
 import os
 import re
+
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Any
 
 from session_search.core import (
     Session,
@@ -43,9 +45,9 @@ def _dir_contains_repo(dir_name: str, repo_name: str) -> bool:
     return repo_name.lower() in dir_name.lower()
 
 
-def _parse_tail_records(tail_bytes: bytes) -> dict:
+def _parse_tail_records(tail_bytes: bytes) -> dict[str, Any]:
     text = tail_bytes.decode("utf-8", errors="replace")
-    result: dict = {}
+    result: dict[str, Any] = {}
     for line in text.split("\n"):
         line = line.strip()
         if not line:
@@ -66,7 +68,7 @@ def _parse_tail_records(tail_bytes: bytes) -> dict:
     return result
 
 
-def _read_head_record(path: Path) -> dict:
+def _read_head_record(path: Path) -> dict[str, Any]:
     try:
         with open(path, encoding="utf-8", errors="replace") as fh:
             for raw in fh:
@@ -74,8 +76,10 @@ def _read_head_record(path: Path) -> dict:
                 if not raw:
                     continue
                 try:
-                    record = json.loads(raw)
-                except json.JSONDecodeError:
+                    record: dict[str, Any] = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(record, dict):
                     continue
                 rtype = record.get("type")
                 if rtype in ("user", "assistant") and record.get("cwd"):
@@ -91,13 +95,15 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     if requested_agent and requested_agent != AGENT_NAME:
         return []
 
-    current_cwd_text = os.getcwd()
+    current_cwd_text = getattr(args, "cwd", None) or os.getcwd()
     current_cwd, current_root, repo_name = repo_context(
         current_cwd_text, getattr(args, "repo", None)
     )
 
     # Pass 1: stat-only scan
-    candidates: list[tuple[int, float, Path, str]] = []  # (hint_score, mtime, path, dir_name)
+    candidates: list[
+        tuple[int, float, Path, str]
+    ] = []  # (hint_score, mtime, path, dir_name)
     try:
         project_entries = list(projects.iterdir())
     except OSError as exc:
@@ -126,7 +132,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
 
     # Build preliminary Session objects with mtime-derived timestamps
     preliminary: list[Session] = []
-    for hint_score, mtime, path, dir_name in candidates:
+    for hint_score, mtime, path, _ in candidates:
         session_id = path.stem
         updated_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
         session = Session(
@@ -145,8 +151,12 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     # Date filtering on preliminary sessions before Pass 2
     after_date = [s for s in preliminary if in_date_window(s, args)]
 
-    limit = getattr(args, "limit", 0)
-    pass2_count = max(limit, _DEFAULT_PASS2_LIMIT) if limit and limit > 0 else max(len(after_date), _DEFAULT_PASS2_LIMIT)
+    limit = getattr(args, "limit", 0) or getattr(args, "limit_sessions", 0)
+    pass2_count = (
+        max(limit, _DEFAULT_PASS2_LIMIT)
+        if limit > 0
+        else max(len(after_date), _DEFAULT_PASS2_LIMIT)
+    )
 
     refined: list[Session] = []
     for i, session in enumerate(after_date):
@@ -166,10 +176,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
             timestamp = head.get("timestamp", session.timestamp)
 
             title = (
-                tail_data.get("customTitle")
-                or tail_data.get("aiTitle")
-                or slug
-                or ""
+                tail_data.get("customTitle") or tail_data.get("aiTitle") or slug or ""
             )
 
             if session_cwd:
@@ -198,7 +205,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     return refined
 
 
-def iter_search_text(record: dict, raw: str) -> Iterable[str]:
+def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
     rtype = record.get("type")
 
     if rtype == "user":
@@ -215,7 +222,10 @@ def iter_search_text(record: dict, raw: str) -> Iterable[str]:
                     inner = block.get("content", [])
                     if isinstance(inner, list):
                         for inner_block in inner:
-                            if isinstance(inner_block, dict) and inner_block.get("type") == "text":
+                            if (
+                                isinstance(inner_block, dict)
+                                and inner_block.get("type") == "text"
+                            ):
                                 t = inner_block.get("text", "")
                                 if t:
                                     yield t
@@ -244,7 +254,7 @@ def iter_search_text(record: dict, raw: str) -> Iterable[str]:
             yield text
 
 
-def display_text(record: dict, raw: str) -> str:
+def display_text(record: dict[str, Any], raw: str) -> str:
     rtype = record.get("type")
 
     if rtype == "user":
@@ -282,7 +292,7 @@ def display_text(record: dict, raw: str) -> str:
 
 
 def search_session(
-    session: Session, pattern: re.Pattern, args: argparse.Namespace
+    session: Session, pattern: re.Pattern[str], args: argparse.Namespace
 ) -> int:
     max_matches = getattr(args, "max_matches", 0)
     width = getattr(args, "width", 280)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
@@ -1,0 +1,296 @@
+"""Codex CLI session reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Any, Iterable
+
+from session_search.core import (
+    Session,
+    date_key,
+    in_date_window,
+    repo_context,
+    repo_score,
+    truncate,
+    warn,
+)
+
+AGENT_NAME: str = "codex"
+
+SESSION_RE = re.compile(
+    r"rollout-(?P<stamp>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})-(?P<id>[0-9a-fA-F-]+)\.jsonl$"
+)
+
+
+def _codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+
+
+def detect() -> bool:
+    home = _codex_home()
+    return (home / "sessions").exists() or (home / "archived_sessions").exists()
+
+
+def _read_index(index_path: Path) -> dict[str, dict[str, str]]:
+    by_id: dict[str, dict[str, str]] = {}
+    if not index_path.exists():
+        return by_id
+    with index_path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            session_id = str(item.get("id") or "")
+            if session_id:
+                by_id[session_id] = {
+                    "thread_name": str(item.get("thread_name") or ""),
+                    "updated_at": str(item.get("updated_at") or ""),
+                }
+    return by_id
+
+
+def _fallback_id_and_timestamp(path: Path) -> tuple[str, str]:
+    match = SESSION_RE.search(path.name)
+    if not match:
+        return "", ""
+    session_id = match.group("id")
+    stamp = match.group("stamp")
+    date_part, time_part = stamp.split("T", 1)
+    timestamp = f"{date_part}T{time_part.replace('-', ':')}Z"
+    return session_id, timestamp
+
+
+def _session_meta(path: Path) -> dict[str, str]:
+    fallback_id, fallback_timestamp = _fallback_id_and_timestamp(path)
+    meta: dict[str, str] = {
+        "id": fallback_id,
+        "timestamp": fallback_timestamp,
+        "cwd": "",
+        "agent_role": "",
+        "agent_nickname": "",
+    }
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for _ in range(40):
+                line = fh.readline()
+                if not line:
+                    break
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if item.get("type") != "session_meta":
+                    continue
+                payload = item.get("payload") or {}
+                meta["id"] = str(payload.get("id") or meta["id"])
+                meta["timestamp"] = str(
+                    payload.get("timestamp") or item.get("timestamp") or meta["timestamp"]
+                )
+                meta["cwd"] = str(payload.get("cwd") or "")
+                meta["agent_role"] = str(payload.get("agent_role") or "")
+                meta["agent_nickname"] = str(payload.get("agent_nickname") or "")
+                break
+    except OSError:
+        pass
+    return meta
+
+
+def iter_sessions(args: argparse.Namespace) -> list[Session]:
+    home = _codex_home()
+    index = _read_index(home / "session_index.jsonl")
+
+    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_root = ""
+    repo_name = getattr(args, "repo", None) or ""
+    if current_cwd:
+        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+
+    dirs: list[Path] = []
+    if (home / "sessions").exists():
+        dirs.append(home / "sessions")
+    if (home / "archived_sessions").exists():
+        dirs.append(home / "archived_sessions")
+
+    sessions: list[Session] = []
+    all_repos = getattr(args, "all_repos", False)
+    for sessions_dir in dirs:
+        for path in sessions_dir.rglob("*.jsonl"):
+            if not SESSION_RE.search(path.name):
+                continue
+            meta = _session_meta(path)
+            session_id = meta["id"]
+            idx_entry = index.get(session_id, {})
+            title = idx_entry.get("thread_name", "")
+            updated_at = idx_entry.get("updated_at", "")
+            timestamp = meta["timestamp"]
+            cwd = meta["cwd"]
+
+            score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
+            if all_repos:
+                score, reason = 0, ""
+
+            session = Session(
+                id=session_id,
+                agent=AGENT_NAME,
+                path=path,
+                timestamp=timestamp,
+                updated_at=updated_at,
+                title=title,
+                cwd=cwd,
+                repo_score=score,
+                repo_reason=reason,
+            )
+            if not in_date_window(session, args):
+                continue
+            sessions.append(session)
+
+    return sessions
+
+
+def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
+    payload = record.get("payload") or {}
+    record_type = record.get("type")
+
+    if record_type == "session_meta":
+        for key in ("id", "cwd", "agent_role", "agent_nickname"):
+            val = str(payload.get(key) or "")
+            if val:
+                yield val
+
+    elif record_type == "turn_context":
+        for key in ("cwd", "summary"):
+            val = str(payload.get(key) or "")
+            if val:
+                yield val
+
+    elif record_type == "response_item":
+        content = payload.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    text = str(part.get("text") or "")
+                    if text:
+                        yield text
+        for key in ("name", "arguments", "output"):
+            val = str(payload.get(key) or "")
+            if val:
+                yield val
+
+    elif record_type == "event_msg":
+        event_payload = payload
+        command = event_payload.get("command")
+        if isinstance(command, list):
+            yield " ".join(shlex.quote(str(p)) for p in command)
+        elif command:
+            yield str(command)
+        for key in ("aggregated_output", "stdout", "stderr"):
+            val = str(event_payload.get(key) or "")
+            if val:
+                yield val
+        msg = str(event_payload.get("message") or "")
+        if msg:
+            yield msg
+        text = str(event_payload.get("text") or "")
+        if text:
+            yield text
+
+    elif record_type == "compacted":
+        summary = str(payload.get("summary") or "")
+        if summary:
+            yield summary
+
+
+def display_text(record: dict[str, Any], raw: str) -> str:
+    payload = record.get("payload") or {}
+    record_type = record.get("type")
+
+    if record_type == "session_meta":
+        keep = {k: payload.get(k) for k in ("id", "timestamp", "cwd", "originator", "agent_role", "agent_nickname")}
+        return json.dumps(keep, ensure_ascii=False)
+
+    if record_type == "turn_context":
+        keep = {k: payload.get(k) for k in ("cwd", "turn_id", "current_date", "timezone", "summary")}
+        return json.dumps(keep, ensure_ascii=False)
+
+    if record_type == "event_msg":
+        event_type = payload.get("type")
+        if event_type == "exec_command_end":
+            command = payload.get("command")
+            if isinstance(command, list):
+                command_text = " ".join(shlex.quote(str(part)) for part in command)
+            else:
+                command_text = str(command or "")
+            keep = {
+                "event": event_type,
+                "cwd": payload.get("cwd"),
+                "command": command_text,
+                "output": (
+                    payload.get("aggregated_output")
+                    or payload.get("stdout")
+                    or payload.get("stderr")
+                ),
+            }
+            return json.dumps(keep, ensure_ascii=False)
+        keep = {
+            "event": event_type,
+            "message": payload.get("message"),
+            "thread_name": payload.get("thread_name"),
+            "text": payload.get("text"),
+        }
+        return json.dumps({k: v for k, v in keep.items() if v}, ensure_ascii=False)
+
+    if record_type == "response_item":
+        role = payload.get("role")
+        content = payload.get("content")
+        if isinstance(content, list):
+            texts = [str(part.get("text") or "") for part in content if isinstance(part, dict)]
+            if any(texts):
+                return json.dumps({"role": role, "text": "\n".join(texts)}, ensure_ascii=False)
+        keep = {k: payload.get(k) for k in ("type", "role", "name", "arguments", "output")}
+        return json.dumps({k: v for k, v in keep.items() if v}, ensure_ascii=False)
+
+    return raw
+
+
+def search_session(
+    session: Session, pattern: re.Pattern[str], args: argparse.Namespace
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw = raw_line.rstrip("\n")
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    record = {}
+
+                for text in iter_search_text(record, raw):
+                    if not pattern.search(text):
+                        continue
+                    if not header_printed:
+                        label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                        title_part = f" - {session.title}" if session.title else ""
+                        print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                        print(f"    {session.path}")
+                        header_printed = True
+                    rendered = display_text(record, raw)
+                    print(truncate(rendered))
+                    matches += 1
+                    if max_matches > 0 and matches >= max_matches:
+                        return matches
+                    break
+
+    except OSError as exc:
+        warn(f"cannot read {session.path}: {exc}")
+
+    return matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
@@ -7,12 +7,13 @@ import json
 import os
 import re
 import shlex
+
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from session_search.core import (
     Session,
-    date_key,
     in_date_window,
     repo_context,
     repo_score,
@@ -90,7 +91,9 @@ def _session_meta(path: Path) -> dict[str, str]:
                 payload = item.get("payload") or {}
                 meta["id"] = str(payload.get("id") or meta["id"])
                 meta["timestamp"] = str(
-                    payload.get("timestamp") or item.get("timestamp") or meta["timestamp"]
+                    payload.get("timestamp")
+                    or item.get("timestamp")
+                    or meta["timestamp"]
                 )
                 meta["cwd"] = str(payload.get("cwd") or "")
                 meta["agent_role"] = str(payload.get("agent_role") or "")
@@ -105,7 +108,9 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     home = _codex_home()
     index = _read_index(home / "session_index.jsonl")
 
-    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_cwd = (
+        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    )
     current_root = ""
     repo_name = getattr(args, "repo", None) or ""
     if current_cwd:
@@ -211,11 +216,24 @@ def display_text(record: dict[str, Any], raw: str) -> str:
     record_type = record.get("type")
 
     if record_type == "session_meta":
-        keep = {k: payload.get(k) for k in ("id", "timestamp", "cwd", "originator", "agent_role", "agent_nickname")}
+        keep = {
+            k: payload.get(k)
+            for k in (
+                "id",
+                "timestamp",
+                "cwd",
+                "originator",
+                "agent_role",
+                "agent_nickname",
+            )
+        }
         return json.dumps(keep, ensure_ascii=False)
 
     if record_type == "turn_context":
-        keep = {k: payload.get(k) for k in ("cwd", "turn_id", "current_date", "timezone", "summary")}
+        keep = {
+            k: payload.get(k)
+            for k in ("cwd", "turn_id", "current_date", "timezone", "summary")
+        }
         return json.dumps(keep, ensure_ascii=False)
 
     if record_type == "event_msg":
@@ -249,10 +267,18 @@ def display_text(record: dict[str, Any], raw: str) -> str:
         role = payload.get("role")
         content = payload.get("content")
         if isinstance(content, list):
-            texts = [str(part.get("text") or "") for part in content if isinstance(part, dict)]
+            texts = [
+                str(part.get("text") or "")
+                for part in content
+                if isinstance(part, dict)
+            ]
             if any(texts):
-                return json.dumps({"role": role, "text": "\n".join(texts)}, ensure_ascii=False)
-        keep = {k: payload.get(k) for k in ("type", "role", "name", "arguments", "output")}
+                return json.dumps(
+                    {"role": role, "text": "\n".join(texts)}, ensure_ascii=False
+                )
+        keep = {
+            k: payload.get(k) for k in ("type", "role", "name", "arguments", "output")
+        }
         return json.dumps({k: v for k, v in keep.items() if v}, ensure_ascii=False)
 
     return raw
@@ -278,9 +304,13 @@ def search_session(
                     if not pattern.search(text):
                         continue
                     if not header_printed:
-                        label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                        label = (
+                            f" [{session.repo_reason}]" if session.repo_reason else ""
+                        )
                         title_part = f" - {session.title}" if session.title else ""
-                        print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                        print(
+                            f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ==="
+                        )
                         print(f"    {session.path}")
                         header_printed = True
                     rendered = display_text(record, raw)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
@@ -1,0 +1,321 @@
+"""Google Gemini CLI session reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+from session_search.core import (
+    Session,
+    in_date_window,
+    repo_context,
+    repo_score,
+    truncate,
+    warn,
+)
+
+AGENT_NAME: str = "gemini"
+
+
+def _gemini_tmp() -> Path:
+    return Path("~/.gemini/tmp").expanduser()
+
+
+def _projects_json() -> Path:
+    return Path("~/.gemini/projects.json").expanduser()
+
+
+def detect() -> bool:
+    return _gemini_tmp().exists()
+
+
+def _load_slug_map() -> dict[str, str]:
+    projects_path = _projects_json()
+    if not projects_path.exists():
+        return {}
+    try:
+        with projects_path.open("r", encoding="utf-8", errors="replace") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    projects = data.get("projects") if isinstance(data, dict) else None
+    if not isinstance(projects, dict):
+        return {}
+    return {v: k for k, v in projects.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def _extract_text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = str(part.get("text") or "")
+                if text:
+                    parts.append(text)
+            elif isinstance(part, str):
+                parts.append(part)
+        return "\n".join(parts)
+    if isinstance(content, dict):
+        text = str(content.get("text") or "")
+        return text
+    return ""
+
+
+def _read_jsonl_meta(path: Path) -> dict[str, str]:
+    meta: dict[str, str] = {"session_id": "", "start_time": "", "last_updated": ""}
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            first_line = fh.readline()
+    except OSError:
+        return meta
+    if not first_line.strip():
+        return meta
+    try:
+        record = json.loads(first_line)
+    except json.JSONDecodeError:
+        return meta
+    if not isinstance(record, dict):
+        return meta
+    meta["session_id"] = str(record.get("sessionId") or record.get("session_id") or "")
+    meta["start_time"] = str(record.get("startTime") or record.get("start_time") or "")
+    meta["last_updated"] = str(record.get("lastUpdated") or record.get("last_updated") or "")
+    return meta
+
+
+def iter_sessions(args: argparse.Namespace) -> list[Session]:
+    tmp_dir = _gemini_tmp()
+    slug_map = _load_slug_map()
+
+    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_root = ""
+    repo_name = getattr(args, "repo", None) or ""
+    if current_cwd:
+        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+
+    sessions: list[Session] = []
+
+    for slug_dir in tmp_dir.iterdir():
+        if not slug_dir.is_dir():
+            continue
+        slug = slug_dir.name
+        cwd = slug_map.get(slug, "")
+
+        chats_dir = slug_dir / "chats"
+        if not chats_dir.is_dir():
+            continue
+
+        for path in chats_dir.iterdir():
+            if not path.is_file():
+                continue
+            name = path.name
+
+            if name.startswith("session-") and name.endswith(".jsonl"):
+                meta = _read_jsonl_meta(path)
+                session_id = meta["session_id"] or path.stem
+                timestamp = meta["start_time"]
+                updated_at = meta["last_updated"]
+            elif name.startswith("session-") and name.endswith(".json"):
+                session_id = path.stem
+                try:
+                    mtime = path.stat().st_mtime
+                except OSError:
+                    mtime = 0.0
+                from datetime import datetime, timezone
+                dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
+                timestamp = dt.isoformat()
+                updated_at = ""
+            else:
+                continue
+
+            score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
+            if not getattr(args, "all_repos", False) and current_cwd and score == 0:
+                continue
+
+            session = Session(
+                id=session_id,
+                agent=AGENT_NAME,
+                path=path,
+                timestamp=timestamp,
+                updated_at=updated_at,
+                title=slug,
+                cwd=cwd,
+                repo_score=score,
+                repo_reason=reason,
+            )
+            if not in_date_window(session, args):
+                continue
+            sessions.append(session)
+
+    return sessions
+
+
+def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
+    record_type = record.get("type")
+
+    if record_type == "user":
+        text = _extract_text_from_content(record.get("content"))
+        if text:
+            yield text
+
+    elif record_type == "gemini":
+        text = _extract_text_from_content(record.get("content"))
+        if text:
+            yield text
+        for thought in record.get("thoughts") or []:
+            if isinstance(thought, dict):
+                t = str(thought.get("text") or "")
+                if t:
+                    yield t
+            elif isinstance(thought, str) and thought:
+                yield thought
+        for tool_call in record.get("toolCalls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            name = str(tool_call.get("name") or "")
+            if name:
+                yield name
+            args_val = tool_call.get("args")
+            if args_val is not None:
+                if isinstance(args_val, str) and args_val:
+                    yield args_val
+                elif isinstance(args_val, dict):
+                    try:
+                        yield json.dumps(args_val, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        pass
+
+
+def display_text(record: dict[str, Any], raw: str) -> str:
+    record_type = record.get("type")
+
+    if record_type == "user":
+        text = _extract_text_from_content(record.get("content"))
+        return json.dumps({"role": "user", "text": text}, ensure_ascii=False)
+
+    if record_type == "gemini":
+        text = _extract_text_from_content(record.get("content"))
+        tool_calls = record.get("toolCalls")
+        if tool_calls:
+            tool_info = [
+                {"name": tc.get("name"), "args": tc.get("args")}
+                for tc in tool_calls
+                if isinstance(tc, dict)
+            ]
+            return json.dumps(
+                {"role": "gemini", "text": text, "toolCalls": tool_info},
+                ensure_ascii=False,
+            )
+        return json.dumps({"role": "gemini", "text": text}, ensure_ascii=False)
+
+    return raw
+
+
+def _search_jsonl(
+    session: Session,
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw = raw_line.rstrip("\n")
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    record = {}
+
+                for text in iter_search_text(record, raw):
+                    if not pattern.search(text):
+                        continue
+                    if not header_printed:
+                        label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                        title_part = f" - {session.title}" if session.title else ""
+                        print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                        print(f"    {session.path}")
+                        header_printed = True
+                    rendered = display_text(record, raw)
+                    width = getattr(args, "width", 280)
+                    print(truncate(rendered, width))
+                    matches += 1
+                    if max_matches > 0 and matches >= max_matches:
+                        return matches
+                    break
+    except OSError as exc:
+        warn(f"cannot read {session.path}: {exc}")
+
+    return matches
+
+
+def _search_legacy_json(
+    session: Session,
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        warn(f"cannot read {session.path}: {exc}")
+        return 0
+
+    history = data.get("history") if isinstance(data, dict) else None
+    if not isinstance(history, list):
+        return 0
+
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        raw = json.dumps(entry, ensure_ascii=False)
+        role = str(entry.get("role") or "")
+        parts = entry.get("parts") or []
+        texts: list[str] = []
+        if isinstance(parts, list):
+            for part in parts:
+                if isinstance(part, dict):
+                    t = str(part.get("text") or "")
+                    if t:
+                        texts.append(t)
+                elif isinstance(part, str) and part:
+                    texts.append(part)
+        combined = "\n".join(texts)
+
+        if not combined or not pattern.search(combined):
+            continue
+
+        if not header_printed:
+            label = f" [{session.repo_reason}]" if session.repo_reason else ""
+            title_part = f" - {session.title}" if session.title else ""
+            print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+            print(f"    {session.path}")
+            header_printed = True
+
+        width = getattr(args, "width", 280)
+        rendered = json.dumps({"role": role, "text": combined}, ensure_ascii=False)
+        print(truncate(rendered, width))
+        matches += 1
+        if max_matches > 0 and matches >= max_matches:
+            return matches
+
+    return matches
+
+
+def search_session(
+    session: Session, pattern: re.Pattern[str], args: argparse.Namespace
+) -> int:
+    if session.path.suffix == ".jsonl":
+        return _search_jsonl(session, pattern, args)
+    return _search_legacy_json(session, pattern, args)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
+
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from session_search.core import (
     Session,
@@ -45,7 +46,9 @@ def _load_slug_map() -> dict[str, str]:
     projects = data.get("projects") if isinstance(data, dict) else None
     if not isinstance(projects, dict):
         return {}
-    return {v: k for k, v in projects.items() if isinstance(k, str) and isinstance(v, str)}
+    return {
+        v: k for k, v in projects.items() if isinstance(k, str) and isinstance(v, str)
+    }
 
 
 def _extract_text_from_content(content: Any) -> str:
@@ -84,7 +87,9 @@ def _read_jsonl_meta(path: Path) -> dict[str, str]:
         return meta
     meta["session_id"] = str(record.get("sessionId") or record.get("session_id") or "")
     meta["start_time"] = str(record.get("startTime") or record.get("start_time") or "")
-    meta["last_updated"] = str(record.get("lastUpdated") or record.get("last_updated") or "")
+    meta["last_updated"] = str(
+        record.get("lastUpdated") or record.get("last_updated") or ""
+    )
     return meta
 
 
@@ -92,7 +97,9 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     tmp_dir = _gemini_tmp()
     slug_map = _load_slug_map()
 
-    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_cwd = (
+        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    )
     current_root = ""
     repo_name = getattr(args, "repo", None) or ""
     if current_cwd:
@@ -127,6 +134,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
                 except OSError:
                     mtime = 0.0
                 from datetime import datetime, timezone
+
                 dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
                 timestamp = dt.isoformat()
                 updated_at = ""
@@ -134,8 +142,6 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
                 continue
 
             score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
-            if not getattr(args, "all_repos", False) and current_cwd and score == 0:
-                continue
 
             session = Session(
                 id=session_id,
@@ -238,9 +244,13 @@ def _search_jsonl(
                     if not pattern.search(text):
                         continue
                     if not header_printed:
-                        label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                        label = (
+                            f" [{session.repo_reason}]" if session.repo_reason else ""
+                        )
                         title_part = f" - {session.title}" if session.title else ""
-                        print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                        print(
+                            f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ==="
+                        )
                         print(f"    {session.path}")
                         header_printed = True
                     rendered = display_text(record, raw)
@@ -279,7 +289,6 @@ def _search_legacy_json(
     for entry in history:
         if not isinstance(entry, dict):
             continue
-        raw = json.dumps(entry, ensure_ascii=False)
         role = str(entry.get("role") or "")
         parts = entry.get("parts") or []
         texts: list[str] = []

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
@@ -1,0 +1,358 @@
+"""Goose (by Block) session reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from session_search.core import (
+    Session,
+    date_key,
+    in_date_window,
+    repo_context,
+    repo_score,
+    truncate,
+    warn,
+)
+
+AGENT_NAME: str = "goose"
+
+
+def _db_path() -> Path:
+    return Path("~/.local/share/goose/sessions/sessions.db").expanduser()
+
+
+def _legacy_dir() -> Path:
+    return Path("~/.config/goose/sessions").expanduser()
+
+
+def detect() -> bool:
+    return _db_path().exists() or any(_legacy_dir().glob("*.jsonl"))
+
+
+def _conn(db: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+
+
+def _ts_from_unix(unix: int) -> str:
+    return datetime.fromtimestamp(unix, tz=timezone.utc).isoformat()
+
+
+def iter_sessions(args: argparse.Namespace) -> list[Session]:
+    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_root = ""
+    repo_name = getattr(args, "repo", None) or ""
+    if current_cwd:
+        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+
+    db = _db_path()
+    if db.exists():
+        return _iter_db_sessions(db, args, current_cwd, current_root, repo_name)
+
+    legacy = _legacy_dir()
+    if legacy.exists():
+        return _iter_legacy_sessions(legacy, args, current_cwd, current_root, repo_name)
+
+    return []
+
+
+def _iter_db_sessions(
+    db: Path,
+    args: argparse.Namespace,
+    current_cwd: str,
+    current_root: str,
+    repo_name: str,
+) -> list[Session]:
+    sessions: list[Session] = []
+    try:
+        with _conn(db) as con:
+            cur = con.execute(
+                "SELECT id, name, working_dir, created_at, updated_at FROM sessions"
+            )
+            for row in cur.fetchall():
+                sid, name, working_dir, created_at, updated_at = row
+                cwd = working_dir or ""
+                title = name or ""
+                timestamp = str(created_at or "")
+                updated = str(updated_at or "")
+
+                score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
+                if not getattr(args, "all_repos", False) and current_cwd and score == 0:
+                    continue
+
+                session = Session(
+                    id=str(sid),
+                    agent=AGENT_NAME,
+                    path=db,
+                    timestamp=timestamp,
+                    updated_at=updated,
+                    title=title,
+                    cwd=cwd,
+                    repo_score=score,
+                    repo_reason=reason,
+                )
+                if not in_date_window(session, args):
+                    continue
+                sessions.append(session)
+    except sqlite3.Error as exc:
+        warn(f"goose: cannot read {db}: {exc}")
+
+    return sessions
+
+
+def _iter_legacy_sessions(
+    legacy_dir: Path,
+    args: argparse.Namespace,
+    current_cwd: str,
+    current_root: str,
+    repo_name: str,
+) -> list[Session]:
+    sessions: list[Session] = []
+    for path in sorted(legacy_dir.glob("*.jsonl")):
+        sid = path.stem
+        cwd = ""
+        title = ""
+        timestamp = ""
+        updated = ""
+
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                first_line = fh.readline()
+            if first_line:
+                try:
+                    meta = json.loads(first_line)
+                    cwd = str(meta.get("working_dir") or "")
+                    title = str(meta.get("description") or "")
+                    timestamp = str(meta.get("created_at") or "")
+                    updated = str(meta.get("updated_at") or "")
+                    if meta.get("id"):
+                        sid = str(meta["id"])
+                except json.JSONDecodeError:
+                    pass
+        except OSError:
+            pass
+
+        if not timestamp:
+            try:
+                mtime = path.stat().st_mtime
+                timestamp = _ts_from_unix(int(mtime))
+            except OSError:
+                pass
+
+        score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
+        if not getattr(args, "all_repos", False) and current_cwd and score == 0:
+            continue
+
+        session = Session(
+            id=sid,
+            agent=AGENT_NAME,
+            path=path,
+            timestamp=timestamp,
+            updated_at=updated,
+            title=title,
+            cwd=cwd,
+            repo_score=score,
+            repo_reason=reason,
+        )
+        if not in_date_window(session, args):
+            continue
+        sessions.append(session)
+
+    return sessions
+
+
+def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
+    role = record.get("role", "")
+    blocks = record.get("content_json_parsed") or []
+
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+
+        if btype == "text":
+            text = str(block.get("text") or "")
+            if text:
+                yield text
+
+        elif btype == "toolRequest":
+            tool_call = block.get("toolCall") or {}
+            ok = tool_call.get("Ok") or {}
+            name = str(ok.get("name") or "")
+            arguments = ok.get("arguments")
+            if name:
+                yield name
+            if arguments is not None:
+                yield json.dumps(arguments, ensure_ascii=False)
+
+        elif btype == "toolResponse":
+            tool_result = block.get("toolResult") or {}
+            items = tool_result.get("Ok") or []
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, dict):
+                        text = str(item.get("text") or "")
+                        if text:
+                            yield text
+
+        elif btype == "thinking":
+            thinking = str(block.get("thinking") or "")
+            if thinking:
+                yield thinking
+
+
+def display_text(record: dict[str, Any], raw: str) -> str:
+    role = record.get("role", "")
+    blocks = record.get("content_json_parsed") or []
+
+    parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+
+        if btype == "text":
+            text = str(block.get("text") or "")
+            if text:
+                parts.append(json.dumps({"role": role, "text": text}, ensure_ascii=False))
+
+        elif btype == "toolRequest":
+            tool_call = block.get("toolCall") or {}
+            ok = tool_call.get("Ok") or {}
+            name = str(ok.get("name") or "")
+            args = ok.get("arguments")
+            parts.append(json.dumps({"role": role, "tool": name, "args": args}, ensure_ascii=False))
+
+        elif btype == "toolResponse":
+            tool_result = block.get("toolResult") or {}
+            items = tool_result.get("Ok") or []
+            texts = []
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, dict):
+                        text = str(item.get("text") or "")
+                        if text:
+                            texts.append(text)
+            parts.append(json.dumps({"role": role, "tool_result": " ".join(texts)}, ensure_ascii=False))
+
+    if parts:
+        return " | ".join(parts)
+    return raw
+
+
+def _search_db_session(
+    session: Session,
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    width = getattr(args, "width", 280)
+    header_printed = False
+    matches = 0
+
+    try:
+        with _conn(session.path) as con:
+            cur = con.execute(
+                "SELECT role, content_json, created_timestamp"
+                " FROM messages"
+                " WHERE session_id = ?"
+                " ORDER BY created_timestamp",
+                (session.id,),
+            )
+            for row in cur.fetchall():
+                role, content_json_raw, created_ts = row
+                try:
+                    blocks = json.loads(content_json_raw)
+                except (json.JSONDecodeError, TypeError):
+                    blocks = []
+
+                record = {"role": role, "content_json_parsed": blocks}
+                searchable = " ".join(iter_search_text(record, content_json_raw or ""))
+
+                if not pattern.search(searchable):
+                    continue
+
+                if not header_printed:
+                    label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                    title_part = f" - {session.title}" if session.title else ""
+                    print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                    print(f"    {session.path}")
+                    header_printed = True
+
+                rendered = display_text(record, content_json_raw or "")
+                print(truncate(rendered, width))
+                matches += 1
+
+                if max_matches > 0 and matches >= max_matches:
+                    return matches
+
+    except sqlite3.Error as exc:
+        warn(f"goose: cannot read session {session.id} from {session.path}: {exc}")
+
+    return matches
+
+
+def _search_legacy_session(
+    session: Session,
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+) -> int:
+    max_matches = getattr(args, "max_matches", 0)
+    width = getattr(args, "width", 280)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw = raw_line.rstrip("\n")
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                if not isinstance(entry, dict):
+                    continue
+
+                role = str(entry.get("role") or "")
+                content = entry.get("content")
+                if not isinstance(content, list):
+                    continue
+
+                record = {"role": role, "content_json_parsed": content}
+                searchable = " ".join(iter_search_text(record, raw))
+
+                if not pattern.search(searchable):
+                    continue
+
+                if not header_printed:
+                    label = f" [{session.repo_reason}]" if session.repo_reason else ""
+                    title_part = f" - {session.title}" if session.title else ""
+                    print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
+                    print(f"    {session.path}")
+                    header_printed = True
+
+                rendered = display_text(record, raw)
+                print(truncate(rendered, width))
+                matches += 1
+
+                if max_matches > 0 and matches >= max_matches:
+                    return matches
+
+    except OSError as exc:
+        warn(f"goose: cannot read {session.path}: {exc}")
+
+    return matches
+
+
+def search_session(
+    session: Session, pattern: re.Pattern[str], args: argparse.Namespace
+) -> int:
+    if session.path == _db_path():
+        return _search_db_session(session, pattern, args)
+    return _search_legacy_session(session, pattern, args)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
@@ -6,13 +6,14 @@ import argparse
 import json
 import re
 import sqlite3
+
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from session_search.core import (
     Session,
-    date_key,
     in_date_window,
     repo_context,
     repo_score,
@@ -44,7 +45,9 @@ def _ts_from_unix(unix: int) -> str:
 
 
 def iter_sessions(args: argparse.Namespace) -> list[Session]:
-    current_cwd = str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    current_cwd = (
+        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    )
     current_root = ""
     repo_name = getattr(args, "repo", None) or ""
     if current_cwd:
@@ -82,8 +85,6 @@ def _iter_db_sessions(
                 updated = str(updated_at or "")
 
                 score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
-                if not getattr(args, "all_repos", False) and current_cwd and score == 0:
-                    continue
 
                 session = Session(
                     id=str(sid),
@@ -145,8 +146,6 @@ def _iter_legacy_sessions(
                 pass
 
         score, reason = repo_score(cwd, current_cwd, current_root, repo_name)
-        if not getattr(args, "all_repos", False) and current_cwd and score == 0:
-            continue
 
         session = Session(
             id=sid,
@@ -167,7 +166,6 @@ def _iter_legacy_sessions(
 
 
 def iter_search_text(record: dict[str, Any], raw: str) -> Iterable[str]:
-    role = record.get("role", "")
     blocks = record.get("content_json_parsed") or []
 
     for block in blocks:
@@ -219,14 +217,20 @@ def display_text(record: dict[str, Any], raw: str) -> str:
         if btype == "text":
             text = str(block.get("text") or "")
             if text:
-                parts.append(json.dumps({"role": role, "text": text}, ensure_ascii=False))
+                parts.append(
+                    json.dumps({"role": role, "text": text}, ensure_ascii=False)
+                )
 
         elif btype == "toolRequest":
             tool_call = block.get("toolCall") or {}
             ok = tool_call.get("Ok") or {}
             name = str(ok.get("name") or "")
             args = ok.get("arguments")
-            parts.append(json.dumps({"role": role, "tool": name, "args": args}, ensure_ascii=False))
+            parts.append(
+                json.dumps(
+                    {"role": role, "tool": name, "args": args}, ensure_ascii=False
+                )
+            )
 
         elif btype == "toolResponse":
             tool_result = block.get("toolResult") or {}
@@ -238,7 +242,11 @@ def display_text(record: dict[str, Any], raw: str) -> str:
                         text = str(item.get("text") or "")
                         if text:
                             texts.append(text)
-            parts.append(json.dumps({"role": role, "tool_result": " ".join(texts)}, ensure_ascii=False))
+            parts.append(
+                json.dumps(
+                    {"role": role, "tool_result": " ".join(texts)}, ensure_ascii=False
+                )
+            )
 
     if parts:
         return " | ".join(parts)

--- a/tests/unit/test_session_search_core.py
+++ b/tests/unit/test_session_search_core.py
@@ -1,7 +1,8 @@
 import argparse
 import json
 import sys
-from datetime import datetime, timezone
+
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -33,23 +34,22 @@ from session_search.core import (  # noqa: E402
     truncate,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
 def make_session(
-    id="abc123",
-    agent="claude",
-    path="/home/user/.claude/sessions/abc123.json",
-    timestamp="2024-03-01T10:00:00Z",
-    updated_at="",
-    title="My Session",
-    cwd="/home/user/projects/myrepo",
-    score=0,
-    reason="",
-):
+    id: str = "abc123",
+    agent: str = "claude",
+    path: str = "/home/user/.claude/sessions/abc123.json",
+    timestamp: str = "2024-03-01T10:00:00Z",
+    updated_at: str = "",
+    title: str = "My Session",
+    cwd: str = "/home/user/projects/myrepo",
+    score: int = 0,
+    reason: str = "",
+) -> Session:
     return Session(
         id=id,
         agent=agent,
@@ -63,7 +63,7 @@ def make_session(
     )
 
 
-def make_args(since=None, until=None):
+def make_args(since: str | None = None, until: str | None = None) -> argparse.Namespace:
     return argparse.Namespace(since=since, until=until)
 
 
@@ -74,12 +74,14 @@ def make_args(since=None, until=None):
 
 def test_session_is_frozen():
     s = make_session()
-    with pytest.raises(Exception):
-        s.id = "other"  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        s.id = "other"  # type: ignore
 
 
 def test_sort_time_returns_updated_at_when_present():
-    s = make_session(timestamp="2024-01-01T00:00:00Z", updated_at="2024-06-01T00:00:00Z")
+    s = make_session(
+        timestamp="2024-01-01T00:00:00Z", updated_at="2024-06-01T00:00:00Z"
+    )
     assert s.sort_time == "2024-06-01T00:00:00Z"
 
 
@@ -116,7 +118,7 @@ def test_parse_iso_z_suffix_returns_utc_datetime():
 def test_parse_iso_timezone_offset_returns_aware_datetime():
     result = parse_iso("2024-03-15T12:30:00+05:00")
     assert result is not None
-    assert result.utcoffset().seconds == 5 * 3600
+    assert result.utcoffset() == timedelta(hours=5)
 
 
 def test_parse_iso_empty_string_returns_none():
@@ -180,14 +182,18 @@ def test_repo_score_empty_session_cwd_returns_zero():
 
 
 def test_repo_score_exact_cwd_match():
-    assert repo_score("/home/user/myrepo", "/home/user/myrepo", "/home/user/myrepo", "myrepo") == (
+    assert repo_score(
+        "/home/user/myrepo", "/home/user/myrepo", "/home/user/myrepo", "myrepo"
+    ) == (
         3,
         "exact-cwd",
     )
 
 
 def test_repo_score_session_equals_root_returns_exact_cwd():
-    assert repo_score("/home/user/myrepo", "/other/path", "/home/user/myrepo", "myrepo") == (
+    assert repo_score(
+        "/home/user/myrepo", "/other/path", "/home/user/myrepo", "myrepo"
+    ) == (
         3,
         "exact-cwd",
     )
@@ -221,7 +227,9 @@ def test_repo_score_repo_name_in_path():
 
 
 def test_repo_score_no_match_returns_zero():
-    assert repo_score("/home/user/unrelated", "/home/user/myrepo", "/home/user/myrepo", "myrepo") == (
+    assert repo_score(
+        "/home/user/unrelated", "/home/user/myrepo", "/home/user/myrepo", "myrepo"
+    ) == (
         0,
         "",
     )
@@ -284,7 +292,9 @@ def test_sorted_sessions_oldest_true_sorts_ascending():
 
 
 def test_sorted_sessions_tie_broken_by_title_then_id():
-    a = make_session(id="zzz", score=1, title="Alpha", updated_at="2024-03-01T00:00:00Z")
+    a = make_session(
+        id="zzz", score=1, title="Alpha", updated_at="2024-03-01T00:00:00Z"
+    )
     b = make_session(id="aaa", score=1, title="Beta", updated_at="2024-03-01T00:00:00Z")
     result = sorted_sessions([a, b], oldest=False)
     assert result[0].title == "Beta"
@@ -378,7 +388,17 @@ def test_truncate_one_over_width_gets_ellipsis():
 def test_session_to_json_contains_expected_keys():
     s = make_session()
     result = session_to_json(s)
-    expected_keys = {"id", "agent", "title", "timestamp", "updated_at", "cwd", "path", "repo_score", "repo_reason"}
+    expected_keys = {
+        "id",
+        "agent",
+        "title",
+        "timestamp",
+        "updated_at",
+        "cwd",
+        "path",
+        "repo_score",
+        "repo_reason",
+    }
     assert set(result.keys()) == expected_keys
 
 

--- a/tests/unit/test_session_search_core.py
+++ b/tests/unit/test_session_search_core.py
@@ -1,0 +1,442 @@
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "ai_rules"
+        / "config"
+        / "skills"
+        / "session-search"
+        / "scripts"
+    ),
+)
+
+from session_search.core import (  # noqa: E402
+    Session,
+    date_key,
+    in_date_window,
+    matches_term,
+    parse_iso,
+    print_sessions,
+    repo_name_from_path,
+    repo_score,
+    session_to_json,
+    sorted_sessions,
+    truncate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_session(
+    id="abc123",
+    agent="claude",
+    path="/home/user/.claude/sessions/abc123.json",
+    timestamp="2024-03-01T10:00:00Z",
+    updated_at="",
+    title="My Session",
+    cwd="/home/user/projects/myrepo",
+    score=0,
+    reason="",
+):
+    return Session(
+        id=id,
+        agent=agent,
+        path=Path(path),
+        timestamp=timestamp,
+        updated_at=updated_at,
+        title=title,
+        cwd=cwd,
+        repo_score=score,
+        repo_reason=reason,
+    )
+
+
+def make_args(since=None, until=None):
+    return argparse.Namespace(since=since, until=until)
+
+
+# ---------------------------------------------------------------------------
+# Session dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_session_is_frozen():
+    s = make_session()
+    with pytest.raises(Exception):
+        s.id = "other"  # type: ignore[misc]
+
+
+def test_sort_time_returns_updated_at_when_present():
+    s = make_session(timestamp="2024-01-01T00:00:00Z", updated_at="2024-06-01T00:00:00Z")
+    assert s.sort_time == "2024-06-01T00:00:00Z"
+
+
+def test_sort_time_falls_back_to_timestamp_when_updated_at_empty():
+    s = make_session(timestamp="2024-01-01T00:00:00Z", updated_at="")
+    assert s.sort_time == "2024-01-01T00:00:00Z"
+
+
+def test_sort_time_falls_back_to_timestamp_when_updated_at_none():
+    s = Session(
+        id="x",
+        agent="claude",
+        path=Path("/tmp/x.json"),
+        timestamp="2024-01-01T00:00:00Z",
+        updated_at=None,  # type: ignore[arg-type]
+        title="",
+        cwd="",
+        repo_score=0,
+        repo_reason="",
+    )
+    assert s.sort_time == "2024-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# parse_iso
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_z_suffix_returns_utc_datetime():
+    result = parse_iso("2024-03-15T12:30:00Z")
+    assert result == datetime(2024, 3, 15, 12, 30, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_timezone_offset_returns_aware_datetime():
+    result = parse_iso("2024-03-15T12:30:00+05:00")
+    assert result is not None
+    assert result.utcoffset().seconds == 5 * 3600
+
+
+def test_parse_iso_empty_string_returns_none():
+    assert parse_iso("") is None
+
+
+def test_parse_iso_invalid_string_returns_none():
+    assert parse_iso("not-a-date") is None
+
+
+def test_parse_iso_partial_string_returns_none():
+    assert parse_iso("2024-13-99") is None
+
+
+# ---------------------------------------------------------------------------
+# date_key
+# ---------------------------------------------------------------------------
+
+
+def test_date_key_valid_iso_returns_datetime():
+    result = date_key("2024-03-15T12:00:00Z")
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+
+
+def test_date_key_empty_string_returns_min_utc():
+    result = date_key("")
+    assert result == datetime.min.replace(tzinfo=timezone.utc)
+
+
+def test_date_key_invalid_string_returns_min_utc():
+    result = date_key("garbage")
+    assert result == datetime.min.replace(tzinfo=timezone.utc)
+
+
+def test_date_key_naive_datetime_gets_utc():
+    result = date_key("2024-03-15T12:00:00")
+    assert result.tzinfo == timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# repo_name_from_path
+# ---------------------------------------------------------------------------
+
+
+def test_repo_name_from_path_returns_last_component():
+    assert repo_name_from_path("/home/user/projects/myrepo") == "myrepo"
+
+
+def test_repo_name_from_path_empty_returns_empty():
+    assert repo_name_from_path("") == ""
+
+
+# ---------------------------------------------------------------------------
+# repo_score
+# ---------------------------------------------------------------------------
+
+
+def test_repo_score_empty_session_cwd_returns_zero():
+    assert repo_score("", "/home/user/myrepo", "/home/user/myrepo", "myrepo") == (0, "")
+
+
+def test_repo_score_exact_cwd_match():
+    assert repo_score("/home/user/myrepo", "/home/user/myrepo", "/home/user/myrepo", "myrepo") == (
+        3,
+        "exact-cwd",
+    )
+
+
+def test_repo_score_session_equals_root_returns_exact_cwd():
+    assert repo_score("/home/user/myrepo", "/other/path", "/home/user/myrepo", "myrepo") == (
+        3,
+        "exact-cwd",
+    )
+
+
+def test_repo_score_subdirectory_of_root_returns_same_root():
+    assert repo_score(
+        "/home/user/myrepo/subdir",
+        "/some/other/path",
+        "/home/user/myrepo",
+        "myrepo",
+    ) == (3, "same-root")
+
+
+def test_repo_score_same_repo_name():
+    assert repo_score(
+        "/home/user/work/myrepo",
+        "/home/user/other/path",
+        "/home/user/other",
+        "myrepo",
+    ) == (2, "same-repo")
+
+
+def test_repo_score_repo_name_in_path():
+    assert repo_score(
+        "/home/user/archive/myrepo/old",
+        "/home/user/other",
+        "/home/user/other",
+        "myrepo",
+    ) == (1, "repo-name-in-path")
+
+
+def test_repo_score_no_match_returns_zero():
+    assert repo_score("/home/user/unrelated", "/home/user/myrepo", "/home/user/myrepo", "myrepo") == (
+        0,
+        "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# in_date_window
+# ---------------------------------------------------------------------------
+
+
+def test_in_date_window_no_filters_returns_true():
+    s = make_session(updated_at="2024-03-01T10:00:00Z")
+    assert in_date_window(s, make_args()) is True
+
+
+def test_in_date_window_session_within_window_returns_true():
+    s = make_session(updated_at="2024-03-15T10:00:00Z")
+    assert in_date_window(s, make_args(since="2024-03-01", until="2024-03-31")) is True
+
+
+def test_in_date_window_session_before_since_returns_false():
+    s = make_session(updated_at="2024-02-28T10:00:00Z")
+    assert in_date_window(s, make_args(since="2024-03-01")) is False
+
+
+def test_in_date_window_session_after_until_returns_false():
+    s = make_session(updated_at="2024-04-01T10:00:00Z")
+    assert in_date_window(s, make_args(until="2024-03-31")) is False
+
+
+def test_in_date_window_session_on_until_date_returns_true():
+    s = make_session(updated_at="2024-03-31T23:59:59Z")
+    assert in_date_window(s, make_args(until="2024-03-31")) is True
+
+
+# ---------------------------------------------------------------------------
+# sorted_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_sorted_sessions_orders_by_repo_score_descending():
+    low = make_session(id="low", score=0, updated_at="2024-03-01T00:00:00Z")
+    high = make_session(id="high", score=3, updated_at="2024-01-01T00:00:00Z")
+    result = sorted_sessions([low, high], oldest=False)
+    assert result[0].id == "high"
+
+
+def test_sorted_sessions_within_same_score_orders_by_recency_descending():
+    older = make_session(id="older", score=2, updated_at="2024-01-01T00:00:00Z")
+    newer = make_session(id="newer", score=2, updated_at="2024-06-01T00:00:00Z")
+    result = sorted_sessions([older, newer], oldest=False)
+    assert result[0].id == "newer"
+
+
+def test_sorted_sessions_oldest_true_sorts_ascending():
+    older = make_session(id="older", score=0, updated_at="2024-01-01T00:00:00Z")
+    newer = make_session(id="newer", score=0, updated_at="2024-06-01T00:00:00Z")
+    result = sorted_sessions([older, newer], oldest=True)
+    assert result[0].id == "older"
+
+
+def test_sorted_sessions_tie_broken_by_title_then_id():
+    a = make_session(id="zzz", score=1, title="Alpha", updated_at="2024-03-01T00:00:00Z")
+    b = make_session(id="aaa", score=1, title="Beta", updated_at="2024-03-01T00:00:00Z")
+    result = sorted_sessions([a, b], oldest=False)
+    assert result[0].title == "Beta"
+
+
+# ---------------------------------------------------------------------------
+# matches_term
+# ---------------------------------------------------------------------------
+
+
+def test_matches_term_matches_in_id():
+    s = make_session(id="unique-abc-id")
+    assert matches_term(s, "unique-abc") is True
+
+
+def test_matches_term_matches_path_name():
+    s = make_session(path="/home/user/.claude/sessions/special123.json")
+    assert matches_term(s, "special123") is True
+
+
+def test_matches_term_matches_full_path():
+    s = make_session(path="/home/user/.claude/sessions/abc.json")
+    assert matches_term(s, ".claude/sessions") is True
+
+
+def test_matches_term_matches_title():
+    s = make_session(title="My Important Project")
+    assert matches_term(s, "important") is True
+
+
+def test_matches_term_matches_cwd():
+    s = make_session(cwd="/home/user/projects/special-repo")
+    assert matches_term(s, "special-repo") is True
+
+
+def test_matches_term_matches_agent():
+    s = make_session(agent="codex")
+    assert matches_term(s, "codex") is True
+
+
+def test_matches_term_case_insensitive():
+    s = make_session(title="My Project")
+    assert matches_term(s, "MY PROJECT") is True
+
+
+def test_matches_term_no_match_returns_false():
+    s = make_session(id="abc", title="Hello", cwd="/tmp/foo", agent="claude")
+    assert matches_term(s, "zzznomatch") is False
+
+
+# ---------------------------------------------------------------------------
+# truncate
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_short_text_unchanged():
+    assert truncate("hello world", 20) == "hello world"
+
+
+def test_truncate_long_text_truncated_with_ellipsis():
+    result = truncate("a" * 300)
+    assert result.endswith("...")
+    assert "a" in result
+
+
+def test_truncate_whitespace_collapsed():
+    assert truncate("hello   world", 50) == "hello world"
+
+
+def test_truncate_internal_newlines_collapsed():
+    assert truncate("line one\nline two", 50) == "line one line two"
+
+
+def test_truncate_exactly_at_width_not_truncated():
+    text = "x" * 280
+    assert truncate(text, 280) == text
+
+
+def test_truncate_one_over_width_gets_ellipsis():
+    text = "x" * 281
+    result = truncate(text, 280)
+    assert result.endswith("...")
+    assert result.startswith("x")
+
+
+# ---------------------------------------------------------------------------
+# session_to_json
+# ---------------------------------------------------------------------------
+
+
+def test_session_to_json_contains_expected_keys():
+    s = make_session()
+    result = session_to_json(s)
+    expected_keys = {"id", "agent", "title", "timestamp", "updated_at", "cwd", "path", "repo_score", "repo_reason"}
+    assert set(result.keys()) == expected_keys
+
+
+def test_session_to_json_path_is_string():
+    s = make_session(path="/tmp/test.json")
+    result = session_to_json(s)
+    assert isinstance(result["path"], str)
+    assert result["path"] == "/tmp/test.json"
+
+
+def test_session_to_json_agent_field_present():
+    s = make_session(agent="codex")
+    result = session_to_json(s)
+    assert result["agent"] == "codex"
+
+
+# ---------------------------------------------------------------------------
+# print_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_print_sessions_limit_zero_shows_all(capsys):
+    sessions = [make_session(id=f"s{i}") for i in range(5)]
+    print_sessions(sessions, limit=0, json_output=False)
+    captured = capsys.readouterr()
+    for i in range(5):
+        assert f"s{i}" in captured.out
+
+
+def test_print_sessions_limit_n_shows_only_first_n(capsys):
+    sessions = [make_session(id=f"sess{i}", title=f"Title {i}") for i in range(5)]
+    print_sessions(sessions, limit=2, json_output=False)
+    captured = capsys.readouterr()
+    assert "sess0" in captured.out
+    assert "sess1" in captured.out
+    assert "sess2" not in captured.out
+
+
+def test_print_sessions_limit_shows_overflow_hint(capsys):
+    sessions = [make_session(id=f"s{i}") for i in range(5)]
+    print_sessions(sessions, limit=3, json_output=False)
+    captured = capsys.readouterr()
+    assert "2 more" in captured.out
+
+
+def test_print_sessions_json_mode_outputs_valid_json(capsys):
+    sessions = [make_session(id="abc"), make_session(id="def")]
+    print_sessions(sessions, limit=0, json_output=True)
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 2
+    assert parsed[0]["id"] == "abc"
+
+
+def test_print_sessions_json_mode_respects_limit(capsys):
+    sessions = [make_session(id=f"s{i}") for i in range(4)]
+    print_sessions(sessions, limit=2, json_output=True)
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert len(parsed) == 2

--- a/tests/unit/test_session_search_grep.py
+++ b/tests/unit/test_session_search_grep.py
@@ -3,9 +3,9 @@ import json
 import re
 import sqlite3
 import sys
-from pathlib import Path
 
-import pytest
+from pathlib import Path
+from typing import Any
 
 sys.path.insert(
     0,
@@ -24,14 +24,13 @@ from session_search import readers  # noqa: E402
 from session_search.core import Session  # noqa: E402
 from session_search.readers import amp, claude, codex, gemini, goose  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 
 
-def make_args(**kwargs):
-    defaults = dict(
+def make_args(**kwargs: Any) -> argparse.Namespace:
+    defaults: dict[str, Any] = dict(
         max_matches=40,
         width=280,
         ignore_case=False,
@@ -46,8 +45,8 @@ def make_args(**kwargs):
     return argparse.Namespace(**defaults)
 
 
-def make_session(agent, path, **kwargs):
-    defaults = dict(
+def make_session(agent: str, path: str, **kwargs: Any) -> Session:
+    defaults: dict[str, Any] = dict(
         id="test-session-001",
         timestamp="2026-01-01T10:00:00Z",
         updated_at="2026-01-01T10:00:00Z",
@@ -348,7 +347,9 @@ def test_goose_iter_search_text_tool_request_yields_name_and_arguments():
 def test_goose_iter_search_text_text_block_yields_text():
     record = {
         "role": "assistant",
-        "content_json_parsed": [{"type": "text", "text": "Task completed successfully"}],
+        "content_json_parsed": [
+            {"type": "text", "text": "Task completed successfully"}
+        ],
     }
     results = list(goose.iter_search_text(record, ""))
     assert "Task completed successfully" in results
@@ -511,7 +512,8 @@ def test_codex_search_session_width_truncation(tmp_path, capsys):
 
     captured = capsys.readouterr()
     content_lines = [
-        l for l in captured.out.splitlines()
+        l
+        for l in captured.out.splitlines()
         if l and not l.startswith("===") and not l.startswith("    ")
     ]
     for line in content_lines:
@@ -670,7 +672,13 @@ def _make_goose_db(path: Path, session_id: str, content_json: str) -> None:
         )
         con.execute(
             "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)",
-            (session_id, "test session", "/tmp/project", "2026-01-01T10:00:00", "2026-01-01T10:00:00"),
+            (
+                session_id,
+                "test session",
+                "/tmp/project",
+                "2026-01-01T10:00:00",
+                "2026-01-01T10:00:00",
+            ),
         )
         con.execute(
             "CREATE TABLE IF NOT EXISTS messages "
@@ -703,7 +711,9 @@ def test_goose_search_session_db_finds_text_content(tmp_path, capsys, monkeypatc
     assert "goose-sess-001" in captured.out
 
 
-def test_goose_search_session_db_regex_no_sql_like_prefilter(tmp_path, capsys, monkeypatch):
+def test_goose_search_session_db_regex_no_sql_like_prefilter(
+    tmp_path, capsys, monkeypatch
+):
     db_path = tmp_path / "sessions.db"
     content = json.dumps([{"type": "text", "text": "foo xyz bar"}])
     _make_goose_db(db_path, "goose-regex-001", content)
@@ -1072,7 +1082,9 @@ def test_goose_regex_case_insensitive_matches_uppercase(tmp_path, monkeypatch, c
     assert count >= 1
 
 
-def test_goose_regex_does_not_match_partial_without_wildcard(tmp_path, monkeypatch, capsys):
+def test_goose_regex_does_not_match_partial_without_wildcard(
+    tmp_path, monkeypatch, capsys
+):
     db_path = tmp_path / "sessions.db"
     content = json.dumps([{"type": "text", "text": "foo baz bar"}])
     _make_goose_db(db_path, "goose-partial", content)

--- a/tests/unit/test_session_search_grep.py
+++ b/tests/unit/test_session_search_grep.py
@@ -1,0 +1,1088 @@
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "ai_rules"
+        / "config"
+        / "skills"
+        / "session-search"
+        / "scripts"
+    ),
+)
+
+from session_search import readers  # noqa: E402
+from session_search.core import Session  # noqa: E402
+from session_search.readers import amp, claude, codex, gemini, goose  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def make_args(**kwargs):
+    defaults = dict(
+        max_matches=40,
+        width=280,
+        ignore_case=False,
+        cwd="/tmp",
+        repo=None,
+        all_repos=True,
+        since=None,
+        until=None,
+        oldest=False,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def make_session(agent, path, **kwargs):
+    defaults = dict(
+        id="test-session-001",
+        timestamp="2026-01-01T10:00:00Z",
+        updated_at="2026-01-01T10:00:00Z",
+        title="Test Session",
+        cwd="/tmp/project",
+        repo_score=0,
+        repo_reason="",
+    )
+    defaults.update(kwargs)
+    return Session(agent=agent, path=Path(path), **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Codex JSONL fixture
+# ---------------------------------------------------------------------------
+
+CODEX_LINES = [
+    json.dumps(
+        {
+            "type": "session_meta",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "payload": {
+                "id": "test-001",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "cwd": "/tmp/project",
+                "agent_role": "assistant",
+                "agent_nickname": "",
+            },
+        }
+    ),
+    json.dumps(
+        {
+            "type": "response_item",
+            "timestamp": "2026-01-01T10:00:01Z",
+            "payload": {
+                "role": "assistant",
+                "content": [{"text": "Here is the result"}],
+            },
+        }
+    ),
+    json.dumps(
+        {
+            "type": "event_msg",
+            "timestamp": "2026-01-01T10:00:02Z",
+            "payload": {
+                "type": "exec_command_end",
+                "command": ["git", "status"],
+                "cwd": "/tmp/project",
+                "aggregated_output": "On branch main",
+                "exit_code": 0,
+            },
+        }
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Claude JSONL fixture
+# ---------------------------------------------------------------------------
+
+CLAUDE_LINES = [
+    json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "search for foo bar"},
+            "cwd": "/tmp/project",
+            "sessionId": "test-claude",
+            "timestamp": "2026-01-01T10:00:00Z",
+            "uuid": "u1",
+        }
+    ),
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I found foo xyz bar in the results"}
+                ],
+            },
+            "cwd": "/tmp/project",
+            "sessionId": "test-claude",
+            "timestamp": "2026-01-01T10:00:01Z",
+            "uuid": "u2",
+        }
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Gemini JSONL fixture
+# ---------------------------------------------------------------------------
+
+GEMINI_LINES = [
+    json.dumps(
+        {
+            "type": "user",
+            "sessionId": "test-gemini",
+            "startTime": "2026-01-01T10:00:00Z",
+            "content": "find foo bar in codebase",
+        }
+    ),
+    json.dumps(
+        {
+            "type": "gemini",
+            "content": "I searched and found foo xyz bar",
+            "toolCalls": [{"name": "read_file", "args": {"path": "/tmp/test"}}],
+        }
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Amp JSON fixture
+# ---------------------------------------------------------------------------
+
+AMP_DATA = {
+    "v": 1,
+    "id": "T-test",
+    "created": 1704067200000,
+    "messages": [
+        {
+            "role": "user",
+            "messageId": 0,
+            "content": [{"type": "text", "text": "find foo bar"}],
+            "meta": {"sentAt": 1704067200000},
+        },
+        {
+            "role": "assistant",
+            "messageId": 1,
+            "content": [{"type": "text", "text": "foo xyz bar result"}],
+            "meta": {"sentAt": 1704067201000},
+        },
+    ],
+    "title": "test thread",
+}
+
+
+# ---------------------------------------------------------------------------
+# iter_search_text — Codex
+# ---------------------------------------------------------------------------
+
+
+def test_codex_iter_search_text_exec_command_end_yields_command_and_output():
+    record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "exec_command_end",
+            "command": ["ls", "-la"],
+            "aggregated_output": "total 42\ndrwxr-xr-x  ...",
+        },
+    }
+    results = list(codex.iter_search_text(record, ""))
+    combined = " ".join(results)
+    assert "ls" in combined
+    assert "total 42" in combined
+
+
+def test_codex_iter_search_text_exec_command_list_yields_shell_quoted_form():
+    record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "exec_command_end",
+            "command": ["git", "status"],
+            "aggregated_output": "On branch main",
+        },
+    }
+    results = list(codex.iter_search_text(record, ""))
+    assert any("git" in r and "status" in r for r in results)
+
+
+def test_codex_iter_search_text_response_item_yields_content_text():
+    record = {
+        "type": "response_item",
+        "payload": {
+            "role": "assistant",
+            "content": [{"text": "Here is the result"}],
+        },
+    }
+    results = list(codex.iter_search_text(record, ""))
+    assert any("Here is the result" in r for r in results)
+
+
+def test_codex_iter_search_text_session_meta_yields_id_and_cwd():
+    record = {
+        "type": "session_meta",
+        "payload": {"id": "sess-abc", "cwd": "/home/user/project"},
+    }
+    results = list(codex.iter_search_text(record, ""))
+    assert "sess-abc" in results
+    assert "/home/user/project" in results
+
+
+# ---------------------------------------------------------------------------
+# iter_search_text — Claude
+# ---------------------------------------------------------------------------
+
+
+def test_claude_iter_search_text_tool_use_yields_name_and_input():
+    record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "id": "123",
+                    "input": {"command": "git status"},
+                }
+            ],
+        },
+    }
+    results = list(claude.iter_search_text(record, ""))
+    combined = " ".join(results)
+    assert "Bash" in combined
+    assert "git status" in combined
+
+
+def test_claude_iter_search_text_text_block_yields_text():
+    record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "I found something interesting"}],
+        },
+    }
+    results = list(claude.iter_search_text(record, ""))
+    assert any("I found something interesting" in r for r in results)
+
+
+def test_claude_iter_search_text_user_message_yields_content():
+    record = {
+        "type": "user",
+        "message": {"role": "user", "content": "please run git status"},
+    }
+    results = list(claude.iter_search_text(record, ""))
+    assert any("git status" in r for r in results)
+
+
+# ---------------------------------------------------------------------------
+# iter_search_text — Gemini
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_iter_search_text_tool_calls_yields_name_and_args():
+    record = {
+        "type": "gemini",
+        "content": "some text",
+        "toolCalls": [{"name": "read_file", "args": {"path": "/tmp/test"}}],
+    }
+    results = list(gemini.iter_search_text(record, ""))
+    combined = " ".join(results)
+    assert "read_file" in combined
+    assert "/tmp/test" in combined
+
+
+def test_gemini_iter_search_text_content_text_yielded():
+    record = {
+        "type": "gemini",
+        "content": "I analyzed the foo bar pattern",
+        "toolCalls": [],
+    }
+    results = list(gemini.iter_search_text(record, ""))
+    assert any("foo bar" in r for r in results)
+
+
+def test_gemini_iter_search_text_user_type_yields_content():
+    record = {"type": "user", "content": "search the codebase for foo"}
+    results = list(gemini.iter_search_text(record, ""))
+    assert any("foo" in r for r in results)
+
+
+# ---------------------------------------------------------------------------
+# iter_search_text — Goose
+# ---------------------------------------------------------------------------
+
+
+def test_goose_iter_search_text_tool_request_yields_name_and_arguments():
+    record = {
+        "role": "user",
+        "content_json_parsed": [
+            {
+                "type": "toolRequest",
+                "id": "1",
+                "toolCall": {
+                    "Ok": {
+                        "name": "developer__shell",
+                        "arguments": {"command": "echo hello"},
+                    }
+                },
+            }
+        ],
+    }
+    results = list(goose.iter_search_text(record, ""))
+    combined = " ".join(results)
+    assert "developer__shell" in combined
+    assert "echo hello" in combined
+
+
+def test_goose_iter_search_text_text_block_yields_text():
+    record = {
+        "role": "assistant",
+        "content_json_parsed": [{"type": "text", "text": "Task completed successfully"}],
+    }
+    results = list(goose.iter_search_text(record, ""))
+    assert "Task completed successfully" in results
+
+
+def test_goose_iter_search_text_tool_response_yields_output_text():
+    record = {
+        "role": "user",
+        "content_json_parsed": [
+            {
+                "type": "toolResponse",
+                "toolResult": {"Ok": [{"text": "command output here"}]},
+            }
+        ],
+    }
+    results = list(goose.iter_search_text(record, ""))
+    assert "command output here" in results
+
+
+# ---------------------------------------------------------------------------
+# iter_search_text — Amp
+# ---------------------------------------------------------------------------
+
+
+def test_amp_iter_search_text_tool_use_yields_name_and_input():
+    record = {
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "1", "name": "Bash", "input": {"command": "ls"}}
+        ],
+    }
+    results = list(amp.iter_search_text(record, ""))
+    combined = " ".join(results)
+    assert "Bash" in combined
+    assert "ls" in combined
+
+
+def test_amp_iter_search_text_tool_result_yields_content_text():
+    record = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "content": [{"type": "text", "text": "file contents here"}],
+            }
+        ],
+    }
+    results = list(amp.iter_search_text(record, ""))
+    assert "file contents here" in results
+
+
+def test_amp_iter_search_text_text_block_yields_text():
+    record = {
+        "role": "user",
+        "content": [{"type": "text", "text": "please help me debug"}],
+    }
+    results = list(amp.iter_search_text(record, ""))
+    assert "please help me debug" in results
+
+
+# ---------------------------------------------------------------------------
+# search_session — Codex (file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_codex_search_session_finds_match_in_command_output(tmp_path, capsys):
+    session_file = tmp_path / "rollout-2026-01-01T10-00-00-test-001.jsonl"
+    session_file.write_text("\n".join(CODEX_LINES) + "\n")
+
+    session = make_session("codex", session_file, id="test-001")
+    pattern = re.compile(r"On branch main")
+    args = make_args()
+
+    count = codex.search_session(session, pattern, args)
+
+    assert count >= 1
+    captured = capsys.readouterr()
+    assert "test-001" in captured.out
+
+
+def test_codex_search_session_header_printed_on_first_match(tmp_path, capsys):
+    session_file = tmp_path / "rollout-2026-01-01T10-00-00-test-001.jsonl"
+    session_file.write_text("\n".join(CODEX_LINES) + "\n")
+
+    session = make_session("codex", session_file, id="test-001")
+    pattern = re.compile(r"git")
+    args = make_args()
+
+    codex.search_session(session, pattern, args)
+
+    captured = capsys.readouterr()
+    assert "[codex]" in captured.out
+    assert "test-001" in captured.out
+
+
+def test_codex_search_session_max_matches_respected(tmp_path, capsys):
+    lines = []
+    for i in range(10):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "exec_command_end",
+                        "command": ["echo", f"msg-{i}"],
+                        "aggregated_output": f"output-line-{i}",
+                    },
+                }
+            )
+        )
+    session_file = tmp_path / "rollout-2026-01-01T10-00-00-multi.jsonl"
+    session_file.write_text("\n".join(lines) + "\n")
+
+    session = make_session("codex", session_file, id="multi")
+    pattern = re.compile(r"output-line")
+    args = make_args(max_matches=1)
+
+    count = codex.search_session(session, pattern, args)
+
+    assert count == 1
+
+
+def test_codex_search_session_no_match_returns_zero(tmp_path, capsys):
+    session_file = tmp_path / "rollout-2026-01-01T10-00-00-test-001.jsonl"
+    session_file.write_text("\n".join(CODEX_LINES) + "\n")
+
+    session = make_session("codex", session_file, id="test-001")
+    pattern = re.compile(r"zzznomatch")
+    args = make_args()
+
+    count = codex.search_session(session, pattern, args)
+
+    assert count == 0
+    captured = capsys.readouterr()
+    assert "[codex]" not in captured.out
+
+
+def test_codex_search_session_width_truncation(tmp_path, capsys):
+    long_output = "x" * 500
+    lines = [
+        json.dumps(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "exec_command_end",
+                    "command": ["cat", "file"],
+                    "aggregated_output": long_output,
+                },
+            }
+        )
+    ]
+    session_file = tmp_path / "rollout-2026-01-01T10-00-00-wide.jsonl"
+    session_file.write_text("\n".join(lines) + "\n")
+
+    session = make_session("codex", session_file, id="wide")
+    pattern = re.compile(r"x{10}")
+    args = make_args(width=50)
+
+    codex.search_session(session, pattern, args)
+
+    captured = capsys.readouterr()
+    content_lines = [
+        l for l in captured.out.splitlines()
+        if l and not l.startswith("===") and not l.startswith("    ")
+    ]
+    for line in content_lines:
+        assert "..." in line or len(line) <= 60
+
+
+# ---------------------------------------------------------------------------
+# search_session — Claude (file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_search_session_finds_match_in_text(tmp_path, capsys):
+    session_file = tmp_path / "test-claude.jsonl"
+    session_file.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    session = make_session("claude", session_file, id="test-claude", cwd="/tmp/project")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    count = claude.search_session(session, pattern, args)
+
+    assert count >= 1
+    captured = capsys.readouterr()
+    assert "test-claude" in captured.out
+
+
+def test_claude_search_session_header_includes_agent_tag(tmp_path, capsys):
+    session_file = tmp_path / "test-claude.jsonl"
+    session_file.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    session = make_session("claude", session_file, id="test-claude", cwd="/tmp/project")
+    pattern = re.compile(r"foo")
+    args = make_args()
+
+    claude.search_session(session, pattern, args)
+
+    captured = capsys.readouterr()
+    assert "[claude]" in captured.out
+
+
+def test_claude_search_session_max_matches_one_stops_early(tmp_path, capsys):
+    lines = []
+    for i in range(5):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": f"foo bar iteration {i}"},
+                    "cwd": "/tmp",
+                    "sessionId": "s1",
+                    "timestamp": "2026-01-01T10:00:00Z",
+                    "uuid": f"u{i}",
+                }
+            )
+        )
+    session_file = tmp_path / "multi.jsonl"
+    session_file.write_text("\n".join(lines) + "\n")
+
+    session = make_session("claude", session_file, id="multi", cwd="/tmp")
+    pattern = re.compile(r"foo bar")
+    args = make_args(max_matches=1)
+
+    count = claude.search_session(session, pattern, args)
+
+    assert count == 1
+
+
+def test_claude_search_session_tool_use_block_is_searchable(tmp_path, capsys):
+    record = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "id": "t1",
+                    "input": {"command": "grep -r needle ."},
+                }
+            ],
+        },
+        "cwd": "/tmp",
+        "sessionId": "tc",
+        "timestamp": "2026-01-01T10:00:00Z",
+        "uuid": "u1",
+    }
+    session_file = tmp_path / "tool.jsonl"
+    session_file.write_text(json.dumps(record) + "\n")
+
+    session = make_session("claude", session_file, id="tc", cwd="/tmp")
+    pattern = re.compile(r"needle")
+    args = make_args()
+
+    count = claude.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+# ---------------------------------------------------------------------------
+# search_session — Gemini (file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_search_session_jsonl_finds_tool_call_name(tmp_path, capsys):
+    session_file = tmp_path / "session-test-gemini.jsonl"
+    session_file.write_text("\n".join(GEMINI_LINES) + "\n")
+
+    session = make_session("gemini", session_file, id="test-gemini", cwd="/tmp/project")
+    pattern = re.compile(r"read_file")
+    args = make_args()
+
+    count = gemini.search_session(session, pattern, args)
+
+    assert count >= 1
+    captured = capsys.readouterr()
+    assert "[gemini]" in captured.out
+
+
+def test_gemini_search_session_jsonl_finds_text_content(tmp_path, capsys):
+    session_file = tmp_path / "session-test-gemini.jsonl"
+    session_file.write_text("\n".join(GEMINI_LINES) + "\n")
+
+    session = make_session("gemini", session_file, id="test-gemini", cwd="/tmp/project")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    count = gemini.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+def test_gemini_search_session_jsonl_no_match_returns_zero(tmp_path, capsys):
+    session_file = tmp_path / "session-test-gemini.jsonl"
+    session_file.write_text("\n".join(GEMINI_LINES) + "\n")
+
+    session = make_session("gemini", session_file, id="test-gemini", cwd="/tmp/project")
+    pattern = re.compile(r"zzznomatch")
+    args = make_args()
+
+    count = gemini.search_session(session, pattern, args)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# search_session — Goose (SQLite-based)
+# ---------------------------------------------------------------------------
+
+
+def _make_goose_db(path: Path, session_id: str, content_json: str) -> None:
+    with sqlite3.connect(str(path)) as con:
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS sessions "
+            "(id TEXT PRIMARY KEY, name TEXT, working_dir TEXT, "
+            "created_at TEXT, updated_at TEXT)"
+        )
+        con.execute(
+            "INSERT INTO sessions VALUES (?, ?, ?, ?, ?)",
+            (session_id, "test session", "/tmp/project", "2026-01-01T10:00:00", "2026-01-01T10:00:00"),
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS messages "
+            "(id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, "
+            "content_json TEXT, created_timestamp TEXT)"
+        )
+        con.execute(
+            "INSERT INTO messages VALUES (1, ?, 'assistant', ?, '2026-01-01T10:00:00')",
+            (session_id, content_json),
+        )
+        con.commit()
+
+
+def test_goose_search_session_db_finds_text_content(tmp_path, capsys, monkeypatch):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "foo xyz bar found"}])
+    _make_goose_db(db_path, "goose-sess-001", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-sess-001", cwd="/tmp/project")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count >= 1
+    captured = capsys.readouterr()
+    assert "[goose]" in captured.out
+    assert "goose-sess-001" in captured.out
+
+
+def test_goose_search_session_db_regex_no_sql_like_prefilter(tmp_path, capsys, monkeypatch):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "foo xyz bar"}])
+    _make_goose_db(db_path, "goose-regex-001", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-regex-001", cwd="/tmp")
+    pattern = re.compile(r"foo.*bar")
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+def test_goose_search_session_db_no_match_returns_zero(tmp_path, capsys, monkeypatch):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "unrelated content"}])
+    _make_goose_db(db_path, "goose-nomatch", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-nomatch", cwd="/tmp")
+    pattern = re.compile(r"zzznomatch")
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count == 0
+
+
+def test_goose_search_session_db_max_matches_respected(tmp_path, capsys, monkeypatch):
+    db_path = tmp_path / "sessions.db"
+    with sqlite3.connect(str(db_path)) as con:
+        con.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, name TEXT, "
+            "working_dir TEXT, created_at TEXT, updated_at TEXT)"
+        )
+        con.execute(
+            "INSERT INTO sessions VALUES (?, 'name', '/tmp', '2026-01-01', '2026-01-01')",
+            ("goose-multi",),
+        )
+        con.execute(
+            "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, "
+            "role TEXT, content_json TEXT, created_timestamp TEXT)"
+        )
+        for i in range(5):
+            content = json.dumps([{"type": "text", "text": f"foo xyz bar row {i}"}])
+            con.execute(
+                "INSERT INTO messages VALUES (?, ?, 'assistant', ?, '2026-01-01')",
+                (i + 1, "goose-multi", content),
+            )
+        con.commit()
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-multi", cwd="/tmp")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args(max_matches=2)
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count == 2
+
+
+def test_goose_search_session_db_case_insensitive_flag(tmp_path, capsys, monkeypatch):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "FOO XYZ BAR"}])
+    _make_goose_db(db_path, "goose-ci-001", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-ci-001", cwd="/tmp")
+    pattern = re.compile(r"foo xyz bar", re.IGNORECASE)
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+# ---------------------------------------------------------------------------
+# search_session — Amp (file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_amp_search_session_finds_text_match(tmp_path, capsys):
+    session_file = tmp_path / "T-test.json"
+    session_file.write_text(json.dumps(AMP_DATA))
+
+    session = make_session("amp", session_file, id="T-test", title="test thread")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    count = amp.search_session(session, pattern, args)
+
+    assert count >= 1
+    captured = capsys.readouterr()
+    assert "[amp]" in captured.out
+    assert "T-test" in captured.out
+
+
+def test_amp_search_session_finds_tool_use_name(tmp_path, capsys):
+    data = {
+        "v": 1,
+        "id": "T-tool",
+        "created": 1704067200000,
+        "messages": [
+            {
+                "role": "assistant",
+                "messageId": 0,
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "1",
+                        "name": "GrepTool",
+                        "input": {"pattern": "needle"},
+                    }
+                ],
+                "meta": {"sentAt": 1704067200000},
+            }
+        ],
+        "title": "tool test",
+    }
+    session_file = tmp_path / "T-tool.json"
+    session_file.write_text(json.dumps(data))
+
+    session = make_session("amp", session_file, id="T-tool", title="tool test")
+    pattern = re.compile(r"GrepTool")
+    args = make_args()
+
+    count = amp.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+def test_amp_search_session_max_matches_one_stops_early(tmp_path, capsys):
+    data = {
+        "v": 1,
+        "id": "T-multi",
+        "created": 1704067200000,
+        "messages": [
+            {
+                "role": "user",
+                "messageId": i,
+                "content": [{"type": "text", "text": f"foo bar iteration {i}"}],
+                "meta": {"sentAt": 1704067200000 + i * 1000},
+            }
+            for i in range(5)
+        ],
+        "title": "multi",
+    }
+    session_file = tmp_path / "T-multi.json"
+    session_file.write_text(json.dumps(data))
+
+    session = make_session("amp", session_file, id="T-multi", title="multi")
+    pattern = re.compile(r"foo bar")
+    args = make_args(max_matches=1)
+
+    count = amp.search_session(session, pattern, args)
+
+    assert count == 1
+
+
+def test_amp_search_session_no_match_returns_zero(tmp_path, capsys):
+    session_file = tmp_path / "T-test.json"
+    session_file.write_text(json.dumps(AMP_DATA))
+
+    session = make_session("amp", session_file, id="T-test", title="test thread")
+    pattern = re.compile(r"zzznomatch")
+    args = make_args()
+
+    count = amp.search_session(session, pattern, args)
+
+    assert count == 0
+    captured = capsys.readouterr()
+    assert "[amp]" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# search_sessions dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_search_sessions_dispatcher_routes_to_correct_reader(tmp_path, capsys):
+    session_file = tmp_path / "test-claude.jsonl"
+    session_file.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    session = make_session("claude", session_file, id="test-claude", cwd="/tmp/project")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    total = readers.search_sessions([session], pattern, args)
+
+    assert total >= 1
+
+
+def test_search_sessions_dispatcher_aggregates_counts_across_sessions(tmp_path, capsys):
+    file1 = tmp_path / "claude1.jsonl"
+    file1.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    amp_file = tmp_path / "T-test.json"
+    amp_file.write_text(json.dumps(AMP_DATA))
+
+    sessions = [
+        make_session("claude", file1, id="c1", cwd="/tmp/project"),
+        make_session("amp", amp_file, id="T-test", title="test thread"),
+    ]
+    pattern = re.compile(r"foo")
+    args = make_args()
+
+    total = readers.search_sessions(sessions, pattern, args)
+
+    assert total >= 2
+
+
+def test_search_sessions_dispatcher_max_matches_stops_early(tmp_path, capsys):
+    lines = []
+    for i in range(10):
+        lines.append(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": f"foo bar hit {i}"},
+                    "cwd": "/tmp",
+                    "sessionId": "s1",
+                    "timestamp": "2026-01-01T10:00:00Z",
+                    "uuid": f"u{i}",
+                }
+            )
+        )
+    session_file = tmp_path / "multi.jsonl"
+    session_file.write_text("\n".join(lines) + "\n")
+
+    session = make_session("claude", session_file, id="multi", cwd="/tmp")
+    pattern = re.compile(r"foo bar hit")
+    args = make_args(max_matches=3)
+
+    total = readers.search_sessions([session], pattern, args)
+
+    assert total == 3
+
+
+def test_search_sessions_dispatcher_unknown_agent_skipped(tmp_path, capsys):
+    session = make_session("unknown_agent", tmp_path / "dummy.json", id="x")
+    pattern = re.compile(r"anything")
+    args = make_args()
+
+    total = readers.search_sessions([session], pattern, args)
+
+    assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# cmd_grep — CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_grep_returns_zero_on_match(tmp_path, monkeypatch, capsys):
+    session_file = tmp_path / "test-claude.jsonl"
+    session_file.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    session = make_session("claude", session_file, id="test-claude", cwd="/tmp/project")
+    monkeypatch.setattr(
+        readers,
+        "iter_all_sessions",
+        lambda _args: [session],
+    )
+
+    from session_search.__main__ import cmd_grep
+
+    args = make_args(
+        pattern=r"foo xyz bar",
+        id=None,
+        limit_sessions=25,
+        all_repos=True,
+    )
+    args.pattern = r"foo xyz bar"
+
+    result = cmd_grep(args)
+
+    assert result == 0
+
+
+def test_cmd_grep_returns_one_on_no_match(tmp_path, monkeypatch, capsys):
+    session_file = tmp_path / "test-claude.jsonl"
+    session_file.write_text("\n".join(CLAUDE_LINES) + "\n")
+
+    session = make_session("claude", session_file, id="test-claude", cwd="/tmp/project")
+    monkeypatch.setattr(
+        readers,
+        "iter_all_sessions",
+        lambda _args: [session],
+    )
+
+    from session_search.__main__ import cmd_grep
+
+    args = make_args(
+        pattern=r"zzznomatch",
+        id=None,
+        limit_sessions=25,
+        all_repos=True,
+    )
+    args.pattern = r"zzznomatch"
+
+    result = cmd_grep(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    assert "No matches" in captured.out
+
+
+def test_cmd_grep_returns_two_on_invalid_regex(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(readers, "iter_all_sessions", lambda _args: [])
+
+    from session_search.__main__ import cmd_grep
+
+    args = make_args(
+        pattern=r"[invalid(",
+        id=None,
+        limit_sessions=25,
+        all_repos=True,
+    )
+    args.pattern = r"[invalid("
+
+    result = cmd_grep(args)
+
+    assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# Regex correctness — critical fix verification
+# ---------------------------------------------------------------------------
+
+
+def test_goose_regex_foo_star_bar_matches_foo_xyz_bar(tmp_path, monkeypatch, capsys):
+    """Verify regex is applied directly without SQL LIKE prefilter."""
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "foo xyz bar"}])
+    _make_goose_db(db_path, "goose-regex-fix", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-regex-fix", cwd="/tmp")
+    pattern = re.compile(r"foo.*bar")
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+def test_goose_regex_case_insensitive_matches_uppercase(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "NEEDLE in haystack"}])
+    _make_goose_db(db_path, "goose-ci-needle", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-ci-needle", cwd="/tmp")
+    pattern = re.compile(r"needle", re.IGNORECASE)
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count >= 1
+
+
+def test_goose_regex_does_not_match_partial_without_wildcard(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "sessions.db"
+    content = json.dumps([{"type": "text", "text": "foo baz bar"}])
+    _make_goose_db(db_path, "goose-partial", content)
+
+    monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    session = make_session("goose", db_path, id="goose-partial", cwd="/tmp")
+    pattern = re.compile(r"foo xyz bar")
+    args = make_args()
+
+    count = goose.search_session(session, pattern, args)
+
+    assert count == 0

--- a/tests/unit/test_session_search_readers.py
+++ b/tests/unit/test_session_search_readers.py
@@ -1,0 +1,1066 @@
+"""Unit tests for session_search reader modules (codex, claude, gemini, goose, amp)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[2] / "src" / "ai_rules" / "config" / "skills" / "session-search" / "scripts"),
+)
+
+import pytest
+
+from session_search.readers import amp, claude, codex, gemini, goose
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "cwd": None,
+        "repo": None,
+        "all_repos": True,
+        "since": None,
+        "until": None,
+        "limit": 0,
+        "max_matches": 0,
+        "width": 280,
+        "agent": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Codex reader tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCodexReader:
+    def test_codex_detect_returns_false_when_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / "nonexistent"))
+
+        assert codex.detect() is False
+
+    def test_codex_detect_returns_true_when_sessions_dir_exists(self, tmp_path, monkeypatch):
+        (tmp_path / "sessions").mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+        assert codex.detect() is True
+
+    def test_codex_detect_returns_true_when_archived_sessions_dir_exists(self, tmp_path, monkeypatch):
+        (tmp_path / "archived_sessions").mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+        assert codex.detect() is True
+
+    def test_codex_iter_sessions_finds_session_with_meta(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        sessions_dir = tmp_path / "sessions" / "2026" / "01" / "01"
+        sessions_dir.mkdir(parents=True)
+
+        session_file = sessions_dir / "rollout-2026-01-01T10-00-00-abc123ef.jsonl"
+        session_meta = {
+            "type": "session_meta",
+            "payload": {
+                "id": "abc123ef",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "cwd": "/home/user/myproject",
+                "agent_role": "coder",
+                "agent_nickname": "hal",
+            },
+        }
+        response_item = {
+            "type": "response_item",
+            "payload": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello from codex"}],
+            },
+        }
+        session_file.write_text(
+            json.dumps(session_meta) + "\n" + json.dumps(response_item) + "\n"
+        )
+
+        index_entry = {"id": "abc123ef", "thread_name": "My Thread", "updated_at": "2026-01-01T10:05:00Z"}
+        (tmp_path / "session_index.jsonl").write_text(json.dumps(index_entry) + "\n")
+
+        sessions = codex.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.id == "abc123ef"
+        assert s.cwd == "/home/user/myproject"
+        assert s.title == "My Thread"
+        assert s.agent == "codex"
+
+    def test_codex_iter_sessions_falls_back_to_filename_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        session_file = sessions_dir / "rollout-2026-03-15T08-30-00-deadbeef.jsonl"
+        session_file.write_text("{}\n")
+
+        sessions = codex.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].id == "deadbeef"
+
+    def test_codex_iter_search_text_response_item_yields_text(self):
+        record = {
+            "type": "response_item",
+            "payload": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "important output"}],
+            },
+        }
+
+        texts = list(codex.iter_search_text(record, ""))
+
+        assert "important output" in texts
+
+    def test_codex_iter_search_text_session_meta_yields_fields(self):
+        record = {
+            "type": "session_meta",
+            "payload": {
+                "id": "abc123",
+                "cwd": "/some/path",
+                "agent_role": "coder",
+                "agent_nickname": "",
+            },
+        }
+
+        texts = list(codex.iter_search_text(record, ""))
+
+        assert "abc123" in texts
+        assert "/some/path" in texts
+        assert "coder" in texts
+
+    def test_codex_iter_search_text_response_item_also_yields_name_and_output(self):
+        record = {
+            "type": "response_item",
+            "payload": {
+                "name": "my_tool",
+                "arguments": '{"x": 1}',
+                "output": "tool ran",
+            },
+        }
+
+        texts = list(codex.iter_search_text(record, ""))
+
+        assert "my_tool" in texts
+        assert "tool ran" in texts
+
+    def test_codex_iter_search_text_skips_unknown_type(self):
+        record = {"type": "unknown_type", "payload": {"data": "hidden"}}
+
+        texts = list(codex.iter_search_text(record, "raw line"))
+
+        assert texts == []
+
+    def test_codex_display_text_session_meta_returns_json(self):
+        record = {
+            "type": "session_meta",
+            "payload": {
+                "id": "abc",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "cwd": "/foo",
+                "originator": "user",
+                "agent_role": "coder",
+                "agent_nickname": "bot",
+            },
+        }
+
+        result = codex.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["id"] == "abc"
+        assert parsed["cwd"] == "/foo"
+
+    def test_codex_display_text_response_item_returns_role_and_text(self):
+        record = {
+            "type": "response_item",
+            "payload": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        }
+
+        result = codex.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "assistant"
+        assert "hello" in parsed["text"]
+
+    def test_codex_display_text_unknown_type_returns_raw(self):
+        raw = '{"type": "unknown"}'
+        record = json.loads(raw)
+
+        result = codex.display_text(record, raw)
+
+        assert result == raw
+
+    def test_codex_iter_sessions_empty_dir_returns_no_sessions(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        (tmp_path / "sessions").mkdir()
+
+        sessions = codex.iter_sessions(_args())
+
+        assert sessions == []
+
+    def test_codex_iter_sessions_skips_corrupt_json_lines(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        session_file = sessions_dir / "rollout-2026-01-01T10-00-00-aabbccdd.jsonl"
+        session_file.write_text("NOT VALID JSON\n{\"also\": bad}\n")
+
+        sessions = codex.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].id == "aabbccdd"
+
+
+# ---------------------------------------------------------------------------
+# Claude reader tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClaudeReader:
+    def test_claude_detect_returns_false_when_no_projects_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "nonexistent"))
+
+        assert claude.detect() is False
+
+    def test_claude_detect_returns_true_when_projects_dir_exists(self, tmp_path, monkeypatch):
+        (tmp_path / "projects").mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+        assert claude.detect() is True
+
+    def test_claude_iter_sessions_finds_session_with_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        project_dir = tmp_path / "projects" / "-test-project"
+        project_dir.mkdir(parents=True)
+
+        session_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        session_file = project_dir / f"{session_uuid}.jsonl"
+
+        user_record = {
+            "type": "user",
+            "cwd": "/home/user/test-project",
+            "message": {"content": "hello"},
+        }
+        ai_title_record = {"type": "ai-title", "aiTitle": "My session title"}
+        session_file.write_text(
+            json.dumps(user_record) + "\n" + json.dumps(ai_title_record) + "\n"
+        )
+
+        sessions = claude.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.id == session_uuid
+        assert s.cwd == "/home/user/test-project"
+        assert s.title == "My session title"
+
+    def test_claude_iter_sessions_hint_score_for_matching_repo_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        project_dir = tmp_path / "projects" / "-home-user-my-repo"
+        project_dir.mkdir(parents=True)
+
+        session_file = project_dir / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"
+        user_record = {"type": "user", "cwd": "/home/user/my-repo", "message": {"content": "hi"}}
+        session_file.write_text(json.dumps(user_record) + "\n")
+
+        sessions = claude.iter_sessions(_args(repo="my-repo"))
+
+        assert len(sessions) == 1
+
+    def test_claude_iter_sessions_returns_empty_for_empty_projects_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+        (tmp_path / "projects").mkdir()
+
+        sessions = claude.iter_sessions(_args())
+
+        assert sessions == []
+
+    def test_claude_iter_search_text_user_string_content(self):
+        record = {
+            "type": "user",
+            "message": {"content": "what is the meaning of life?"},
+        }
+
+        texts = list(claude.iter_search_text(record, ""))
+
+        assert "what is the meaning of life?" in texts
+
+    def test_claude_iter_search_text_user_list_content(self):
+        record = {
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": "block content"}]},
+        }
+
+        texts = list(claude.iter_search_text(record, ""))
+
+        assert "block content" in texts
+
+    def test_claude_iter_search_text_assistant_text_block(self):
+        record = {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "assistant reply here"}]
+            },
+        }
+
+        texts = list(claude.iter_search_text(record, ""))
+
+        assert "assistant reply here" in texts
+
+    def test_claude_iter_search_text_assistant_tool_use_block(self):
+        record = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "bash", "input": {"command": "ls"}}
+                ]
+            },
+        }
+
+        texts = list(claude.iter_search_text(record, ""))
+
+        combined = " ".join(texts)
+        assert "bash" in combined
+        assert "ls" in combined
+
+    def test_claude_iter_search_text_skips_unknown_type(self):
+        record = {"type": "system", "data": "should be ignored"}
+
+        texts = list(claude.iter_search_text(record, ""))
+
+        assert texts == []
+
+    def test_claude_display_text_user_record(self):
+        record = {
+            "type": "user",
+            "message": {"content": "my question"},
+        }
+
+        result = claude.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "user"
+        assert "my question" in parsed["text"]
+
+    def test_claude_display_text_assistant_text_block(self):
+        record = {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "my answer"}]
+            },
+        }
+
+        result = claude.display_text(record, "")
+
+        assert "assistant" in result
+        assert "my answer" in result
+
+    def test_claude_display_text_assistant_tool_use_block(self):
+        record = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "read_file", "input": {"path": "/etc/hosts"}}
+                ]
+            },
+        }
+
+        result = claude.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "assistant"
+        assert parsed["tool"] == "read_file"
+
+    def test_claude_display_text_unknown_type_returns_raw(self):
+        raw = '{"type": "other", "x": 1}'
+        record = json.loads(raw)
+
+        result = claude.display_text(record, raw)
+
+        assert result == raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Gemini reader tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGeminiReader:
+    def _gemini_home(self, tmp_path):
+        return tmp_path / "gemini_home"
+
+    def _patch_home(self, monkeypatch, tmp_path):
+        home = self._gemini_home(tmp_path)
+        (home / ".gemini" / "tmp").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        return home
+
+    def test_gemini_detect_returns_false_when_no_tmp_dir(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "empty_home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        assert gemini.detect() is False
+
+    def test_gemini_detect_returns_true_when_tmp_dir_exists(self, tmp_path, monkeypatch):
+        self._patch_home(monkeypatch, tmp_path)
+
+        assert gemini.detect() is True
+
+    def test_gemini_iter_sessions_finds_jsonl_session(self, tmp_path, monkeypatch):
+        home = self._patch_home(monkeypatch, tmp_path)
+        slug = "my-project-slug"
+        chats_dir = home / ".gemini" / "tmp" / slug / "chats"
+        chats_dir.mkdir(parents=True)
+
+        session_file = chats_dir / "session-2026-01-01T10-00-abcd1234.jsonl"
+        first_line = {
+            "sessionId": "abcd1234-session",
+            "startTime": "2026-01-01T10:00:00Z",
+            "lastUpdated": "2026-01-01T10:30:00Z",
+        }
+        user_line = {"type": "user", "content": "What is this?"}
+        gemini_line = {"type": "gemini", "content": "This is a thing."}
+        session_file.write_text(
+            json.dumps(first_line) + "\n"
+            + json.dumps(user_line) + "\n"
+            + json.dumps(gemini_line) + "\n"
+        )
+
+        projects_json = home / ".gemini" / "projects.json"
+        projects_json.write_text(json.dumps({"projects": {"/home/user/my-project": slug}}))
+
+        sessions = gemini.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.id == "abcd1234-session"
+        assert s.cwd == "/home/user/my-project"
+        assert s.agent == "gemini"
+
+    def test_gemini_iter_sessions_finds_legacy_json_session(self, tmp_path, monkeypatch):
+        home = self._patch_home(monkeypatch, tmp_path)
+        slug = "legacy-slug"
+        chats_dir = home / ".gemini" / "tmp" / slug / "chats"
+        chats_dir.mkdir(parents=True)
+
+        legacy_file = chats_dir / "session-legacy.json"
+        legacy_data = {
+            "history": [
+                {"role": "user", "parts": [{"text": "hello"}]},
+                {"role": "model", "parts": [{"text": "world"}]},
+            ]
+        }
+        legacy_file.write_text(json.dumps(legacy_data))
+
+        sessions = gemini.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.id == "session-legacy"
+        assert s.agent == "gemini"
+
+    def test_gemini_iter_sessions_skips_slug_dir_without_chats(self, tmp_path, monkeypatch):
+        home = self._patch_home(monkeypatch, tmp_path)
+        (home / ".gemini" / "tmp" / "bare-slug").mkdir(parents=True)
+
+        sessions = gemini.iter_sessions(_args())
+
+        assert sessions == []
+
+    def test_gemini_iter_search_text_user_record(self):
+        record = {"type": "user", "content": "search query text"}
+
+        texts = list(gemini.iter_search_text(record, ""))
+
+        assert "search query text" in texts
+
+    def test_gemini_iter_search_text_gemini_record_content(self):
+        record = {"type": "gemini", "content": "model response text"}
+
+        texts = list(gemini.iter_search_text(record, ""))
+
+        assert "model response text" in texts
+
+    def test_gemini_iter_search_text_gemini_record_thoughts(self):
+        record = {
+            "type": "gemini",
+            "content": "",
+            "thoughts": [{"text": "internal reasoning"}],
+        }
+
+        texts = list(gemini.iter_search_text(record, ""))
+
+        assert "internal reasoning" in texts
+
+    def test_gemini_iter_search_text_gemini_record_tool_calls(self):
+        record = {
+            "type": "gemini",
+            "content": "",
+            "toolCalls": [{"name": "search_web", "args": {"query": "python"}}],
+        }
+
+        texts = list(gemini.iter_search_text(record, ""))
+
+        combined = " ".join(texts)
+        assert "search_web" in combined
+        assert "python" in combined
+
+    def test_gemini_iter_search_text_skips_unknown_type(self):
+        record = {"type": "metadata", "data": "ignored"}
+
+        texts = list(gemini.iter_search_text(record, ""))
+
+        assert texts == []
+
+    def test_gemini_display_text_user_record(self):
+        record = {"type": "user", "content": "my input"}
+
+        result = gemini.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "user"
+        assert parsed["text"] == "my input"
+
+    def test_gemini_display_text_gemini_record_no_tools(self):
+        record = {"type": "gemini", "content": "my reply"}
+
+        result = gemini.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "gemini"
+        assert parsed["text"] == "my reply"
+
+    def test_gemini_display_text_gemini_record_with_tool_calls(self):
+        record = {
+            "type": "gemini",
+            "content": "",
+            "toolCalls": [{"name": "run_code", "args": {"lang": "py"}}],
+        }
+
+        result = gemini.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert "toolCalls" in parsed
+        assert parsed["toolCalls"][0]["name"] == "run_code"
+
+    def test_gemini_display_text_unknown_type_returns_raw(self):
+        raw = '{"type": "unknown", "val": 42}'
+        record = json.loads(raw)
+
+        result = gemini.display_text(record, raw)
+
+        assert result == raw
+
+    def test_gemini_iter_sessions_empty_chats_dir_returns_no_sessions(self, tmp_path, monkeypatch):
+        home = self._patch_home(monkeypatch, tmp_path)
+        chats_dir = home / ".gemini" / "tmp" / "some-slug" / "chats"
+        chats_dir.mkdir(parents=True)
+
+        sessions = gemini.iter_sessions(_args())
+
+        assert sessions == []
+
+
+# ---------------------------------------------------------------------------
+# Goose reader tests
+# ---------------------------------------------------------------------------
+
+
+def _create_goose_db(db_path: Path) -> None:
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        "CREATE TABLE sessions ("
+        "id TEXT PRIMARY KEY, "
+        "name TEXT DEFAULT '', "
+        "working_dir TEXT NOT NULL, "
+        "created_at TIMESTAMP, "
+        "updated_at TIMESTAMP, "
+        "provider_name TEXT, "
+        "goose_mode TEXT DEFAULT 'auto'"
+        ")"
+    )
+    con.execute(
+        "CREATE TABLE messages ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "session_id TEXT NOT NULL, "
+        "role TEXT NOT NULL, "
+        "content_json TEXT NOT NULL, "
+        "created_timestamp INTEGER NOT NULL"
+        ")"
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.mark.unit
+class TestGooseReader:
+    def _patch_db(self, monkeypatch, db_path: Path) -> None:
+        monkeypatch.setattr(goose, "_db_path", lambda: db_path)
+
+    def _patch_legacy(self, monkeypatch, legacy_dir: Path) -> None:
+        monkeypatch.setattr(goose, "_legacy_dir", lambda: legacy_dir)
+
+    def test_goose_detect_returns_false_when_neither_source_exists(self, tmp_path, monkeypatch):
+        self._patch_db(monkeypatch, tmp_path / "nonexistent.db")
+        self._patch_legacy(monkeypatch, tmp_path / "nonexistent_dir")
+
+        assert goose.detect() is False
+
+    def test_goose_detect_returns_true_when_db_exists(self, tmp_path, monkeypatch):
+        db = tmp_path / "sessions.db"
+        _create_goose_db(db)
+        self._patch_db(monkeypatch, db)
+        self._patch_legacy(monkeypatch, tmp_path / "nonexistent_dir")
+
+        assert goose.detect() is True
+
+    def test_goose_detect_returns_true_when_legacy_jsonl_exists(self, tmp_path, monkeypatch):
+        legacy_dir = tmp_path / "legacy"
+        legacy_dir.mkdir()
+        (legacy_dir / "session.jsonl").write_text("{}\n")
+        self._patch_db(monkeypatch, tmp_path / "nonexistent.db")
+        self._patch_legacy(monkeypatch, legacy_dir)
+
+        assert goose.detect() is True
+
+    def test_goose_iter_sessions_reads_from_sqlite(self, tmp_path, monkeypatch):
+        db = tmp_path / "sessions.db"
+        _create_goose_db(db)
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO sessions (id, name, working_dir, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("sess-1", "My Session", "/home/user/project", "2026-01-01T10:00:00", "2026-01-01T11:00:00"),
+        )
+        con.commit()
+        con.close()
+
+        self._patch_db(monkeypatch, db)
+        legacy_dir = tmp_path / "no_legacy"
+        self._patch_legacy(monkeypatch, legacy_dir)
+
+        sessions = goose.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.id == "sess-1"
+        assert s.cwd == "/home/user/project"
+        assert s.title == "My Session"
+        assert s.agent == "goose"
+
+    def test_goose_iter_sessions_prefers_sqlite_over_legacy(self, tmp_path, monkeypatch):
+        db = tmp_path / "sessions.db"
+        _create_goose_db(db)
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO sessions (id, name, working_dir, created_at) VALUES (?, ?, ?, ?)",
+            ("db-session", "DB Session", "/db/path", "2026-01-01T10:00:00"),
+        )
+        con.commit()
+        con.close()
+
+        legacy_dir = tmp_path / "legacy"
+        legacy_dir.mkdir()
+        meta = {"id": "legacy-session", "working_dir": "/legacy/path", "description": "Old"}
+        (legacy_dir / "old.jsonl").write_text(json.dumps(meta) + "\n")
+
+        self._patch_db(monkeypatch, db)
+        self._patch_legacy(monkeypatch, legacy_dir)
+
+        sessions = goose.iter_sessions(_args())
+
+        ids = [s.id for s in sessions]
+        assert "db-session" in ids
+        assert "legacy-session" not in ids
+
+    def test_goose_iter_sessions_reads_legacy_when_no_sqlite(self, tmp_path, monkeypatch):
+        self._patch_db(monkeypatch, tmp_path / "nonexistent.db")
+
+        legacy_dir = tmp_path / "legacy"
+        legacy_dir.mkdir()
+        meta = {"id": "legacy-abc", "working_dir": "/some/path", "description": "Legacy title"}
+        (legacy_dir / "legacy-abc.jsonl").write_text(json.dumps(meta) + "\n")
+        self._patch_legacy(monkeypatch, legacy_dir)
+
+        sessions = goose.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].id == "legacy-abc"
+        assert sessions[0].title == "Legacy title"
+
+    def test_goose_iter_search_text_text_block(self):
+        record = {
+            "role": "user",
+            "content_json_parsed": [{"type": "text", "text": "user message"}],
+        }
+
+        texts = list(goose.iter_search_text(record, ""))
+
+        assert "user message" in texts
+
+    def test_goose_iter_search_text_tool_request_block(self):
+        record = {
+            "role": "assistant",
+            "content_json_parsed": [
+                {
+                    "type": "toolRequest",
+                    "toolCall": {
+                        "Ok": {"name": "bash", "arguments": {"command": "echo hi"}}
+                    },
+                }
+            ],
+        }
+
+        texts = list(goose.iter_search_text(record, ""))
+
+        combined = " ".join(texts)
+        assert "bash" in combined
+        assert "echo hi" in combined
+
+    def test_goose_iter_search_text_tool_response_block(self):
+        record = {
+            "role": "tool",
+            "content_json_parsed": [
+                {
+                    "type": "toolResponse",
+                    "toolResult": {
+                        "Ok": [{"text": "command output here"}]
+                    },
+                }
+            ],
+        }
+
+        texts = list(goose.iter_search_text(record, ""))
+
+        assert "command output here" in texts
+
+    def test_goose_iter_search_text_thinking_block(self):
+        record = {
+            "role": "assistant",
+            "content_json_parsed": [{"type": "thinking", "thinking": "deep thoughts"}],
+        }
+
+        texts = list(goose.iter_search_text(record, ""))
+
+        assert "deep thoughts" in texts
+
+    def test_goose_iter_search_text_empty_blocks(self):
+        record = {"role": "user", "content_json_parsed": []}
+
+        texts = list(goose.iter_search_text(record, ""))
+
+        assert texts == []
+
+    def test_goose_display_text_text_block(self):
+        record = {
+            "role": "user",
+            "content_json_parsed": [{"type": "text", "text": "my text"}],
+        }
+
+        result = goose.display_text(record, "")
+
+        assert "user" in result
+        assert "my text" in result
+
+    def test_goose_display_text_tool_request_block(self):
+        record = {
+            "role": "assistant",
+            "content_json_parsed": [
+                {
+                    "type": "toolRequest",
+                    "toolCall": {"Ok": {"name": "list_files", "arguments": {}}},
+                }
+            ],
+        }
+
+        result = goose.display_text(record, "")
+        parts = result.split(" | ")
+        parsed = json.loads(parts[0])
+
+        assert parsed["tool"] == "list_files"
+
+    def test_goose_display_text_tool_response_block(self):
+        record = {
+            "role": "tool",
+            "content_json_parsed": [
+                {
+                    "type": "toolResponse",
+                    "toolResult": {"Ok": [{"text": "file list here"}]},
+                }
+            ],
+        }
+
+        result = goose.display_text(record, "")
+
+        assert "file list here" in result
+
+    def test_goose_display_text_no_blocks_returns_raw(self):
+        raw = "raw fallback"
+        record = {"role": "user", "content_json_parsed": []}
+
+        result = goose.display_text(record, raw)
+
+        assert result == raw
+
+
+# ---------------------------------------------------------------------------
+# Amp reader tests
+# ---------------------------------------------------------------------------
+
+
+def _make_amp_thread(tmp_path: Path, thread_id: str, **overrides) -> Path:
+    threads_dir = tmp_path / ".local" / "share" / "amp" / "threads"
+    threads_dir.mkdir(parents=True, exist_ok=True)
+
+    data: dict = {
+        "id": thread_id,
+        "v": 1,
+        "title": "Test session",
+        "created": 1735689600000,
+        "env": {
+            "initial": json.dumps(
+                {"trees": [{"uri": "file:///home/user/test-repo"}]}
+            )
+        },
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello amp"}],
+                "meta": {"sentAt": 1735689660000},
+            }
+        ],
+    }
+    data.update(overrides)
+
+    path = threads_dir / f"T-{thread_id}.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.mark.unit
+class TestAmpReader:
+    def _patch_threads_dir(self, monkeypatch, tmp_path: Path) -> Path:
+        threads_dir = tmp_path / ".local" / "share" / "amp" / "threads"
+        threads_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(amp, "_AMP_THREADS", threads_dir)
+        return threads_dir
+
+    def test_amp_detect_returns_false_when_no_threads_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(amp, "_AMP_THREADS", tmp_path / "nonexistent")
+
+        assert amp.detect() is False
+
+    def test_amp_detect_returns_true_when_threads_dir_exists(self, tmp_path, monkeypatch):
+        threads_dir = self._patch_threads_dir(monkeypatch, tmp_path)
+
+        assert amp.detect() is True
+
+    def test_amp_iter_sessions_extracts_cwd_from_env_initial(self, tmp_path, monkeypatch):
+        self._patch_threads_dir(monkeypatch, tmp_path)
+        _make_amp_thread(tmp_path, "test-uuid-001")
+
+        sessions = amp.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        s = sessions[0]
+        assert s.cwd == "/home/user/test-repo"
+        assert s.title == "Test session"
+        assert s.agent == "amp"
+
+    def test_amp_iter_sessions_graceful_fallback_when_env_missing(self, tmp_path, monkeypatch):
+        self._patch_threads_dir(monkeypatch, tmp_path)
+        path = _make_amp_thread(tmp_path, "no-env-uuid")
+
+        data = json.loads(path.read_text())
+        del data["env"]
+        path.write_text(json.dumps(data))
+
+        sessions = amp.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].cwd == ""
+
+    def test_amp_iter_sessions_graceful_fallback_when_title_null(self, tmp_path, monkeypatch):
+        self._patch_threads_dir(monkeypatch, tmp_path)
+        path = _make_amp_thread(tmp_path, "null-title-uuid")
+
+        data = json.loads(path.read_text())
+        data["title"] = None
+        path.write_text(json.dumps(data))
+
+        sessions = amp.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].title == ""
+
+    def test_amp_iter_sessions_graceful_with_empty_messages_array(self, tmp_path, monkeypatch):
+        self._patch_threads_dir(monkeypatch, tmp_path)
+        path = _make_amp_thread(tmp_path, "empty-msgs-uuid")
+
+        data = json.loads(path.read_text())
+        data["messages"] = []
+        path.write_text(json.dumps(data))
+
+        sessions = amp.iter_sessions(_args())
+
+        assert len(sessions) == 1
+        assert sessions[0].id == "empty-msgs-uuid"
+
+    def test_amp_iter_sessions_skips_corrupt_json_file(self, tmp_path, monkeypatch):
+        threads_dir = self._patch_threads_dir(monkeypatch, tmp_path)
+        (threads_dir / "T-bad-file.json").write_text("not valid json {{{")
+
+        sessions = amp.iter_sessions(_args())
+
+        assert sessions == []
+
+    def test_amp_iter_sessions_returns_empty_for_empty_threads_dir(self, tmp_path, monkeypatch):
+        self._patch_threads_dir(monkeypatch, tmp_path)
+
+        sessions = amp.iter_sessions(_args())
+
+        assert sessions == []
+
+    def test_amp_iter_search_text_text_block(self):
+        record = {
+            "role": "user",
+            "content": [{"type": "text", "text": "user message"}],
+        }
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        assert "user message" in texts
+
+    def test_amp_iter_search_text_tool_use_block(self):
+        record = {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": "bash", "input": {"command": "pwd"}}
+            ],
+        }
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        combined = " ".join(texts)
+        assert "bash" in combined
+        assert "pwd" in combined
+
+    def test_amp_iter_search_text_tool_result_block(self):
+        record = {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [{"text": "output text here"}],
+                }
+            ],
+        }
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        assert "output text here" in texts
+
+    def test_amp_iter_search_text_thinking_block(self):
+        record = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "chain of thought"}],
+        }
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        assert "chain of thought" in texts
+
+    def test_amp_iter_search_text_empty_content(self):
+        record = {"role": "user", "content": []}
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        assert texts == []
+
+    def test_amp_iter_search_text_non_list_content_returns_empty(self):
+        record = {"role": "user", "content": "plain string"}
+
+        texts = list(amp.iter_search_text(record, ""))
+
+        assert texts == []
+
+    def test_amp_display_text_text_block(self):
+        record = {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello world"}],
+        }
+
+        result = amp.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "user"
+        assert parsed["text"] == "hello world"
+
+    def test_amp_display_text_tool_use_block(self):
+        record = {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": "read_file", "input": {"path": "/foo.txt"}}
+            ],
+        }
+
+        result = amp.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "assistant"
+        assert parsed["tool"] == "read_file"
+
+    def test_amp_display_text_tool_result_block(self):
+        record = {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [{"text": "result content"}],
+                }
+            ],
+        }
+
+        result = amp.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert "tool_result" in parsed
+
+    def test_amp_display_text_empty_content_returns_role_only(self):
+        record = {"role": "system", "content": []}
+
+        result = amp.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "system"
+
+    def test_amp_display_text_non_list_content_returns_role_only(self):
+        record = {"role": "user", "content": None}
+
+        result = amp.display_text(record, "")
+        parsed = json.loads(result)
+
+        assert parsed["role"] == "user"

--- a/tests/unit/test_session_search_readers.py
+++ b/tests/unit/test_session_search_readers.py
@@ -6,24 +6,33 @@ import argparse
 import json
 import sqlite3
 import sys
+
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(
     0,
-    str(Path(__file__).resolve().parents[2] / "src" / "ai_rules" / "config" / "skills" / "session-search" / "scripts"),
+    str(
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "ai_rules"
+        / "config"
+        / "skills"
+        / "session-search"
+        / "scripts"
+    ),
 )
 
 import pytest
 
 from session_search.readers import amp, claude, codex, gemini, goose
 
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 
 
-def _args(**kwargs) -> argparse.Namespace:
+def _args(**kwargs: Any) -> argparse.Namespace:
     defaults = {
         "cwd": None,
         "repo": None,
@@ -51,13 +60,17 @@ class TestCodexReader:
 
         assert codex.detect() is False
 
-    def test_codex_detect_returns_true_when_sessions_dir_exists(self, tmp_path, monkeypatch):
+    def test_codex_detect_returns_true_when_sessions_dir_exists(
+        self, tmp_path, monkeypatch
+    ):
         (tmp_path / "sessions").mkdir()
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
         assert codex.detect() is True
 
-    def test_codex_detect_returns_true_when_archived_sessions_dir_exists(self, tmp_path, monkeypatch):
+    def test_codex_detect_returns_true_when_archived_sessions_dir_exists(
+        self, tmp_path, monkeypatch
+    ):
         (tmp_path / "archived_sessions").mkdir()
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
@@ -90,7 +103,11 @@ class TestCodexReader:
             json.dumps(session_meta) + "\n" + json.dumps(response_item) + "\n"
         )
 
-        index_entry = {"id": "abc123ef", "thread_name": "My Thread", "updated_at": "2026-01-01T10:05:00Z"}
+        index_entry = {
+            "id": "abc123ef",
+            "thread_name": "My Thread",
+            "updated_at": "2026-01-01T10:05:00Z",
+        }
         (tmp_path / "session_index.jsonl").write_text(json.dumps(index_entry) + "\n")
 
         sessions = codex.iter_sessions(_args())
@@ -209,7 +226,9 @@ class TestCodexReader:
 
         assert result == raw
 
-    def test_codex_iter_sessions_empty_dir_returns_no_sessions(self, tmp_path, monkeypatch):
+    def test_codex_iter_sessions_empty_dir_returns_no_sessions(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("CODEX_HOME", str(tmp_path))
         (tmp_path / "sessions").mkdir()
 
@@ -223,7 +242,7 @@ class TestCodexReader:
         sessions_dir.mkdir()
 
         session_file = sessions_dir / "rollout-2026-01-01T10-00-00-aabbccdd.jsonl"
-        session_file.write_text("NOT VALID JSON\n{\"also\": bad}\n")
+        session_file.write_text('NOT VALID JSON\n{"also": bad}\n')
 
         sessions = codex.iter_sessions(_args())
 
@@ -238,12 +257,16 @@ class TestCodexReader:
 
 @pytest.mark.unit
 class TestClaudeReader:
-    def test_claude_detect_returns_false_when_no_projects_dir(self, tmp_path, monkeypatch):
+    def test_claude_detect_returns_false_when_no_projects_dir(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "nonexistent"))
 
         assert claude.detect() is False
 
-    def test_claude_detect_returns_true_when_projects_dir_exists(self, tmp_path, monkeypatch):
+    def test_claude_detect_returns_true_when_projects_dir_exists(
+        self, tmp_path, monkeypatch
+    ):
         (tmp_path / "projects").mkdir()
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
 
@@ -275,20 +298,28 @@ class TestClaudeReader:
         assert s.cwd == "/home/user/test-project"
         assert s.title == "My session title"
 
-    def test_claude_iter_sessions_hint_score_for_matching_repo_name(self, tmp_path, monkeypatch):
+    def test_claude_iter_sessions_hint_score_for_matching_repo_name(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
         project_dir = tmp_path / "projects" / "-home-user-my-repo"
         project_dir.mkdir(parents=True)
 
         session_file = project_dir / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl"
-        user_record = {"type": "user", "cwd": "/home/user/my-repo", "message": {"content": "hi"}}
+        user_record = {
+            "type": "user",
+            "cwd": "/home/user/my-repo",
+            "message": {"content": "hi"},
+        }
         session_file.write_text(json.dumps(user_record) + "\n")
 
         sessions = claude.iter_sessions(_args(repo="my-repo"))
 
         assert len(sessions) == 1
 
-    def test_claude_iter_sessions_returns_empty_for_empty_projects_dir(self, tmp_path, monkeypatch):
+    def test_claude_iter_sessions_returns_empty_for_empty_projects_dir(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
         (tmp_path / "projects").mkdir()
 
@@ -319,9 +350,7 @@ class TestClaudeReader:
     def test_claude_iter_search_text_assistant_text_block(self):
         record = {
             "type": "assistant",
-            "message": {
-                "content": [{"type": "text", "text": "assistant reply here"}]
-            },
+            "message": {"content": [{"type": "text", "text": "assistant reply here"}]},
         }
 
         texts = list(claude.iter_search_text(record, ""))
@@ -366,9 +395,7 @@ class TestClaudeReader:
     def test_claude_display_text_assistant_text_block(self):
         record = {
             "type": "assistant",
-            "message": {
-                "content": [{"type": "text", "text": "my answer"}]
-            },
+            "message": {"content": [{"type": "text", "text": "my answer"}]},
         }
 
         result = claude.display_text(record, "")
@@ -381,7 +408,11 @@ class TestClaudeReader:
             "type": "assistant",
             "message": {
                 "content": [
-                    {"type": "tool_use", "name": "read_file", "input": {"path": "/etc/hosts"}}
+                    {
+                        "type": "tool_use",
+                        "name": "read_file",
+                        "input": {"path": "/etc/hosts"},
+                    }
                 ]
             },
         }
@@ -408,10 +439,10 @@ class TestClaudeReader:
 
 @pytest.mark.unit
 class TestGeminiReader:
-    def _gemini_home(self, tmp_path):
+    def _gemini_home(self, tmp_path: Path) -> Path:
         return tmp_path / "gemini_home"
 
-    def _patch_home(self, monkeypatch, tmp_path):
+    def _patch_home(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
         home = self._gemini_home(tmp_path)
         (home / ".gemini" / "tmp").mkdir(parents=True)
         monkeypatch.setenv("HOME", str(home))
@@ -424,7 +455,9 @@ class TestGeminiReader:
 
         assert gemini.detect() is False
 
-    def test_gemini_detect_returns_true_when_tmp_dir_exists(self, tmp_path, monkeypatch):
+    def test_gemini_detect_returns_true_when_tmp_dir_exists(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_home(monkeypatch, tmp_path)
 
         assert gemini.detect() is True
@@ -444,13 +477,18 @@ class TestGeminiReader:
         user_line = {"type": "user", "content": "What is this?"}
         gemini_line = {"type": "gemini", "content": "This is a thing."}
         session_file.write_text(
-            json.dumps(first_line) + "\n"
-            + json.dumps(user_line) + "\n"
-            + json.dumps(gemini_line) + "\n"
+            json.dumps(first_line)
+            + "\n"
+            + json.dumps(user_line)
+            + "\n"
+            + json.dumps(gemini_line)
+            + "\n"
         )
 
         projects_json = home / ".gemini" / "projects.json"
-        projects_json.write_text(json.dumps({"projects": {"/home/user/my-project": slug}}))
+        projects_json.write_text(
+            json.dumps({"projects": {"/home/user/my-project": slug}})
+        )
 
         sessions = gemini.iter_sessions(_args())
 
@@ -460,7 +498,9 @@ class TestGeminiReader:
         assert s.cwd == "/home/user/my-project"
         assert s.agent == "gemini"
 
-    def test_gemini_iter_sessions_finds_legacy_json_session(self, tmp_path, monkeypatch):
+    def test_gemini_iter_sessions_finds_legacy_json_session(
+        self, tmp_path, monkeypatch
+    ):
         home = self._patch_home(monkeypatch, tmp_path)
         slug = "legacy-slug"
         chats_dir = home / ".gemini" / "tmp" / slug / "chats"
@@ -482,7 +522,9 @@ class TestGeminiReader:
         assert s.id == "session-legacy"
         assert s.agent == "gemini"
 
-    def test_gemini_iter_sessions_skips_slug_dir_without_chats(self, tmp_path, monkeypatch):
+    def test_gemini_iter_sessions_skips_slug_dir_without_chats(
+        self, tmp_path, monkeypatch
+    ):
         home = self._patch_home(monkeypatch, tmp_path)
         (home / ".gemini" / "tmp" / "bare-slug").mkdir(parents=True)
 
@@ -574,7 +616,9 @@ class TestGeminiReader:
 
         assert result == raw
 
-    def test_gemini_iter_sessions_empty_chats_dir_returns_no_sessions(self, tmp_path, monkeypatch):
+    def test_gemini_iter_sessions_empty_chats_dir_returns_no_sessions(
+        self, tmp_path, monkeypatch
+    ):
         home = self._patch_home(monkeypatch, tmp_path)
         chats_dir = home / ".gemini" / "tmp" / "some-slug" / "chats"
         chats_dir.mkdir(parents=True)
@@ -617,13 +661,15 @@ def _create_goose_db(db_path: Path) -> None:
 
 @pytest.mark.unit
 class TestGooseReader:
-    def _patch_db(self, monkeypatch, db_path: Path) -> None:
+    def _patch_db(self, monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
         monkeypatch.setattr(goose, "_db_path", lambda: db_path)
 
-    def _patch_legacy(self, monkeypatch, legacy_dir: Path) -> None:
+    def _patch_legacy(self, monkeypatch: pytest.MonkeyPatch, legacy_dir: Path) -> None:
         monkeypatch.setattr(goose, "_legacy_dir", lambda: legacy_dir)
 
-    def test_goose_detect_returns_false_when_neither_source_exists(self, tmp_path, monkeypatch):
+    def test_goose_detect_returns_false_when_neither_source_exists(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_db(monkeypatch, tmp_path / "nonexistent.db")
         self._patch_legacy(monkeypatch, tmp_path / "nonexistent_dir")
 
@@ -637,7 +683,9 @@ class TestGooseReader:
 
         assert goose.detect() is True
 
-    def test_goose_detect_returns_true_when_legacy_jsonl_exists(self, tmp_path, monkeypatch):
+    def test_goose_detect_returns_true_when_legacy_jsonl_exists(
+        self, tmp_path, monkeypatch
+    ):
         legacy_dir = tmp_path / "legacy"
         legacy_dir.mkdir()
         (legacy_dir / "session.jsonl").write_text("{}\n")
@@ -653,7 +701,13 @@ class TestGooseReader:
         con.execute(
             "INSERT INTO sessions (id, name, working_dir, created_at, updated_at) "
             "VALUES (?, ?, ?, ?, ?)",
-            ("sess-1", "My Session", "/home/user/project", "2026-01-01T10:00:00", "2026-01-01T11:00:00"),
+            (
+                "sess-1",
+                "My Session",
+                "/home/user/project",
+                "2026-01-01T10:00:00",
+                "2026-01-01T11:00:00",
+            ),
         )
         con.commit()
         con.close()
@@ -671,7 +725,9 @@ class TestGooseReader:
         assert s.title == "My Session"
         assert s.agent == "goose"
 
-    def test_goose_iter_sessions_prefers_sqlite_over_legacy(self, tmp_path, monkeypatch):
+    def test_goose_iter_sessions_prefers_sqlite_over_legacy(
+        self, tmp_path, monkeypatch
+    ):
         db = tmp_path / "sessions.db"
         _create_goose_db(db)
         con = sqlite3.connect(str(db))
@@ -684,7 +740,11 @@ class TestGooseReader:
 
         legacy_dir = tmp_path / "legacy"
         legacy_dir.mkdir()
-        meta = {"id": "legacy-session", "working_dir": "/legacy/path", "description": "Old"}
+        meta = {
+            "id": "legacy-session",
+            "working_dir": "/legacy/path",
+            "description": "Old",
+        }
         (legacy_dir / "old.jsonl").write_text(json.dumps(meta) + "\n")
 
         self._patch_db(monkeypatch, db)
@@ -696,12 +756,18 @@ class TestGooseReader:
         assert "db-session" in ids
         assert "legacy-session" not in ids
 
-    def test_goose_iter_sessions_reads_legacy_when_no_sqlite(self, tmp_path, monkeypatch):
+    def test_goose_iter_sessions_reads_legacy_when_no_sqlite(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_db(monkeypatch, tmp_path / "nonexistent.db")
 
         legacy_dir = tmp_path / "legacy"
         legacy_dir.mkdir()
-        meta = {"id": "legacy-abc", "working_dir": "/some/path", "description": "Legacy title"}
+        meta = {
+            "id": "legacy-abc",
+            "working_dir": "/some/path",
+            "description": "Legacy title",
+        }
         (legacy_dir / "legacy-abc.jsonl").write_text(json.dumps(meta) + "\n")
         self._patch_legacy(monkeypatch, legacy_dir)
 
@@ -746,9 +812,7 @@ class TestGooseReader:
             "content_json_parsed": [
                 {
                     "type": "toolResponse",
-                    "toolResult": {
-                        "Ok": [{"text": "command output here"}]
-                    },
+                    "toolResult": {"Ok": [{"text": "command output here"}]},
                 }
             ],
         }
@@ -831,7 +895,7 @@ class TestGooseReader:
 # ---------------------------------------------------------------------------
 
 
-def _make_amp_thread(tmp_path: Path, thread_id: str, **overrides) -> Path:
+def _make_amp_thread(tmp_path: Path, thread_id: str, **overrides: Any) -> Path:
     threads_dir = tmp_path / ".local" / "share" / "amp" / "threads"
     threads_dir.mkdir(parents=True, exist_ok=True)
 
@@ -841,9 +905,7 @@ def _make_amp_thread(tmp_path: Path, thread_id: str, **overrides) -> Path:
         "title": "Test session",
         "created": 1735689600000,
         "env": {
-            "initial": json.dumps(
-                {"trees": [{"uri": "file:///home/user/test-repo"}]}
-            )
+            "initial": json.dumps({"trees": [{"uri": "file:///home/user/test-repo"}]})
         },
         "messages": [
             {
@@ -862,7 +924,9 @@ def _make_amp_thread(tmp_path: Path, thread_id: str, **overrides) -> Path:
 
 @pytest.mark.unit
 class TestAmpReader:
-    def _patch_threads_dir(self, monkeypatch, tmp_path: Path) -> Path:
+    def _patch_threads_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> Path:
         threads_dir = tmp_path / ".local" / "share" / "amp" / "threads"
         threads_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr(amp, "_AMP_THREADS", threads_dir)
@@ -873,12 +937,16 @@ class TestAmpReader:
 
         assert amp.detect() is False
 
-    def test_amp_detect_returns_true_when_threads_dir_exists(self, tmp_path, monkeypatch):
-        threads_dir = self._patch_threads_dir(monkeypatch, tmp_path)
+    def test_amp_detect_returns_true_when_threads_dir_exists(
+        self, tmp_path, monkeypatch
+    ):
+        self._patch_threads_dir(monkeypatch, tmp_path)
 
         assert amp.detect() is True
 
-    def test_amp_iter_sessions_extracts_cwd_from_env_initial(self, tmp_path, monkeypatch):
+    def test_amp_iter_sessions_extracts_cwd_from_env_initial(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_threads_dir(monkeypatch, tmp_path)
         _make_amp_thread(tmp_path, "test-uuid-001")
 
@@ -890,7 +958,9 @@ class TestAmpReader:
         assert s.title == "Test session"
         assert s.agent == "amp"
 
-    def test_amp_iter_sessions_graceful_fallback_when_env_missing(self, tmp_path, monkeypatch):
+    def test_amp_iter_sessions_graceful_fallback_when_env_missing(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_threads_dir(monkeypatch, tmp_path)
         path = _make_amp_thread(tmp_path, "no-env-uuid")
 
@@ -903,7 +973,9 @@ class TestAmpReader:
         assert len(sessions) == 1
         assert sessions[0].cwd == ""
 
-    def test_amp_iter_sessions_graceful_fallback_when_title_null(self, tmp_path, monkeypatch):
+    def test_amp_iter_sessions_graceful_fallback_when_title_null(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_threads_dir(monkeypatch, tmp_path)
         path = _make_amp_thread(tmp_path, "null-title-uuid")
 
@@ -916,7 +988,9 @@ class TestAmpReader:
         assert len(sessions) == 1
         assert sessions[0].title == ""
 
-    def test_amp_iter_sessions_graceful_with_empty_messages_array(self, tmp_path, monkeypatch):
+    def test_amp_iter_sessions_graceful_with_empty_messages_array(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_threads_dir(monkeypatch, tmp_path)
         path = _make_amp_thread(tmp_path, "empty-msgs-uuid")
 
@@ -937,7 +1011,9 @@ class TestAmpReader:
 
         assert sessions == []
 
-    def test_amp_iter_sessions_returns_empty_for_empty_threads_dir(self, tmp_path, monkeypatch):
+    def test_amp_iter_sessions_returns_empty_for_empty_threads_dir(
+        self, tmp_path, monkeypatch
+    ):
         self._patch_threads_dir(monkeypatch, tmp_path)
 
         sessions = amp.iter_sessions(_args())


### PR DESCRIPTION
This PR adds a `session-search` shared skill that lets any coding agent find and grep previous session transcripts across all five supported agents: Claude Code, Codex CLI, Gemini CLI, Goose, and Amp.

Previously there was no way to search across agent session history without knowing each agent's storage format. An existing Codex-only reference skill existed but was not integrated and covered only one agent.

- Add `session_search` Python package under `skills/session-search/scripts/` with a `list`/`find`/`grep` CLI invoked via `uv run python <skill-dir>/scripts/session_search <subcommand>` with `--agent` filtering and repo-biased ranking
- Implement five reader modules — JSONL for Claude Code/Codex/Gemini, SQLite (read-only) for Goose, and monolithic JSON for Amp — each exporting `iter_sessions`, `iter_search_text`, `display_text`, and `search_session` against a common `Session` dataclass
- Claude reader uses a two-pass approach (mtime scan + substring hint, then targeted cwd read) to handle ~4000 files without path reconstruction; Goose grep applies regex in Python after SQL fetch to avoid the `LIKE` vs regex mismatch
- Add 177 fixture-based tests covering per-reader parsing, repo scoring, date filtering, grep text extraction (tool calls and command outputs, not just prose), and a Goose regex correctness test