### PR TITLE
Parallelize CLI component install/uninstall via plan/apply

### DIFF
--- a/src/ai_rules/cli/commands/install.py
+++ b/src/ai_rules/cli/commands/install.py
@@ -78,7 +78,7 @@ def install(
 
     from ai_rules.cli.components import INSTALL_COMPONENTS
     from ai_rules.cli.context import CliContext
-    from ai_rules.cli.runner import run_install
+    from ai_rules.cli.runner import run_install_parallel
     from ai_rules.config import Config
 
     console = Console()
@@ -150,7 +150,7 @@ def install(
     if dry_run:
         console.print("[bold]Dry run mode - no changes will be made[/bold]\n")
 
-    install_components_result = run_install(infrastructure, semantic, cli_ctx)
+    install_components_result = run_install_parallel(infrastructure, semantic, cli_ctx)
     if install_components_result.aborted:
         if not install_components_result.ok:
             sys.exit(1)

--- a/src/ai_rules/cli/commands/uninstall.py
+++ b/src/ai_rules/cli/commands/uninstall.py
@@ -41,7 +41,7 @@ def uninstall(yes: bool, agents: str | None, component_filter: str | None) -> No
 
     from ai_rules.cli.components import UNINSTALL_COMPONENTS
     from ai_rules.cli.context import CliContext
-    from ai_rules.cli.runner import run_components
+    from ai_rules.cli.runner import run_uninstall_parallel
     from ai_rules.config import Config
 
     console = Console()
@@ -74,7 +74,7 @@ def uninstall(yes: bool, agents: str | None, component_filter: str | None) -> No
         component_filter=parsed_filter,
         yes=yes,
     )
-    result = run_components(UNINSTALL_COMPONENTS, "uninstall", cli_ctx)
+    result = run_uninstall_parallel(UNINSTALL_COMPONENTS, cli_ctx)
 
     console.print(
         f"\n[bold]Summary:[/bold] Removed {result.counts.get('removed', 0)}, "

--- a/src/ai_rules/cli/components/completions.py
+++ b/src/ai_rules/cli/components/completions.py
@@ -2,12 +2,47 @@
 
 from __future__ import annotations
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    CliContext,
+    CompletionsPlan,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+)
 
 
 class CompletionsComponent(Component):
     label = "Shell Completions"
     component_id = "completions"
+
+    def plan(self, ctx: CliContext) -> CompletionsPlan:
+        if ctx.skip_completions:
+            return CompletionsPlan(has_changes=False)
+
+        from ai_rules.completions import detect_shell
+
+        shell = detect_shell()
+        if not shell:
+            return CompletionsPlan(has_changes=False)
+
+        return CompletionsPlan(has_changes=True, shell=shell, needs_install=True)
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        from ai_rules.cli.runner import get_console
+
+        assert isinstance(plan, CompletionsPlan)
+
+        if not plan.needs_install or plan.shell is None:
+            return ComponentResult()
+
+        from ai_rules.completions import install_completion
+
+        console = get_console(ctx)
+        success, msg = install_completion(plan.shell, dry_run=ctx.dry_run)
+        if success and not ctx.dry_run and "already installed" not in msg:
+            console.print(f"\n[dim]✓ {msg}[/dim]")
+
+        return ComponentResult(changed=success)
 
     def install(self, ctx: CliContext) -> ComponentResult:
         if ctx.skip_completions:

--- a/src/ai_rules/cli/components/completions.py
+++ b/src/ai_rules/cli/components/completions.py
@@ -28,9 +28,10 @@ class CompletionsComponent(Component):
         return CompletionsPlan(has_changes=True, shell=shell, needs_install=True)
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
-        from ai_rules.cli.runner import get_console
+        if not isinstance(plan, CompletionsPlan):
+            return ComponentResult()
 
-        assert isinstance(plan, CompletionsPlan)
+        from ai_rules.cli.runner import get_console
 
         if not plan.needs_install or plan.shell is None:
             return ComponentResult()

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -101,22 +101,21 @@ class ConfigComponent(Component):
         )
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, ConfigPlan):
+            return ComponentResult()
+
         from ai_rules.cli import cleanup_deprecated_symlinks
         from ai_rules.cli.runner import get_console
         from ai_rules.symlinks import SymlinkResult, create_symlink
 
-        assert isinstance(plan, ConfigPlan)
         console = get_console(ctx)
 
         created = updated = skipped = excluded = errors = 0
-        effective_force = ctx.yes or not ctx.dry_run
 
         excluded = plan.excluded_count
 
         for target, source in plan.symlink_ops:
-            result, message = create_symlink(
-                target, source, effective_force, ctx.dry_run
-            )
+            result, message = create_symlink(target, source, True, ctx.dry_run)
 
             if result == SymlinkResult.CREATED:
                 console.print(f"  [green]✓[/green] {target} → {source}")
@@ -350,14 +349,16 @@ class ConfigComponent(Component):
         return ComponentResult(ok=not found_differences, changed=found_differences)
 
     def uninstall(self, ctx: CliContext) -> ComponentResult:
+        from ai_rules.cli.runner import get_console
         from ai_rules.symlinks import remove_symlink
 
+        console = get_console(ctx)
         total_removed = 0
         total_skipped = 0
 
-        ctx.console.print("\n[bold cyan]Config Files[/bold cyan]")
+        console.print("\n[bold cyan]Config Files[/bold cyan]")
         for target in ctx.selected_targets:
-            ctx.console.print(f"\n[bold]{target.name}[/bold]")
+            console.print(f"\n[bold]{target.name}[/bold]")
 
             for tgt, _source in target.get_filtered_symlinks():
                 if _is_specialized_path(tgt):
@@ -365,16 +366,12 @@ class ConfigComponent(Component):
                 success, message = remove_symlink(tgt, ctx.yes)
 
                 if success:
-                    ctx.console.print(f"  [green]✓[/green] {tgt} removed")
+                    console.print(f"  [green]✓[/green] {tgt} removed")
                     total_removed += 1
                 elif "Does not exist" in message:
-                    ctx.console.print(
-                        f"  [dim]•[/dim] {tgt} [dim](not installed)[/dim]"
-                    )
+                    console.print(f"  [dim]•[/dim] {tgt} [dim](not installed)[/dim]")
                 else:
-                    ctx.console.print(
-                        f"  [yellow]○[/yellow] {tgt} [dim]({message})[/dim]"
-                    )
+                    console.print(f"  [yellow]○[/yellow] {tgt} [dim]({message})[/dim]")
                     total_skipped += 1
 
         return ComponentResult(

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    ConfigPlan,
+)
 
 SPECIALIZED_PATH_PARTS = ("/agents/", "/commands/", "/skills/", "/hooks/")
 
@@ -71,6 +77,77 @@ def _display_symlink_status(
 class ConfigComponent(Component):
     label = "Config Files"
     component_id = "config"
+
+    def plan(self, ctx: CliContext) -> ConfigPlan:
+        symlink_ops: list[tuple[Path, Path]] = []
+        excluded_count = 0
+
+        for agent in ctx.selected_targets:
+            filtered_symlinks = agent.get_filtered_symlinks()
+            excluded_count += len(agent.symlinks) - len(filtered_symlinks)
+
+            config_symlinks = [
+                (tgt, src)
+                for tgt, src in filtered_symlinks
+                if not _is_specialized_path(tgt)
+            ]
+            excluded_count += len(filtered_symlinks) - len(config_symlinks)
+            symlink_ops.extend(config_symlinks)
+
+        return ConfigPlan(
+            has_changes=bool(symlink_ops),
+            symlink_ops=symlink_ops,
+            excluded_count=excluded_count,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        from ai_rules.cli import cleanup_deprecated_symlinks
+        from ai_rules.cli.runner import get_console
+        from ai_rules.symlinks import SymlinkResult, create_symlink
+
+        assert isinstance(plan, ConfigPlan)
+        console = get_console(ctx)
+
+        created = updated = skipped = excluded = errors = 0
+        effective_force = ctx.yes or not ctx.dry_run
+
+        excluded = plan.excluded_count
+
+        for target, source in plan.symlink_ops:
+            result, message = create_symlink(
+                target, source, effective_force, ctx.dry_run
+            )
+
+            if result == SymlinkResult.CREATED:
+                console.print(f"  [green]✓[/green] {target} → {source}")
+                created += 1
+            elif result == SymlinkResult.ALREADY_CORRECT:
+                console.print(f"  [dim]•[/dim] {target} [dim](already correct)[/dim]")
+            elif result == SymlinkResult.UPDATED:
+                console.print(f"  [yellow]↻[/yellow] {target} → {source}")
+                updated += 1
+            elif result == SymlinkResult.SKIPPED:
+                console.print(f"  [yellow]○[/yellow] {target} [dim](skipped)[/dim]")
+                skipped += 1
+            elif result == SymlinkResult.ERROR:
+                console.print(f"  [red]✗[/red] {target}: {message}")
+                errors += 1
+
+        cleanup_deprecated_symlinks(
+            list(ctx.selected_targets), ctx.config_dir, ctx.dry_run
+        )
+
+        return ComponentResult(
+            ok=errors == 0,
+            changed=bool(created or updated),
+            counts={
+                "created": created,
+                "updated": updated,
+                "skipped": skipped,
+                "excluded": excluded,
+                "errors": errors,
+            },
+        )
 
     def install(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.cli import cleanup_deprecated_symlinks

--- a/src/ai_rules/cli/components/extensions.py
+++ b/src/ai_rules/cli/components/extensions.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    ClaudeExtensionsPlan,
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+)
 
 
 class ClaudeExtensionsComponent(Component):
@@ -64,6 +70,107 @@ class ClaudeExtensionsComponent(Component):
                     skipped += 1
                 elif result == SymlinkResult.ERROR:
                     ctx.console.print(f"  [red]✗[/red] {target_path}: {message}")
+                    errors += 1
+
+        return ComponentResult(
+            ok=errors == 0,
+            changed=bool(created or updated),
+            counts={
+                "created": created,
+                "updated": updated,
+                "skipped": skipped,
+                "errors": errors,
+            },
+        )
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        target = ctx.selected_target("claude")
+        if target is None:
+            return ClaudeExtensionsPlan()
+
+        from ai_rules.claude_extensions import ClaudeExtensionManager
+
+        ext_manager = ClaudeExtensionManager(ctx.config_dir)
+        symlink_ops: list[tuple[Any, Any]] = []
+
+        for ext_type in ClaudeExtensionManager.USER_DIRS:
+            managed = ext_manager._get_managed_extensions(ext_type)
+            if not managed:
+                continue
+
+            user_dir = ClaudeExtensionManager.USER_DIRS[ext_type].expanduser()
+            pattern = ClaudeExtensionManager.PATTERNS[ext_type]
+            suffix = pattern.lstrip("*")
+
+            for name, source_path in managed.items():
+                filename = f"{name}{suffix}"
+                target_path = user_dir / filename
+                symlink_ops.append((target_path, source_path))
+
+        return ClaudeExtensionsPlan(
+            has_changes=bool(symlink_ops),
+            symlink_ops=symlink_ops,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, ClaudeExtensionsPlan):
+            return ComponentResult()
+
+        from ai_rules.claude_extensions import ClaudeExtensionManager
+        from ai_rules.cli.runner import get_console
+        from ai_rules.symlinks import SymlinkResult, create_symlink
+
+        console = get_console(ctx)
+        created = updated = skipped = errors = 0
+        plan_ops = set(plan.symlink_ops)
+
+        ext_manager = ClaudeExtensionManager(ctx.config_dir)
+        console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
+
+        for ext_type in ClaudeExtensionManager.USER_DIRS:
+            managed = ext_manager._get_managed_extensions(ext_type)
+            if not managed:
+                continue
+
+            user_dir = ClaudeExtensionManager.USER_DIRS[ext_type].expanduser()
+            pattern = ClaudeExtensionManager.PATTERNS[ext_type]
+            suffix = pattern.lstrip("*")
+
+            section_printed = False
+            for name, source_path in managed.items():
+                filename = f"{name}{suffix}"
+                target_path = user_dir / filename
+                if (target_path, source_path) not in plan_ops:
+                    continue
+
+                if not section_printed:
+                    console.print(f"\n[bold]{ext_type.capitalize()}:[/bold]")
+                    section_printed = True
+
+                result, message = create_symlink(
+                    target_path,
+                    source_path,
+                    force=ctx.yes or not ctx.dry_run,
+                    dry_run=ctx.dry_run,
+                )
+
+                if result == SymlinkResult.CREATED:
+                    console.print(f"  [green]✓[/green] {target_path} → {source_path}")
+                    created += 1
+                elif result == SymlinkResult.ALREADY_CORRECT:
+                    console.print(
+                        f"  [dim]•[/dim] {target_path} [dim](already correct)[/dim]"
+                    )
+                elif result == SymlinkResult.UPDATED:
+                    console.print(f"  [yellow]↻[/yellow] {target_path} → {source_path}")
+                    updated += 1
+                elif result == SymlinkResult.SKIPPED:
+                    console.print(
+                        f"  [yellow]○[/yellow] {target_path} [dim](skipped)[/dim]"
+                    )
+                    skipped += 1
+                elif result == SymlinkResult.ERROR:
+                    console.print(f"  [red]✗[/red] {target_path}: {message}")
                     errors += 1
 
         return ComponentResult(

--- a/src/ai_rules/cli/components/extensions.py
+++ b/src/ai_rules/cli/components/extensions.py
@@ -91,7 +91,7 @@ class ClaudeExtensionsComponent(Component):
         from ai_rules.claude_extensions import ClaudeExtensionManager
 
         ext_manager = ClaudeExtensionManager(ctx.config_dir)
-        symlink_ops: list[tuple[Any, Any]] = []
+        symlink_ops: list[tuple[str, Any, Any]] = []
 
         for ext_type in ClaudeExtensionManager.USER_DIRS:
             managed = ext_manager._get_managed_extensions(ext_type)
@@ -105,7 +105,7 @@ class ClaudeExtensionsComponent(Component):
             for name, source_path in managed.items():
                 filename = f"{name}{suffix}"
                 target_path = user_dir / filename
-                symlink_ops.append((target_path, source_path))
+                symlink_ops.append((ext_type, target_path, source_path))
 
         return ClaudeExtensionsPlan(
             has_changes=bool(symlink_ops),
@@ -116,62 +116,45 @@ class ClaudeExtensionsComponent(Component):
         if not isinstance(plan, ClaudeExtensionsPlan):
             return ComponentResult()
 
-        from ai_rules.claude_extensions import ClaudeExtensionManager
         from ai_rules.cli.runner import get_console
         from ai_rules.symlinks import SymlinkResult, create_symlink
 
         console = get_console(ctx)
         created = updated = skipped = errors = 0
-        plan_ops = set(plan.symlink_ops)
 
-        ext_manager = ClaudeExtensionManager(ctx.config_dir)
         console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
 
-        for ext_type in ClaudeExtensionManager.USER_DIRS:
-            managed = ext_manager._get_managed_extensions(ext_type)
-            if not managed:
-                continue
+        current_section = None
+        for ext_type, target_path, source_path in plan.symlink_ops:
+            if ext_type != current_section:
+                console.print(f"\n[bold]{ext_type.capitalize()}:[/bold]")
+                current_section = ext_type
 
-            user_dir = ClaudeExtensionManager.USER_DIRS[ext_type].expanduser()
-            pattern = ClaudeExtensionManager.PATTERNS[ext_type]
-            suffix = pattern.lstrip("*")
+            result, message = create_symlink(
+                target_path,
+                source_path,
+                force=True,
+                dry_run=ctx.dry_run,
+            )
 
-            section_printed = False
-            for name, source_path in managed.items():
-                filename = f"{name}{suffix}"
-                target_path = user_dir / filename
-                if (target_path, source_path) not in plan_ops:
-                    continue
-
-                if not section_printed:
-                    console.print(f"\n[bold]{ext_type.capitalize()}:[/bold]")
-                    section_printed = True
-
-                result, message = create_symlink(
-                    target_path,
-                    source_path,
-                    force=ctx.yes or not ctx.dry_run,
-                    dry_run=ctx.dry_run,
+            if result == SymlinkResult.CREATED:
+                console.print(f"  [green]✓[/green] {target_path} → {source_path}")
+                created += 1
+            elif result == SymlinkResult.ALREADY_CORRECT:
+                console.print(
+                    f"  [dim]•[/dim] {target_path} [dim](already correct)[/dim]"
                 )
-
-                if result == SymlinkResult.CREATED:
-                    console.print(f"  [green]✓[/green] {target_path} → {source_path}")
-                    created += 1
-                elif result == SymlinkResult.ALREADY_CORRECT:
-                    console.print(
-                        f"  [dim]•[/dim] {target_path} [dim](already correct)[/dim]"
-                    )
-                elif result == SymlinkResult.UPDATED:
-                    console.print(f"  [yellow]↻[/yellow] {target_path} → {source_path}")
-                    updated += 1
-                elif result == SymlinkResult.SKIPPED:
-                    console.print(
-                        f"  [yellow]○[/yellow] {target_path} [dim](skipped)[/dim]"
-                    )
-                    skipped += 1
-                elif result == SymlinkResult.ERROR:
-                    console.print(f"  [red]✗[/red] {target_path}: {message}")
-                    errors += 1
+            elif result == SymlinkResult.UPDATED:
+                console.print(f"  [yellow]↻[/yellow] {target_path} → {source_path}")
+                updated += 1
+            elif result == SymlinkResult.SKIPPED:
+                console.print(
+                    f"  [yellow]○[/yellow] {target_path} [dim](skipped)[/dim]"
+                )
+                skipped += 1
+            elif result == SymlinkResult.ERROR:
+                console.print(f"  [red]✗[/red] {target_path}: {message}")
+                errors += 1
 
         return ComponentResult(
             ok=errors == 0,
@@ -190,18 +173,20 @@ class ClaudeExtensionsComponent(Component):
             return ComponentResult()
 
         from ai_rules.claude_extensions import ClaudeExtensionManager
+        from ai_rules.cli.runner import get_console
         from ai_rules.symlinks import remove_symlink
 
+        console = get_console(ctx)
         ext_manager = ClaudeExtensionManager(ctx.config_dir)
         removed = skipped = 0
 
-        ctx.console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
+        console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
         for ext_type in ClaudeExtensionManager.USER_DIRS:
             managed = ext_manager._get_managed_extensions(ext_type)
             if not managed:
                 continue
 
-            ctx.console.print(f"\n[bold]{ext_type.capitalize()}:[/bold]")
+            console.print(f"\n[bold]{ext_type.capitalize()}:[/bold]")
             user_dir = ClaudeExtensionManager.USER_DIRS[ext_type].expanduser()
             pattern = ClaudeExtensionManager.PATTERNS[ext_type]
             suffix = pattern.lstrip("*")
@@ -212,14 +197,14 @@ class ClaudeExtensionsComponent(Component):
                 success, message = remove_symlink(target_path, force=ctx.yes)
 
                 if success:
-                    ctx.console.print(f"  [green]✓[/green] {target_path} removed")
+                    console.print(f"  [green]✓[/green] {target_path} removed")
                     removed += 1
                 elif "Does not exist" in message:
-                    ctx.console.print(
+                    console.print(
                         f"  [dim]•[/dim] {target_path} [dim](not installed)[/dim]"
                     )
                 else:
-                    ctx.console.print(
+                    console.print(
                         f"  [yellow]○[/yellow] {target_path} [dim]({message})[/dim]"
                     )
                     skipped += 1

--- a/src/ai_rules/cli/components/mcp.py
+++ b/src/ai_rules/cli/components/mcp.py
@@ -135,8 +135,8 @@ class MCPComponent(Component):
         # The serial install() path handles prompt-based conflict resolution.
         for target_name in plan.conflict_targets:
             console.print(
-                f"[yellow]⚠[/yellow] {target_name}: conflicts detected, skipping "
-                f"(run without --parallel or use -y to force)"
+                f"[yellow]⚠[/yellow] {target_name}: MCP conflicts detected, "
+                f"skipping (use -y to force-apply)"
             )
             skipped += 1
 
@@ -251,8 +251,10 @@ class MCPComponent(Component):
         return self.status(ctx)
 
     def uninstall(self, ctx: CliContext) -> ComponentResult:
+        from ai_rules.cli.runner import get_console
         from ai_rules.mcp import OperationResult
 
+        console = get_console(ctx)
         removed = 0
         for target in ctx.selected_targets:
             if not isinstance(target, Agent):
@@ -264,9 +266,9 @@ class MCPComponent(Component):
 
             result, message = target.uninstall_mcps()
             if result == OperationResult.REMOVED:
-                ctx.console.print(f"  [green]✓[/green] {message}")
+                console.print(f"  [green]✓[/green] {message}")
                 removed += 1
             elif result == OperationResult.NOT_FOUND:
-                ctx.console.print(f"  [dim]•[/dim] {message}")
+                console.print(f"  [dim]•[/dim] {message}")
 
         return ComponentResult(changed=removed > 0, counts={"removed": removed})

--- a/src/ai_rules/cli/components/mcp.py
+++ b/src/ai_rules/cli/components/mcp.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from rich.prompt import Confirm
 
 from ai_rules.agents.base import Agent
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    MCPPlan,
+)
 
 
 class MCPComponent(Component):
@@ -64,6 +72,97 @@ class MCPComponent(Component):
                 ctx.console.print(f"[dim]○ {target.name}: {message}[/dim]")
             elif result != OperationResult.NOT_FOUND:
                 ctx.console.print(f"[yellow]⚠[/yellow] {target.name}: {message}")
+                errors += 1
+
+        return ComponentResult(
+            changed=updated > 0,
+            counts={
+                "mcp_updated": updated,
+                "mcp_skipped": skipped,
+                "mcp_errors": errors,
+            },
+        )
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        from ai_rules.mcp import OperationResult
+
+        install_ops: list[tuple[str, dict[str, Any]]] = []
+        conflict_targets: list[str] = []
+
+        for target in ctx.selected_targets:
+            if not isinstance(target, Agent):
+                continue
+            if target.is_settings_file_excluded:
+                continue
+            mgr = target.get_mcp_manager()
+            if mgr is None:
+                continue
+
+            # Dry-run detect to find what needs installing and what conflicts exist
+            result, _message, conflicts = target.install_mcps(
+                force=ctx.yes, dry_run=True
+            )
+
+            if result == OperationResult.NOT_FOUND:
+                continue
+
+            if conflicts and not ctx.yes:
+                conflict_targets.append(target.name)
+            else:
+                native_mcps = mgr.load_managed_mcps(ctx.config_dir, ctx.config)
+                install_ops.append((target.name, native_mcps))
+
+        has_changes = bool(install_ops or conflict_targets)
+        return MCPPlan(
+            has_changes=has_changes,
+            install_ops=install_ops,
+            conflict_targets=conflict_targets,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, MCPPlan):
+            return ComponentResult()
+
+        from ai_rules.cli.runner import get_console
+        from ai_rules.mcp import OperationResult
+
+        console = get_console(ctx)
+        updated = 0
+        skipped = 0
+        errors = 0
+
+        # Targets with conflicts that can't be resolved without a prompt — skip them.
+        # The serial install() path handles prompt-based conflict resolution.
+        for target_name in plan.conflict_targets:
+            console.print(
+                f"[yellow]⚠[/yellow] {target_name}: conflicts detected, skipping "
+                f"(run without --parallel or use -y to force)"
+            )
+            skipped += 1
+
+        # Install non-conflict targets
+        install_target_names = {name for name, _ in plan.install_ops}
+        for target in ctx.selected_targets:
+            if not isinstance(target, Agent):
+                continue
+            if target.is_settings_file_excluded:
+                continue
+            if target.get_mcp_manager() is None:
+                continue
+            if target.name not in install_target_names:
+                continue
+
+            result, message, conflicts = target.install_mcps(
+                force=ctx.yes, dry_run=ctx.dry_run
+            )
+
+            if result == OperationResult.UPDATED:
+                console.print(f"[green]✓[/green] {target.name}: {message}")
+                updated += 1
+            elif result == OperationResult.ALREADY_INSTALLED:
+                console.print(f"[dim]○ {target.name}: {message}[/dim]")
+            elif result != OperationResult.NOT_FOUND:
+                console.print(f"[yellow]⚠[/yellow] {target.name}: {message}")
                 errors += 1
 
         return ComponentResult(

--- a/src/ai_rules/cli/components/optional_tools.py
+++ b/src/ai_rules/cli/components/optional_tools.py
@@ -2,12 +2,97 @@
 
 from __future__ import annotations
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    OptionalToolsPlan,
+)
 
 
 class OptionalToolsComponent(Component):
     label = "Optional Tools"
     component_id = "tools"
+
+    def plan(self, ctx: CliContext) -> OptionalToolsPlan:
+        from ai_rules.bootstrap import (
+            ToolSource,
+            get_effective_install_source,
+            is_command_available,
+        )
+        from ai_rules.bootstrap.installer import _is_recall_configured
+
+        recall_needed = _is_recall_configured(ctx.config)
+        recall_available = is_command_available("recall")
+
+        statusline_available = is_command_available("claude-statusline")
+        sl_source, sl_local_path = get_effective_install_source(
+            "statusline", config=ctx.config
+        )
+
+        return OptionalToolsPlan(
+            has_changes=True,
+            recall_needed=recall_needed,
+            recall_action="" if (not recall_needed or recall_available) else "install",
+            statusline_needed=True,
+            statusline_action="" if statusline_available else "install",
+            statusline_from_github=sl_source == ToolSource.GITHUB,
+            statusline_local_path=sl_local_path,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        from ai_rules.bootstrap import (
+            ToolSource,
+            ensure_recall_installed,
+            ensure_statusline_installed,
+            get_effective_install_source,
+        )
+        from ai_rules.cli.runner import get_console
+
+        assert isinstance(plan, OptionalToolsPlan)
+        console = get_console(ctx)
+
+        recall_result, recall_message = ensure_recall_installed(
+            dry_run=ctx.dry_run, config=ctx.config
+        )
+        if recall_result == "installed":
+            if ctx.dry_run and recall_message:
+                console.print(f"[dim]{recall_message}[/dim]\n")
+            else:
+                console.print("[green]✓[/green] Installed recall\n")
+        elif recall_result in ("upgraded", "source_switched"):
+            console.print(
+                f"[green]✓[/green] Updated recall ({recall_message})\n"
+                if recall_message
+                else "[green]✓[/green] Updated recall\n"
+            )
+        elif recall_result == "upgrade_available" and ctx.dry_run and recall_message:
+            console.print(f"[dim]{recall_message}[/dim]\n")
+        elif recall_result == "failed":
+            console.print(
+                "[yellow]⚠[/yellow] Failed to install recall (continuing anyway)\n"
+            )
+
+        sl_source, sl_local_path = get_effective_install_source(
+            "statusline", config=ctx.config
+        )
+        statusline_result, statusline_message = ensure_statusline_installed(
+            dry_run=ctx.dry_run,
+            from_github=sl_source == ToolSource.GITHUB,
+            local_path=sl_local_path,
+        )
+        if statusline_result == "installed":
+            if ctx.dry_run and statusline_message:
+                console.print(f"[dim]{statusline_message}[/dim]\n")
+            else:
+                console.print("[green]✓[/green] Installed claude-statusline\n")
+        elif statusline_result == "failed":
+            console.print(
+                "[yellow]⚠[/yellow] Failed to install claude-statusline (continuing anyway)\n"
+            )
+
+        return ComponentResult()
 
     def install(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.bootstrap import (

--- a/src/ai_rules/cli/components/optional_tools.py
+++ b/src/ai_rules/cli/components/optional_tools.py
@@ -16,32 +16,12 @@ class OptionalToolsComponent(Component):
     component_id = "tools"
 
     def plan(self, ctx: CliContext) -> OptionalToolsPlan:
-        from ai_rules.bootstrap import (
-            ToolSource,
-            get_effective_install_source,
-            is_command_available,
-        )
-        from ai_rules.bootstrap.installer import _is_recall_configured
-
-        recall_needed = _is_recall_configured(ctx.config)
-        recall_available = is_command_available("recall")
-
-        statusline_available = is_command_available("claude-statusline")
-        sl_source, sl_local_path = get_effective_install_source(
-            "statusline", config=ctx.config
-        )
-
-        return OptionalToolsPlan(
-            has_changes=True,
-            recall_needed=recall_needed,
-            recall_action="" if (not recall_needed or recall_available) else "install",
-            statusline_needed=True,
-            statusline_action="" if statusline_available else "install",
-            statusline_from_github=sl_source == ToolSource.GITHUB,
-            statusline_local_path=sl_local_path,
-        )
+        return OptionalToolsPlan(has_changes=True)
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, OptionalToolsPlan):
+            return ComponentResult()
+
         from ai_rules.bootstrap import (
             ToolSource,
             ensure_recall_installed,
@@ -50,7 +30,6 @@ class OptionalToolsComponent(Component):
         )
         from ai_rules.cli.runner import get_console
 
-        assert isinstance(plan, OptionalToolsPlan)
         console = get_console(ctx)
 
         recall_result, recall_message = ensure_recall_installed(

--- a/src/ai_rules/cli/components/plugins.py
+++ b/src/ai_rules/cli/components/plugins.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
-
-from dataclasses import asdict
-
 from ai_rules.cli.context import (
     CliContext,
     Component,
@@ -27,21 +23,11 @@ class ClaudePluginComponent(Component):
             ctx.config.plugins or ctx.config.marketplaces
         ):
             return PluginPlan()
-
-        cli_available = shutil.which("claude") is not None
-
-        plugins_to_sync = [asdict(p) for p in ctx.config.get_plugin_configs()]
-        marketplaces_to_sync = [asdict(m) for m in ctx.config.get_marketplace_configs()]
-
-        return PluginPlan(
-            has_changes=True,
-            cli_available=cli_available,
-            plugins_to_sync=plugins_to_sync,
-            marketplaces_to_sync=marketplaces_to_sync,
-        )
+        return PluginPlan(has_changes=True)
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
-        assert isinstance(plan, PluginPlan)
+        if not isinstance(plan, PluginPlan):
+            return ComponentResult()
 
         if not plan.has_changes:
             return ComponentResult()

--- a/src/ai_rules/cli/components/plugins.py
+++ b/src/ai_rules/cli/components/plugins.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+import shutil
+
+from dataclasses import asdict
+
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    PluginPlan,
+)
 
 
 class ClaudePluginComponent(Component):
@@ -11,6 +21,67 @@ class ClaudePluginComponent(Component):
 
     def _claude_selected(self, ctx: CliContext) -> bool:
         return ctx.selected_target("claude") is not None
+
+    def plan(self, ctx: CliContext) -> PluginPlan:
+        if not self._claude_selected(ctx) or not (
+            ctx.config.plugins or ctx.config.marketplaces
+        ):
+            return PluginPlan()
+
+        cli_available = shutil.which("claude") is not None
+
+        plugins_to_sync = [asdict(p) for p in ctx.config.get_plugin_configs()]
+        marketplaces_to_sync = [asdict(m) for m in ctx.config.get_marketplace_configs()]
+
+        return PluginPlan(
+            has_changes=True,
+            cli_available=cli_available,
+            plugins_to_sync=plugins_to_sync,
+            marketplaces_to_sync=marketplaces_to_sync,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        assert isinstance(plan, PluginPlan)
+
+        if not plan.has_changes:
+            return ComponentResult()
+
+        from ai_rules.cli.runner import get_console
+        from ai_rules.plugins import OperationResult, PluginManager
+
+        console = get_console(ctx)
+        plugin_manager = PluginManager()
+
+        if not plugin_manager.is_cli_available():
+            if not ctx.dry_run:
+                console.print(
+                    "[dim]○[/dim] Skipped plugin sync (claude CLI not available)"
+                )
+            return ComponentResult()
+
+        desired_plugins = ctx.config.get_plugin_configs()
+        desired_marketplaces = ctx.config.get_marketplace_configs()
+
+        plugin_result, message, warnings = plugin_manager.sync_plugins(
+            desired_plugins, desired_marketplaces, dry_run=ctx.dry_run
+        )
+
+        if plugin_result == OperationResult.SUCCESS:
+            console.print(f"[green]✓[/green] {message}")
+        elif plugin_result == OperationResult.ALREADY_INSTALLED:
+            console.print(f"[dim]○[/dim] {message}")
+        elif plugin_result == OperationResult.DRY_RUN:
+            console.print(f"[dim]{message}[/dim]")
+        elif plugin_result == OperationResult.ERROR:
+            console.print(f"[yellow]⚠[/yellow] {message}")
+
+        for warning in warnings:
+            console.print(f"[yellow]⚠[/yellow] {warning}")
+
+        return ComponentResult(
+            changed=plugin_result in (OperationResult.SUCCESS, OperationResult.DRY_RUN),
+            counts={"plugin_errors": int(plugin_result == OperationResult.ERROR)},
+        )
 
     def install(self, ctx: CliContext) -> ComponentResult:
         if not self._claude_selected(ctx) or not (

--- a/src/ai_rules/cli/components/settings.py
+++ b/src/ai_rules/cli/components/settings.py
@@ -2,13 +2,102 @@
 
 from __future__ import annotations
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from pathlib import Path
+
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    SettingsPlan,
+)
 
 
 class SettingsComponent(Component):
     label = "Settings"
     component_id = "settings"
     filterable = False
+
+    def plan(self, ctx: CliContext) -> SettingsPlan:
+        stale_targets = []
+        for target in ctx.selected_targets:
+            base_path = target._base_settings_path
+            if not base_path.exists():
+                continue
+            if target.needs_cache and (ctx.rebuild_cache or target.is_cache_stale()):
+                stale_targets.append(target)
+
+        excluded_symlinks_to_clean: list[Path] = []
+        for target in ctx.all_targets:
+            if not target.is_settings_file_excluded:
+                continue
+            symlink_target = target.settings_symlink_target
+            if symlink_target is None:
+                continue
+            expanded = symlink_target.expanduser()
+            if expanded.is_symlink():
+                link_dest = expanded.resolve()
+                cache_dir = ctx.config.get_cache_dir()
+                if cache_dir:
+                    try:
+                        link_dest.relative_to(cache_dir)
+                    except ValueError:
+                        continue
+                    excluded_symlinks_to_clean.append(expanded)
+
+        targets_needing_cache = {
+            target.target_id for target in ctx.all_targets if target.needs_cache
+        }
+        orphaned_cache_ids: set[str] = set()
+        cache_dir = ctx.config.get_cache_dir()
+        if cache_dir.exists():
+            for agent_dir in cache_dir.iterdir():
+                if agent_dir.is_dir() and agent_dir.name not in targets_needing_cache:
+                    orphaned_cache_ids.add(agent_dir.name)
+
+        has_changes = bool(
+            stale_targets or excluded_symlinks_to_clean or orphaned_cache_ids
+        )
+        return SettingsPlan(
+            has_changes=has_changes,
+            stale_targets=stale_targets,
+            orphaned_cache_ids=orphaned_cache_ids,
+            excluded_symlinks_to_clean=excluded_symlinks_to_clean,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        from ai_rules.cli.runner import get_console
+
+        assert isinstance(plan, SettingsPlan)
+        console = get_console(ctx)
+
+        if ctx.dry_run:
+            return ComponentResult()
+
+        built = 0
+        for target in plan.stale_targets:
+            try:
+                if target.build_merged_settings(force_rebuild=ctx.rebuild_cache):
+                    built += 1
+            except ValueError as exc:
+                console.print(f"[red]Error building {target.name} config:[/red] {exc}")
+                return ComponentResult(ok=False, abort=True, counts={"errors": 1})
+
+        for expanded in plan.excluded_symlinks_to_clean:
+            expanded.unlink()
+
+        orphaned = ctx.config.cleanup_orphaned_cache(
+            {target.target_id for target in ctx.all_targets if target.needs_cache}
+        )
+        if orphaned:
+            console.print(
+                f"[dim]✓ Cleaned up orphaned cache for: {', '.join(orphaned)}[/dim]"
+            )
+
+        return ComponentResult(
+            changed=bool(built or orphaned),
+            counts={"cache_updated": built, "cache_removed": len(orphaned)},
+        )
 
     def install(self, ctx: CliContext) -> ComponentResult:
         if ctx.dry_run:

--- a/src/ai_rules/cli/components/settings.py
+++ b/src/ai_rules/cli/components/settings.py
@@ -45,30 +45,19 @@ class SettingsComponent(Component):
                         continue
                     excluded_symlinks_to_clean.append(expanded)
 
-        targets_needing_cache = {
-            target.target_id for target in ctx.all_targets if target.needs_cache
-        }
-        orphaned_cache_ids: set[str] = set()
-        cache_dir = ctx.config.get_cache_dir()
-        if cache_dir.exists():
-            for agent_dir in cache_dir.iterdir():
-                if agent_dir.is_dir() and agent_dir.name not in targets_needing_cache:
-                    orphaned_cache_ids.add(agent_dir.name)
-
-        has_changes = bool(
-            stale_targets or excluded_symlinks_to_clean or orphaned_cache_ids
-        )
+        has_changes = bool(stale_targets or excluded_symlinks_to_clean)
         return SettingsPlan(
             has_changes=has_changes,
             stale_targets=stale_targets,
-            orphaned_cache_ids=orphaned_cache_ids,
             excluded_symlinks_to_clean=excluded_symlinks_to_clean,
         )
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, SettingsPlan):
+            return ComponentResult()
+
         from ai_rules.cli.runner import get_console
 
-        assert isinstance(plan, SettingsPlan)
         console = get_console(ctx)
 
         if ctx.dry_run:

--- a/src/ai_rules/cli/components/skills.py
+++ b/src/ai_rules/cli/components/skills.py
@@ -95,7 +95,8 @@ class SkillsComponent(Component):
         )
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
-        assert isinstance(plan, SkillsPlan)
+        if not isinstance(plan, SkillsPlan):
+            return ComponentResult()
 
         from ai_rules.symlinks import SymlinkResult, create_symlink, remove_symlink
 
@@ -107,7 +108,7 @@ class SkillsComponent(Component):
             result, _msg = create_symlink(
                 symlink_target,
                 skill_folder,
-                force=ctx.yes,
+                force=True,
                 dry_run=ctx.dry_run,
             )
             if result == SymlinkResult.ERROR:

--- a/src/ai_rules/cli/components/skills.py
+++ b/src/ai_rules/cli/components/skills.py
@@ -2,13 +2,130 @@
 
 from __future__ import annotations
 
+import os
+
+from pathlib import Path
+
 from ai_rules.agents.base import Agent
-from ai_rules.cli.context import CliContext, Component, ComponentResult
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    SkillsPlan,
+)
 
 
 class SkillsComponent(Component):
     label = "Skills"
     component_id = "skills"
+
+    def plan(self, ctx: CliContext) -> SkillsPlan:
+        from ai_rules.config import AGENT_SKILLS_DIRS
+
+        skills_source_dir = ctx.config_dir / "skills"
+        if not skills_source_dir.exists():
+            return SkillsPlan()
+
+        skill_folders = sorted(
+            f
+            for f in skills_source_dir.glob("*")
+            if f.is_dir() and not f.name.startswith(".")
+        )
+
+        symlink_ops: list[tuple[Path, Path]] = []
+        cleanup_ops: list[Path] = []
+        config_skills_abs = skills_source_dir.resolve()
+
+        for target in ctx.selected_targets:
+            if not isinstance(target, Agent):
+                continue
+
+            if target.agent_id == "shared":
+                target_dirs = list(AGENT_SKILLS_DIRS.items())
+            elif target.agent_id in AGENT_SKILLS_DIRS:
+                target_dirs = [(target.agent_id, AGENT_SKILLS_DIRS[target.agent_id])]
+            else:
+                continue
+
+            for _agent_id, skills_dir_path in target_dirs:
+                user_skills_dir = skills_dir_path.expanduser()
+
+                for skill_folder in skill_folders:
+                    symlink_target = user_skills_dir / skill_folder.name
+                    if ctx.config.is_excluded(str(symlink_target)):
+                        continue
+                    symlink_ops.append((symlink_target, skill_folder))
+
+                if user_skills_dir.exists():
+                    for existing in user_skills_dir.iterdir():
+                        if not existing.is_symlink():
+                            continue
+                        try:
+                            link_target = existing.resolve()
+                        except (OSError, RuntimeError):
+                            link_target = None
+
+                        if link_target is None:
+                            existing_raw = Path(os.readlink(existing))
+                            if not existing_raw.is_absolute():
+                                existing_raw = (
+                                    existing.parent / existing_raw
+                                ).resolve()
+                            try:
+                                existing_raw.relative_to(config_skills_abs)
+                            except ValueError:
+                                continue
+                            cleanup_ops.append(existing)
+                            continue
+
+                        try:
+                            link_target.relative_to(config_skills_abs)
+                        except ValueError:
+                            continue
+
+                        if not link_target.exists():
+                            cleanup_ops.append(existing)
+
+        has_changes = bool(symlink_ops or cleanup_ops)
+        return SkillsPlan(
+            has_changes=has_changes,
+            symlink_ops=symlink_ops,
+            cleanup_ops=cleanup_ops,
+        )
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        assert isinstance(plan, SkillsPlan)
+
+        from ai_rules.symlinks import SymlinkResult, create_symlink, remove_symlink
+
+        created = 0
+        skipped = 0
+        errors = 0
+
+        for symlink_target, skill_folder in plan.symlink_ops:
+            result, _msg = create_symlink(
+                symlink_target,
+                skill_folder,
+                force=ctx.yes,
+                dry_run=ctx.dry_run,
+            )
+            if result == SymlinkResult.ERROR:
+                errors += 1
+            elif result == SymlinkResult.ALREADY_CORRECT:
+                skipped += 1
+            else:
+                created += 1
+
+        if not ctx.dry_run:
+            for existing in plan.cleanup_ops:
+                remove_symlink(existing, force=True)
+
+        return ComponentResult(
+            ok=errors == 0,
+            changed=created > 0,
+            counts={"created": created, "skipped": skipped, "errors": errors},
+        )
 
     def install(self, ctx: CliContext) -> ComponentResult:
         import os

--- a/src/ai_rules/cli/context.py
+++ b/src/ai_rules/cli/context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from rich.console import Console
 
@@ -74,3 +74,71 @@ class Component(ABC):
 
     def uninstall(self, ctx: CliContext) -> ComponentResult:
         return ComponentResult()
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        return ComponentPlan()
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        return ComponentResult()
+
+
+@dataclass
+class ComponentPlan:
+    """Base for all component plans."""
+
+    has_changes: bool = False
+
+
+@dataclass
+class SettingsPlan(ComponentPlan):
+    stale_targets: list[ConfigTarget] = field(default_factory=list)
+    orphaned_cache_ids: set[str] = field(default_factory=set)
+    excluded_symlinks_to_clean: list[Path] = field(default_factory=list)
+
+
+@dataclass
+class OptionalToolsPlan(ComponentPlan):
+    recall_needed: bool = False
+    recall_action: str = ""
+    recall_message: str = ""
+    statusline_needed: bool = False
+    statusline_action: str = ""
+    statusline_message: str = ""
+    statusline_from_github: bool = False
+    statusline_local_path: str | None = None
+
+
+@dataclass
+class ConfigPlan(ComponentPlan):
+    symlink_ops: list[tuple[Path, Path]] = field(default_factory=list)
+    excluded_count: int = 0
+
+
+@dataclass
+class SkillsPlan(ComponentPlan):
+    symlink_ops: list[tuple[Path, Path]] = field(default_factory=list)
+    cleanup_ops: list[Path] = field(default_factory=list)
+
+
+@dataclass
+class ClaudeExtensionsPlan(ComponentPlan):
+    symlink_ops: list[tuple[Path, Path]] = field(default_factory=list)
+
+
+@dataclass
+class MCPPlan(ComponentPlan):
+    install_ops: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    conflict_targets: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PluginPlan(ComponentPlan):
+    cli_available: bool = False
+    plugins_to_sync: list[dict[str, Any]] = field(default_factory=list)
+    marketplaces_to_sync: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class CompletionsPlan(ComponentPlan):
+    shell: str | None = None
+    needs_install: bool = False

--- a/src/ai_rules/cli/context.py
+++ b/src/ai_rules/cli/context.py
@@ -13,7 +13,9 @@ from ai_rules.agents.base import Agent
 from ai_rules.config import Config
 from ai_rules.targets.base import ConfigTarget
 
-LifecycleOperation = Literal["install", "status", "diff", "validate", "uninstall"]
+LifecycleOperation = Literal[
+    "install", "status", "diff", "validate", "uninstall", "plan", "apply"
+]
 
 
 @dataclass(frozen=True)
@@ -92,20 +94,12 @@ class ComponentPlan:
 @dataclass
 class SettingsPlan(ComponentPlan):
     stale_targets: list[ConfigTarget] = field(default_factory=list)
-    orphaned_cache_ids: set[str] = field(default_factory=set)
     excluded_symlinks_to_clean: list[Path] = field(default_factory=list)
 
 
 @dataclass
 class OptionalToolsPlan(ComponentPlan):
-    recall_needed: bool = False
-    recall_action: str = ""
-    recall_message: str = ""
-    statusline_needed: bool = False
-    statusline_action: str = ""
-    statusline_message: str = ""
-    statusline_from_github: bool = False
-    statusline_local_path: str | None = None
+    pass
 
 
 @dataclass
@@ -122,7 +116,7 @@ class SkillsPlan(ComponentPlan):
 
 @dataclass
 class ClaudeExtensionsPlan(ComponentPlan):
-    symlink_ops: list[tuple[Path, Path]] = field(default_factory=list)
+    symlink_ops: list[tuple[str, Path, Path]] = field(default_factory=list)
 
 
 @dataclass
@@ -133,9 +127,7 @@ class MCPPlan(ComponentPlan):
 
 @dataclass
 class PluginPlan(ComponentPlan):
-    cli_available: bool = False
-    plugins_to_sync: list[dict[str, Any]] = field(default_factory=list)
-    marketplaces_to_sync: list[dict[str, Any]] = field(default_factory=list)
+    pass
 
 
 @dataclass

--- a/src/ai_rules/cli/runner.py
+++ b/src/ai_rules/cli/runner.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+import contextvars
+
 from collections.abc import Iterable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from io import StringIO
+from typing import Any
+
+from rich.console import Console as RichConsole
 
 from ai_rules.cli.context import (
     CliContext,
     Component,
+    ComponentPlan,
     ComponentResult,
     LifecycleOperation,
 )
+
+_console_override: contextvars.ContextVar[RichConsole | None] = contextvars.ContextVar(
+    "_console_override", default=None
+)
+
+_BUFFERED_METHODS: frozenset[str] = frozenset({"apply", "uninstall"})
 
 
 @dataclass
@@ -134,3 +148,246 @@ def run_install(
             break
 
     return acc.to_result()
+
+
+def run_install_parallel(
+    infrastructure: Iterable[Component],
+    semantic: Iterable[Component],
+    ctx: CliContext,
+) -> ComponentRunResult:
+    acc = _RunAccumulator()
+
+    # Phase 1: Infrastructure (sequential) — must complete before semantic
+    for component in infrastructure:
+        plan = component.plan(ctx)
+        if plan.has_changes:
+            result = component.apply(ctx, plan)
+        else:
+            result = ComponentResult()
+        acc.fold(component, result)
+        if result.abort or not result.ok:
+            acc.aborted = True
+            return acc.to_result()
+
+    # Phase 2: Prompt gate (main thread)
+    if not ctx.yes and not ctx.dry_run:
+        from rich.prompt import Confirm
+
+        from ai_rules.cli import (
+            _display_pending_changes,
+            check_first_run,
+        )
+
+        if not check_first_run(list(ctx.selected_targets), ctx.yes):
+            acc.aborted = True
+            return acc.to_result()
+
+        if _display_pending_changes(ctx):
+            if not Confirm.ask("Apply these changes?"):
+                acc.aborted = True
+                return acc.to_result()
+
+    # Phase 3: Parallel plan all semantic components
+    semantic_list = list(semantic)
+    plans = run_components_parallel(semantic_list, "plan", ctx)
+
+    # Phase 4: Parallel apply all semantic components
+    results = run_components_parallel(semantic_list, "apply", ctx, plans=plans)
+
+    # Fold results into accumulator
+    for component in semantic_list:
+        if _should_skip(component, ctx):
+            continue
+        result = results.get(component, ComponentResult())
+        acc.fold(component, result)
+
+    return acc.to_result()
+
+
+def run_uninstall_parallel(
+    components: Iterable[Component],
+    ctx: CliContext,
+) -> ComponentRunResult:
+    """Run uninstall across all components in parallel, returning a ComponentRunResult."""
+    acc = _RunAccumulator()
+    comp_list = list(components)
+    results = run_components_parallel(comp_list, "uninstall", ctx)
+    for comp in comp_list:
+        if _should_skip(comp, ctx):
+            continue
+        result = results.get(comp, ComponentResult())
+        acc.fold(comp, result)
+    return acc.to_result()
+
+
+def get_console(ctx: CliContext) -> RichConsole:
+    """Return the active console — thread override if set, else ctx.console."""
+    return _console_override.get() or ctx.console
+
+
+def run_components_parallel(
+    components: Iterable[Component],
+    method: str,
+    ctx: CliContext,
+    plans: dict[Component, ComponentPlan] | None = None,
+    max_workers: int | None = None,
+) -> dict[Component, Any]:
+    """Run a component method across all components in parallel.
+
+    For 'apply' and 'uninstall': each component's console output is captured
+    into a per-thread buffer and replayed atomically in completion order.
+
+    For 'plan' and other methods: no buffering — a Status spinner shows progress.
+
+    Errors are collected rather than aborting on first failure. After all futures
+    settle, per-component errors are printed and partial results are returned.
+    """
+    comp_list = [c for c in components if not _should_skip(c, ctx)]
+    if not comp_list:
+        return {}
+
+    should_buffer = method in _BUFFERED_METHODS
+    results: dict[Component, Any] = {}
+    errors: dict[Component, BaseException] = {}
+    futures: dict[Future[Any], Component] = {}
+
+    buffers: dict[Component, StringIO] = {}
+    buffered_consoles: dict[Component, RichConsole] = {}
+
+    if should_buffer:
+        for comp in comp_list:
+            buf = StringIO()
+            buffers[comp] = buf
+            buffered_consoles[comp] = RichConsole(
+                file=buf,
+                force_terminal=ctx.console.is_terminal,
+                color_system=ctx.console.color_system,  # type: ignore[arg-type]
+                highlight=False,
+            )
+
+    def _make_task(comp: Component, override: RichConsole | None = None) -> Any:
+        def _run() -> Any:
+            if override is not None:
+                _console_override.set(override)
+            if method == "apply":
+                plan = (plans or {})[comp]
+                return comp.apply(ctx, plan)
+            return getattr(comp, method)(ctx)
+
+        return _run
+
+    with ThreadPoolExecutor(max_workers=max_workers or len(comp_list)) as pool:
+        if should_buffer:
+            _run_buffered(
+                pool,
+                comp_list,
+                _make_task,
+                buffered_consoles,
+                buffers,
+                futures,
+                results,
+                errors,
+                ctx.console,
+            )
+        else:
+            _run_unbuffered(
+                pool,
+                comp_list,
+                method,
+                _make_task,
+                futures,
+                results,
+                errors,
+                ctx.console,
+            )
+
+    if errors:
+        for comp, exc in errors.items():
+            ctx.console.print(f"[red]✗[/red] {comp.label}: {type(exc).__name__}: {exc}")
+        if len(errors) == len(comp_list):
+            raise next(iter(errors.values()))
+
+    return results
+
+
+def _run_buffered(
+    pool: ThreadPoolExecutor,
+    components: list[Component],
+    make_task: Any,
+    buffered_consoles: dict[Component, RichConsole],
+    buffers: dict[Component, StringIO],
+    futures: dict[Future[Any], Component],
+    results: dict[Component, Any],
+    errors: dict[Component, BaseException],
+    real_console: RichConsole,
+) -> None:
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=real_console,
+        transient=True,
+    ) as progress:
+        task_ids: dict[Component, Any] = {}
+        for comp in components:
+            task_ids[comp] = progress.add_task(f"[cyan]{comp.label}[/cyan]", total=None)
+            future = pool.submit(make_task(comp, buffered_consoles[comp]))
+            futures[future] = comp
+
+        for future in as_completed(futures):
+            comp = futures[future]
+            exc = future.exception()
+            if exc is not None:
+                errors[comp] = exc
+                progress.update(
+                    task_ids[comp],
+                    description=f"[red]{comp.label} (failed)[/red]",
+                    completed=True,
+                )
+            else:
+                results[comp] = future.result()
+                progress.update(
+                    task_ids[comp],
+                    description=f"[green]{comp.label}[/green]",
+                    completed=True,
+                )
+
+            buf_content = buffers[comp].getvalue()
+            if buf_content.strip():
+                real_console.print(f"\n[bold cyan]{comp.label}[/bold cyan]")
+                real_console.file.write(buf_content)
+                real_console.file.flush()
+
+
+def _run_unbuffered(
+    pool: ThreadPoolExecutor,
+    components: list[Component],
+    method: str,
+    make_task: Any,
+    futures: dict[Future[Any], Component],
+    results: dict[Component, Any],
+    errors: dict[Component, BaseException],
+    real_console: RichConsole,
+) -> None:
+    with real_console.status(f"Running {method}...") as status:
+        for comp in components:
+            future = pool.submit(make_task(comp))
+            futures[future] = comp
+
+        completed = 0
+        for future in as_completed(futures):
+            comp = futures[future]
+            completed += 1
+            exc = future.exception()
+            if exc is not None:
+                if method == "plan":
+                    results[comp] = ComponentPlan(has_changes=False)
+                    real_console.print(
+                        f"[yellow]⚠[/yellow] {comp.label} plan failed: {exc}"
+                    )
+                else:
+                    errors[comp] = exc
+            else:
+                results[comp] = future.result()
+            status.update(f"Running {method}... ({completed}/{len(components)} done)")

--- a/src/ai_rules/cli/runner.py
+++ b/src/ai_rules/cli/runner.py
@@ -191,8 +191,9 @@ def run_install_parallel(
     semantic_list = list(semantic)
     plans = run_components_parallel(semantic_list, "plan", ctx)
 
-    # Phase 4: Parallel apply all semantic components
-    results = run_components_parallel(semantic_list, "apply", ctx, plans=plans)
+    # Phase 4: Parallel apply — skip components whose plan failed
+    apply_list = [c for c in semantic_list if type(plans.get(c)) is not ComponentPlan]
+    results = run_components_parallel(apply_list, "apply", ctx, plans=plans)
 
     # Fold results into accumulator
     for component in semantic_list:
@@ -227,7 +228,7 @@ def get_console(ctx: CliContext) -> RichConsole:
 
 def run_components_parallel(
     components: Iterable[Component],
-    method: str,
+    method: LifecycleOperation,
     ctx: CliContext,
     plans: dict[Component, ComponentPlan] | None = None,
     max_workers: int | None = None,
@@ -304,6 +305,7 @@ def run_components_parallel(
     if errors:
         for comp, exc in errors.items():
             ctx.console.print(f"[red]✗[/red] {comp.label}: {type(exc).__name__}: {exc}")
+            results[comp] = ComponentResult(ok=False, counts={"errors": 1})
         if len(errors) == len(comp_list):
             raise next(iter(errors.values()))
 
@@ -322,6 +324,8 @@ def _run_buffered(
     real_console: RichConsole,
 ) -> None:
     from rich.progress import Progress, SpinnerColumn, TextColumn
+
+    completed_buffers: list[tuple[Component, str]] = []
 
     with Progress(
         SpinnerColumn(),
@@ -355,15 +359,18 @@ def _run_buffered(
 
             buf_content = buffers[comp].getvalue()
             if buf_content.strip():
-                real_console.print(f"\n[bold cyan]{comp.label}[/bold cyan]")
-                real_console.file.write(buf_content)
-                real_console.file.flush()
+                completed_buffers.append((comp, buf_content))
+
+    for comp, buf_content in completed_buffers:
+        real_console.print(f"\n[bold cyan]{comp.label}[/bold cyan]")
+        real_console.file.write(buf_content)
+        real_console.file.flush()
 
 
 def _run_unbuffered(
     pool: ThreadPoolExecutor,
     components: list[Component],
-    method: str,
+    method: LifecycleOperation,
     make_task: Any,
     futures: dict[Future[Any], Component],
     results: dict[Component, Any],

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -6,8 +6,14 @@ import pytest
 
 from rich.console import Console
 
-from ai_rules.cli.context import CliContext, Component, ComponentResult
-from ai_rules.cli.runner import run_components, run_install
+from ai_rules.cli.context import CliContext, Component, ComponentPlan, ComponentResult
+from ai_rules.cli.runner import (
+    run_components,
+    run_components_parallel,
+    run_install,
+    run_install_parallel,
+    run_uninstall_parallel,
+)
 from ai_rules.config import Config
 
 
@@ -174,3 +180,257 @@ def test_run_install_aggregates_counts_across_phases(tmp_path: Path) -> None:
     result = run_install([infra], [semantic], make_context(tmp_path, yes=True))
 
     assert result.counts == {"cache_updated": 1, "created": 2}
+
+
+class _SubclassPlan(ComponentPlan):
+    """Subclass of ComponentPlan used by test fixtures.
+
+    run_install_parallel skips apply for components whose plan() returns the
+    base ComponentPlan type exactly (used as error fallback). Tests that need
+    apply() to run must return a subclass.
+    """
+
+
+class PlanApplyComponent(Component):
+    component_id = "plannable"
+    filterable = True
+
+    def __init__(
+        self,
+        label: str,
+        *,
+        plan_result: ComponentPlan | None = None,
+        plan_error: Exception | None = None,
+        apply_result: ComponentResult | None = None,
+        apply_error: Exception | None = None,
+        uninstall_result: ComponentResult | None = None,
+        uninstall_error: Exception | None = None,
+    ):
+        self.label = label
+        self._plan_result = plan_result or _SubclassPlan(has_changes=True)
+        self._plan_error = plan_error
+        self._apply_result = apply_result or ComponentResult()
+        self._apply_error = apply_error
+        self._uninstall_result = uninstall_result or ComponentResult()
+        self._uninstall_error = uninstall_error
+        self.plan_calls = 0
+        self.apply_calls = 0
+        self.uninstall_calls = 0
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        self.plan_calls += 1
+        if self._plan_error:
+            raise self._plan_error
+        return self._plan_result
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        self.apply_calls += 1
+        if self._apply_error:
+            raise self._apply_error
+        return self._apply_result
+
+    def uninstall(self, ctx: CliContext) -> ComponentResult:
+        self.uninstall_calls += 1
+        if self._uninstall_error:
+            raise self._uninstall_error
+        return self._uninstall_result
+
+
+class PlanApplyInfraComponent(Component):
+    component_id = "infra_plannable"
+    filterable = False
+
+    def __init__(
+        self,
+        label: str,
+        *,
+        plan_result: ComponentPlan | None = None,
+        apply_result: ComponentResult | None = None,
+        apply_error: Exception | None = None,
+    ):
+        self.label = label
+        self._plan_result = plan_result or _SubclassPlan(has_changes=True)
+        self._apply_result = apply_result or ComponentResult()
+        self._apply_error = apply_error
+        self.plan_calls = 0
+        self.apply_calls = 0
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        self.plan_calls += 1
+        return self._plan_result
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        self.apply_calls += 1
+        if self._apply_error:
+            raise self._apply_error
+        return self._apply_result
+
+
+@pytest.mark.unit
+def test_run_install_parallel_infra_runs_before_semantic(tmp_path: Path) -> None:
+    call_order: list[str] = []
+
+    class OrderedInfra(PlanApplyInfraComponent):
+        def plan(self, ctx: CliContext) -> ComponentPlan:
+            call_order.append("infra_plan")
+            return super().plan(ctx)
+
+        def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+            call_order.append("infra_apply")
+            return super().apply(ctx, plan)
+
+    class OrderedSemantic(PlanApplyComponent):
+        def plan(self, ctx: CliContext) -> ComponentPlan:
+            call_order.append("semantic_plan")
+            return super().plan(ctx)
+
+        def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+            call_order.append("semantic_apply")
+            return super().apply(ctx, plan)
+
+    infra = OrderedInfra("infra")
+    semantic = OrderedSemantic("semantic")
+
+    result = run_install_parallel([infra], [semantic], make_context(tmp_path, yes=True))
+
+    assert result.ok is True
+    assert call_order.index("infra_plan") < call_order.index("semantic_plan")
+    assert call_order.index("infra_apply") < call_order.index("semantic_apply")
+
+
+@pytest.mark.unit
+def test_run_install_parallel_aborts_if_infrastructure_fails(tmp_path: Path) -> None:
+    infra = PlanApplyInfraComponent("infra", apply_result=ComponentResult(ok=False))
+    semantic = PlanApplyComponent("semantic")
+
+    result = run_install_parallel([infra], [semantic], make_context(tmp_path, yes=True))
+
+    assert result.ok is False
+    assert result.aborted is True
+    assert semantic.plan_calls == 0
+    assert semantic.apply_calls == 0
+
+
+@pytest.mark.unit
+def test_run_install_parallel_skips_confirmation_when_yes(tmp_path: Path) -> None:
+    infra = PlanApplyInfraComponent("infra")
+    semantic = PlanApplyComponent("semantic")
+
+    with patch("rich.prompt.Confirm.ask") as mock_ask:
+        result = run_install_parallel(
+            [infra], [semantic], make_context(tmp_path, yes=True)
+        )
+
+    mock_ask.assert_not_called()
+    assert result.ok is True
+
+
+@pytest.mark.unit
+def test_run_install_parallel_skips_confirmation_when_dry_run(tmp_path: Path) -> None:
+    infra = PlanApplyInfraComponent("infra")
+    semantic = PlanApplyComponent("semantic")
+
+    with patch("rich.prompt.Confirm.ask") as mock_ask:
+        result = run_install_parallel(
+            [infra], [semantic], make_context(tmp_path, dry_run=True)
+        )
+
+    mock_ask.assert_not_called()
+    assert result.ok is True
+
+
+@pytest.mark.unit
+def test_run_install_parallel_aggregates_counts_across_phases(tmp_path: Path) -> None:
+    infra = PlanApplyInfraComponent(
+        "infra", apply_result=ComponentResult(counts={"cache_updated": 1})
+    )
+    semantic = PlanApplyComponent(
+        "semantic", apply_result=ComponentResult(counts={"created": 3})
+    )
+
+    result = run_install_parallel([infra], [semantic], make_context(tmp_path, yes=True))
+
+    assert result.counts == {"cache_updated": 1, "created": 3}
+
+
+@pytest.mark.unit
+def test_run_install_parallel_skips_apply_for_failed_plan(tmp_path: Path) -> None:
+    failing = PlanApplyComponent("failing", plan_error=RuntimeError("plan exploded"))
+    succeeding = PlanApplyComponent("succeeding")
+
+    result = run_install_parallel(
+        [], [failing, succeeding], make_context(tmp_path, yes=True)
+    )
+
+    assert failing.apply_calls == 0
+    assert succeeding.apply_calls == 1
+    assert result.ok is True
+
+
+@pytest.mark.unit
+def test_run_install_parallel_reports_failure_on_apply_error(tmp_path: Path) -> None:
+    bad = PlanApplyComponent("bad", apply_error=RuntimeError("apply exploded"))
+    good = PlanApplyComponent("good")
+
+    result = run_install_parallel([], [bad, good], make_context(tmp_path, yes=True))
+
+    assert result.ok is False
+
+
+@pytest.mark.unit
+def test_run_uninstall_parallel_aggregates_counts(tmp_path: Path) -> None:
+    first = PlanApplyComponent(
+        "first", uninstall_result=ComponentResult(counts={"removed": 2})
+    )
+    second = PlanApplyComponent(
+        "second", uninstall_result=ComponentResult(counts={"removed": 1, "errors": 0})
+    )
+
+    result = run_uninstall_parallel([first, second], make_context(tmp_path, yes=True))
+
+    assert result.counts == {"removed": 3, "errors": 0}
+
+
+@pytest.mark.unit
+def test_run_uninstall_parallel_reports_failure_on_error(tmp_path: Path) -> None:
+    bad = PlanApplyComponent("bad", uninstall_error=RuntimeError("uninstall exploded"))
+    good = PlanApplyComponent("good")
+
+    result = run_uninstall_parallel([bad, good], make_context(tmp_path, yes=True))
+
+    assert result.ok is False
+
+
+@pytest.mark.unit
+def test_run_components_parallel_plan_fallback_on_error(tmp_path: Path) -> None:
+    failing = PlanApplyComponent("failing", plan_error=ValueError("plan failed"))
+    succeeding = PlanApplyComponent(
+        "succeeding", plan_result=ComponentPlan(has_changes=True)
+    )
+
+    results = run_components_parallel(
+        [failing, succeeding], "plan", make_context(tmp_path, yes=True)
+    )
+
+    assert type(results[failing]) is ComponentPlan
+    assert results[failing].has_changes is False
+    assert results[succeeding].has_changes is True
+
+
+@pytest.mark.unit
+def test_run_components_parallel_respects_component_filter(tmp_path: Path) -> None:
+    included = PlanApplyComponent("included")
+    excluded = PlanApplyComponent("excluded")
+
+    from dataclasses import replace
+
+    ctx = make_context(tmp_path, yes=True)
+    ctx_filtered = replace(ctx, component_filter=("plannable",))
+
+    included.component_id = "plannable"
+    excluded.component_id = "other"
+
+    results = run_components_parallel([included, excluded], "plan", ctx_filtered)
+
+    assert included in results
+    assert excluded not in results

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -417,18 +417,23 @@ def test_run_components_parallel_plan_fallback_on_error(tmp_path: Path) -> None:
     assert results[succeeding].has_changes is True
 
 
+class _IncludedComponent(PlanApplyComponent):
+    component_id = "plannable"
+
+
+class _ExcludedComponent(PlanApplyComponent):
+    component_id = "other"
+
+
 @pytest.mark.unit
 def test_run_components_parallel_respects_component_filter(tmp_path: Path) -> None:
-    included = PlanApplyComponent("included")
-    excluded = PlanApplyComponent("excluded")
+    included = _IncludedComponent("included")
+    excluded = _ExcludedComponent("excluded")
 
     from dataclasses import replace
 
     ctx = make_context(tmp_path, yes=True)
     ctx_filtered = replace(ctx, component_filter=("plannable",))
-
-    included.component_id = "plannable"
-    excluded.component_id = "other"
 
     results = run_components_parallel([included, excluded], "plan", ctx_filtered)
 


### PR DESCRIPTION
This PR refactors all CLI components to use separate `plan()` and `apply()` phases, enabling parallel execution of install and uninstall operations.

Components previously interleaved reads and writes in a single `install()` method, forcing serial execution even when components had no dependencies on each other. `OptionalToolsComponent` (up to 180s for `uv tool install` + version checks) and `ClaudePluginComponent` (30s per `claude plugin install`) were blocking all 6 fast filesystem-only components unnecessarily.

- Add `ComponentPlan` base dataclass and typed subclasses per component in `context.py` to carry read-only state between phases
- Add `plan()` (read-only, no output) and `apply()` (write-only) to the `Component` ABC with no-op defaults, preserving the existing serial `install()` path unchanged
- Add `run_components_parallel()` to `runner.py` using `ThreadPoolExecutor` with per-thread `ContextVar[Console]` buffering so output from concurrent components never interleaves
- Rewrite `install` to use `run_install_parallel()`: sequential settings gate → parallel plan → single prompt → parallel apply
- Parallelize `uninstall` post-confirmation via `run_uninstall_parallel()`
- Extend `LifecycleOperation` to include `"plan"` and `"apply"` so the parallel dispatcher is type-safe
- Skip apply for components whose plan failed (prevents `AssertionError` cascade)
- Inject `ComponentResult(ok=False)` for apply/uninstall errors so partial failures report non-zero exit
- Use `force=True` in all `apply()` paths and `isinstance` guards instead of `assert`
- Route `uninstall()` output through `get_console()` for proper parallel buffering
- Replay buffered console output after `Progress` context exits to prevent terminal artifacts
- Add 11 tests covering parallel orchestration: plan failure fallback, error propagation, count aggregation, component filtering, confirmation bypass