### PR TITLE
fix: add build_command to PSR config so uv.lock stays in sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ branch = "main"
 commit_parser = "conventional"
 commit_message = "chore(release): {version}"
 allow_zero_version = true
+build_command = "uv sync"
 
 [tool.semantic_release.commit_parser_opts]
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]


### PR DESCRIPTION
## Summary
- Add `build_command = "uv sync"` to `[tool.semantic_release]` in `pyproject.toml`
- PSR bumps `pyproject.toml` version but doesn't update `uv.lock`, leaving the lock file one version behind after every release (0.47.7 at v0.47.8, 0.47.8 at v0.47.9, etc.)
- This drift caused a manual amend + force push to main after v0.47.10 that orphaned the release tag, blocking all subsequent releases — PSR kept resolving to `0.47.10` but the tag already existed on an unreachable commit
- With `build_command`, PSR runs `uv sync` after the version bump so `uv.lock` is included in the release commit automatically

**Note:** The orphaned `v0.47.10` tag was fixed separately via `git tag -fa v0.47.10 4361d8d && git push --force origin v0.47.10`.