### PR TITLE
Add skill download URLs and per-skill release ZIPs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -38,38 +38,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verify-metadata: true
-
-      - name: Bundle skills ZIP
-        run: |
-          if [ ! -d "src/ai_rules/config/skills" ] || [ -z "$(ls -A src/ai_rules/config/skills)" ]; then
-            echo "::error::Skills directory is empty or missing"
-            exit 1
-          fi
-          cd src/ai_rules/config/skills
-          zip -r "${{ github.workspace }}/skills-bundle.zip" .
-
-      - name: Upload skills bundle to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            "${{ github.workspace }}/skills-bundle.zip" \
-            --clobber
-
-      - name: Append download links to release notes
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          gh release view "$TAG" --json body -q '.body // ""' > /tmp/release-notes.md
-          {
-            echo ""
-            echo "---"
-            echo ""
-            echo "### Skills Downloads"
-            echo ""
-            echo "- **[Download skills ZIP](https://github.com/${REPO}/releases/download/${TAG}/skills-bundle.zip)** — upload to Claude Desktop via Customize > Skills > +"
-            echo "- **[Browse & download individual skills](https://download-directory.github.io/?url=https://github.com/${REPO}/tree/main/src/ai_rules/config/skills)** — pick specific skills"
-          } >> /tmp/release-notes.md
-          gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -38,3 +38,38 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verify-metadata: true
+
+      - name: Bundle skills ZIP
+        run: |
+          if [ ! -d "src/ai_rules/config/skills" ] || [ -z "$(ls -A src/ai_rules/config/skills)" ]; then
+            echo "::error::Skills directory is empty or missing"
+            exit 1
+          fi
+          cd src/ai_rules/config/skills
+          zip -r "${{ github.workspace }}/skills-bundle.zip" .
+
+      - name: Upload skills bundle to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ github.workspace }}/skills-bundle.zip" \
+            --clobber
+
+      - name: Append download links to release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release view "$TAG" --json body -q '.body // ""' > /tmp/release-notes.md
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Skills Downloads"
+            echo ""
+            echo "- **[Download skills ZIP](https://github.com/${REPO}/releases/download/${TAG}/skills-bundle.zip)** — upload to Claude Desktop via Customize > Skills > +"
+            echo "- **[Browse & download individual skills](https://download-directory.github.io/?url=https://github.com/${REPO}/tree/main/src/ai_rules/config/skills)** — pick specific skills"
+          } >> /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,6 @@ jobs:
             echo "### Skills Downloads"
             echo ""
             echo "- **[Download skills ZIP](https://github.com/${REPO}/releases/download/${TAG}/skills-bundle.zip)** — upload to Claude Desktop via Customize > Skills > +"
-            echo "- **[Browse & download individual skills](https://download-directory.github.io/?url=https://github.com/${REPO}/tree/main/src/ai_rules/config/skills)** — pick specific skills"
+            echo "- **[Browse individual skills](https://github.com/${REPO}/tree/${TAG}/src/ai_rules/config/skills)** — view and download specific skills from GitHub"
           } >> /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,42 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+
+      - name: Bundle skills ZIP
+        if: steps.release.outputs.released == 'true'
+        run: |
+          if [ ! -d "src/ai_rules/config/skills" ] || [ -z "$(ls -A src/ai_rules/config/skills)" ]; then
+            echo "::error::Skills directory is empty or missing"
+            exit 1
+          fi
+          cd src/ai_rules/config/skills
+          zip -r "${{ github.workspace }}/skills-bundle.zip" .
+
+      - name: Upload skills bundle to release
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh release upload "$TAG" \
+            "${{ github.workspace }}/skills-bundle.zip" \
+            --clobber
+
+      - name: Append download links to release notes
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          gh release view "$TAG" --json body -q '.body // ""' > /tmp/release-notes.md
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Skills Downloads"
+            echo ""
+            echo "- **[Download skills ZIP](https://github.com/${REPO}/releases/download/${TAG}/skills-bundle.zip)** — upload to Claude Desktop via Customize > Skills > +"
+            echo "- **[Browse & download individual skills](https://download-directory.github.io/?url=https://github.com/${REPO}/tree/main/src/ai_rules/config/skills)** — pick specific skills"
+          } >> /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
 
-      - name: Bundle skills ZIP
+      - name: Bundle per-skill ZIPs
         if: steps.release.outputs.released == 'true'
         run: |
           if [ ! -d "src/ai_rules/config/skills" ] || [ -z "$(ls -A src/ai_rules/config/skills)" ]; then
@@ -63,17 +63,18 @@ jobs:
             exit 1
           fi
           cd src/ai_rules/config/skills
-          zip -r "${{ github.workspace }}/skills-bundle.zip" .
+          for skill_dir in */; do
+            skill_name="${skill_dir%/}"
+            zip -r "${{ github.workspace }}/${skill_name}.zip" "$skill_name" -x "*/__pycache__/*"
+          done
 
-      - name: Upload skills bundle to release
+      - name: Upload skill ZIPs to release
         if: steps.release.outputs.released == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
-          gh release upload "$TAG" \
-            "${{ github.workspace }}/skills-bundle.zip" \
-            --clobber
+          gh release upload "$TAG" "${{ github.workspace }}"/*.zip --clobber
 
       - name: Append download links to release notes
         if: steps.release.outputs.released == 'true'
@@ -89,7 +90,15 @@ jobs:
             echo ""
             echo "### Skills Downloads"
             echo ""
-            echo "- **[Download skills ZIP](https://github.com/${REPO}/releases/download/${TAG}/skills-bundle.zip)** — upload to Claude Desktop via Customize > Skills > +"
-            echo "- **[Browse individual skills](https://github.com/${REPO}/tree/${TAG}/src/ai_rules/config/skills)** — view and download specific skills from GitHub"
+            echo "Each ZIP is directly uploadable to Claude Desktop (Customize > Skills > +) or Codex Desktop."
+            echo ""
+            echo "| Skill | Download |"
+            echo "|-------|----------|"
+            for skill_dir in src/ai_rules/config/skills/*/; do
+              skill_name=$(basename "$skill_dir")
+              echo "| \`${skill_name}\` | [${skill_name}.zip](https://github.com/${REPO}/releases/download/${TAG}/${skill_name}.zip) |"
+            done
+            echo ""
+            echo "**[Browse skill source on GitHub](https://github.com/${REPO}/tree/${TAG}/src/ai_rules/config/skills)**"
           } >> /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/src/ai_rules/cli/groups/skill.py
+++ b/src/ai_rules/cli/groups/skill.py
@@ -102,6 +102,8 @@ def skill_show(name: str, url: bool, download_url: bool, raw: bool) -> None:
 
     if url and download_url:
         raise click.UsageError("--url and --download-url are mutually exclusive")
+    if raw and (url or download_url):
+        raise click.UsageError("--raw cannot be combined with --url or --download-url")
 
     if url or download_url:
         managed = manager._get_managed_skills()

--- a/src/ai_rules/cli/groups/skill.py
+++ b/src/ai_rules/cli/groups/skill.py
@@ -32,7 +32,12 @@ def complete_skills(
 
 
 @skill.command("list")
-def skill_list() -> None:
+@click.option(
+    "--download-url",
+    is_flag=True,
+    help="Print browser download URL for all skills",
+)
+def skill_list(download_url: bool) -> None:
     """List all bundled skills."""
     from rich.console import Console
     from rich.table import Table
@@ -40,6 +45,18 @@ def skill_list() -> None:
     from ai_rules.skills import SkillManager
 
     console = Console()
+
+    if download_url:
+        url = SkillManager.get_download_url()
+        if url is None:
+            console.print(
+                "[red]Error:[/red] Could not determine GitHub URL. "
+                "Package metadata may be unavailable."
+            )
+            sys.exit(1)
+        click.echo(url)
+        return
+
     config_dir = cli_facade.get_config_dir()
     manager = SkillManager(config_dir=config_dir, agent_id="")
     skills = manager.list_bundled_skills()
@@ -57,8 +74,13 @@ def skill_list() -> None:
 @skill.command("show")
 @click.argument("name", shell_complete=complete_skills)
 @click.option("--url", is_flag=True, help="Print the GitHub URL instead of content")
+@click.option(
+    "--download-url",
+    is_flag=True,
+    help="Print browser download URL for this skill",
+)
 @click.option("--raw", is_flag=True, help="Print raw markdown without formatting")
-def skill_show(name: str, url: bool, raw: bool) -> None:
+def skill_show(name: str, url: bool, download_url: bool, raw: bool) -> None:
     """Show a bundled skill's content.
 
     NAME is the skill directory name (e.g., research, code-reviewer).
@@ -66,6 +88,7 @@ def skill_show(name: str, url: bool, raw: bool) -> None:
     Examples:
         ai-agent-rules skill show research
         ai-agent-rules skill show research --url
+        ai-agent-rules skill show research --download-url
         ai-agent-rules skill show code-reviewer --raw
     """
     from rich.console import Console
@@ -77,7 +100,10 @@ def skill_show(name: str, url: bool, raw: bool) -> None:
     config_dir = cli_facade.get_config_dir()
     manager = SkillManager(config_dir=config_dir, agent_id="")
 
-    if url:
+    if url and download_url:
+        raise click.UsageError("--url and --download-url are mutually exclusive")
+
+    if url or download_url:
         managed = manager._get_managed_skills()
         if name not in managed:
             available = ", ".join(sorted(managed.keys()))
@@ -85,14 +111,19 @@ def skill_show(name: str, url: bool, raw: bool) -> None:
                 f"[red]Error:[/red] Unknown skill '{name}'. Available: {available}"
             )
             sys.exit(1)
-        skill_url = SkillManager.get_skill_url(name)
-        if skill_url is None:
+
+        if download_url:
+            result = SkillManager.get_download_url(name)
+        else:
+            result = SkillManager.get_skill_url(name)
+
+        if result is None:
             console.print(
                 "[red]Error:[/red] Could not determine GitHub URL. "
                 "Package metadata may be unavailable."
             )
             sys.exit(1)
-        click.echo(skill_url)
+        click.echo(result)
         return
 
     content = manager.get_skill_content(name)

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -273,7 +273,7 @@ class SkillManager:
         for url_entry in dist.metadata.get_all("Project-URL") or []:
             label, url = url_entry.split(",", 1)
             if label.strip().lower() == "repository":
-                return url.strip()
+                return str(url.strip())
 
         return None
 

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -271,9 +271,12 @@ class SkillManager:
             return None
 
         for url_entry in dist.metadata.get_all("Project-URL") or []:
-            label, url = url_entry.split(",", 1)
+            parts = url_entry.split(",", 1)
+            if len(parts) < 2:
+                continue
+            label, url = parts
             if label.strip().lower() == "repository":
-                return str(url.strip())
+                return str(url.strip().rstrip("/"))
 
         return None
 

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -264,25 +264,38 @@ class SkillManager:
         return skill_file.read_text()
 
     @staticmethod
-    def get_skill_url(name: str) -> str | None:
-        """Construct a versioned GitHub URL for a bundled skill.
-
-        Returns:
-            GitHub blob URL, or None if repo URL can't be determined.
-        """
+    def _get_repo_url() -> str | None:
         try:
             dist = importlib.metadata.distribution("ai-agent-rules")
         except importlib.metadata.PackageNotFoundError:
             return None
 
-        repo_url = None
         for url_entry in dist.metadata.get_all("Project-URL") or []:
             label, url = url_entry.split(",", 1)
             if label.strip().lower() == "repository":
-                repo_url = url.strip()
-                break
+                return url.strip()
 
+        return None
+
+    @staticmethod
+    def get_skill_url(name: str) -> str | None:
+        """Construct a versioned GitHub URL for a bundled skill."""
+        repo_url = SkillManager._get_repo_url()
         if not repo_url:
             return None
-
         return f"{repo_url}/blob/main/src/ai_rules/config/skills/{name}/SKILL.md"
+
+    @staticmethod
+    def get_download_url(name: str | None = None) -> str | None:
+        """Construct a download-directory URL for skills.
+
+        Args:
+            name: Skill name for a single skill, or None for all skills.
+        """
+        repo_url = SkillManager._get_repo_url()
+        if not repo_url:
+            return None
+        skills_path = "src/ai_rules/config/skills"
+        if name is not None:
+            skills_path = f"{skills_path}/{name}"
+        return f"https://download-directory.github.io/?url={repo_url}/tree/main/{skills_path}"

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -1,5 +1,9 @@
 """Unit tests for skills module."""
 
+import importlib.metadata
+
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from ai_rules.skills import SkillManager
@@ -67,6 +71,94 @@ class TestGetSkillContent:
         content = manager.get_skill_content("nonexistent")
 
         assert content is None
+
+
+@pytest.mark.unit
+class TestGetRepoUrl:
+    def test_returns_repo_url_from_metadata(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "Repository, https://github.com/wpfleger96/ai-agent-rules",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager._get_repo_url()
+
+        assert url == "https://github.com/wpfleger96/ai-agent-rules"
+
+    def test_returns_none_when_package_not_found(self):
+        with patch(
+            "importlib.metadata.distribution",
+            side_effect=importlib.metadata.PackageNotFoundError("ai-agent-rules"),
+        ):
+            url = SkillManager._get_repo_url()
+
+        assert url is None
+
+    def test_returns_none_when_no_repository_url_in_metadata(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "Homepage, https://example.com",
+            "Documentation, https://docs.example.com",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager._get_repo_url()
+
+        assert url is None
+
+    def test_returns_none_when_project_url_list_is_empty(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = []
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager._get_repo_url()
+
+        assert url is None
+
+
+@pytest.mark.unit
+class TestGetDownloadUrl:
+    def test_returns_url_for_all_skills_when_name_is_none(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "Repository, https://github.com/wpfleger96/ai-agent-rules",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager.get_download_url()
+
+        assert url is not None
+        assert url.startswith("https://download-directory.github.io/?url=")
+        assert "github.com/wpfleger96/ai-agent-rules" in url
+        assert "/tree/main/src/ai_rules/config/skills" in url
+        assert url.endswith("/tree/main/src/ai_rules/config/skills")
+
+    def test_returns_url_for_specific_skill(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "Repository, https://github.com/wpfleger96/ai-agent-rules",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager.get_download_url("research")
+
+        assert url is not None
+        assert url.startswith("https://download-directory.github.io/?url=")
+        assert "/tree/main/src/ai_rules/config/skills/research" in url
+
+    def test_returns_none_when_repo_url_unavailable(self):
+        with patch(
+            "importlib.metadata.distribution",
+            side_effect=importlib.metadata.PackageNotFoundError("ai-agent-rules"),
+        ):
+            url = SkillManager.get_download_url("research")
+
+        assert url is None
+
+    def test_returns_none_for_all_skills_when_repo_url_unavailable(self):
+        with patch(
+            "importlib.metadata.distribution",
+            side_effect=importlib.metadata.PackageNotFoundError("ai-agent-rules"),
+        ):
+            url = SkillManager.get_download_url()
+
+        assert url is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -113,6 +113,27 @@ class TestGetRepoUrl:
 
         assert url is None
 
+    def test_skips_malformed_project_url_entries(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "malformed-no-comma",
+            "Repository, https://github.com/wpfleger96/ai-agent-rules",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager._get_repo_url()
+
+        assert url == "https://github.com/wpfleger96/ai-agent-rules"
+
+    def test_strips_trailing_slash_from_repo_url(self):
+        mock_dist = MagicMock()
+        mock_dist.metadata.get_all.return_value = [
+            "Repository, https://github.com/wpfleger96/ai-agent-rules/",
+        ]
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            url = SkillManager._get_repo_url()
+
+        assert url == "https://github.com/wpfleger96/ai-agent-rules"
+
 
 @pytest.mark.unit
 class TestGetDownloadUrl:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-agent-rules"
-version = "0.47.10"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR adds browser download URLs to the skill CLI and generates per-skill ZIP files as GitHub Release assets, making bundled skills directly uploadable to Claude Desktop and Codex Desktop without requiring the Python package.

Skills were only accessible via the CLI's symlink installation model, with no distribution path for Claude Desktop users — who need individual skill ZIPs they can upload via Customize > Skills > +. Research confirmed Claude Desktop requires one skill per ZIP with `skill-name/SKILL.md` at the archive root.

- Add `SkillManager.get_download_url()` backed by a shared `_get_repo_url()` helper (extracted from `get_skill_url()`); exposes `--download-url` flag on `skill show <name>` and `skill list` to generate download-directory.github.io links for browsing skills
- Generate per-skill ZIPs in `release.yml` after each release — each ZIP contains one skill directory at root (e.g., `research.zip` → `research/SKILL.md` + `research/references/`), directly uploadable to Claude Desktop or Codex Desktop
- Append a markdown table of per-skill download links plus a GitHub tree browse link to release notes automatically
- Guard against malformed `Project-URL` metadata and trailing slashes in `_get_repo_url()`; make `--url`, `--download-url`, and `--raw` mutually exclusive on `skill show`