### PR TITLE
fix(codex): remove commit_attribution from managed config

### DIFF
--- a/src/ai_rules/config/codex/config.toml
+++ b/src/ai_rules/config/codex/config.toml
@@ -3,7 +3,6 @@ approval_policy = "untrusted"
 model_reasoning_effort = "xhigh"
 plan_mode_reasoning_effort = "xhigh"
 model_reasoning_summary = "detailed"
-commit_attribution = ""
 
 [tui]
 # Native Codex footer items that most closely match our Claude status line.

--- a/tests/unit/test_config_files.py
+++ b/tests/unit/test_config_files.py
@@ -144,9 +144,6 @@ class TestConfigFileStructuralInvariants:
     def test_codex_has_reasoning_summary(self, codex_config):
         assert codex_config["model_reasoning_summary"] == "detailed"
 
-    def test_codex_has_commit_attribution_empty(self, codex_config):
-        assert codex_config["commit_attribution"] == ""
-
     def test_codex_has_history_persistence(self, codex_config):
         assert codex_config["history"]["persistence"] == "save-all"
 


### PR DESCRIPTION
## Summary
- Remove `commit_attribution = ""` from the managed Codex `config.toml` and its corresponding unit test
- The `Feature::CodexGitCommit` feature was removed as dead code in [openai/codex#22412](https://github.com/openai/codex/pull/22412) (merged 2026-05-13), and the upstream config schema now uses `additionalProperties: false`, rejecting any config containing this field
- The managed config had it set to `""` (disabled/no-op), so removing it has no functional impact