### PR TITLE
Default PRs to draft, mandate implementation subagents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ branch = "main"
 commit_parser = "conventional"
 commit_message = "chore(release): {version}"
 allow_zero_version = true
-build_command = "pip install uv && uv sync"
+build_command = "pip install uv && uv lock"
+assets = ["uv.lock"]
 
 [tool.semantic_release.commit_parser_opts]
 allowed_types = ["feat", "fix", "chore", "ci", "docs", "style", "refactor", "test"]

--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -27,7 +27,7 @@
 
 | Stage | Action | Proceed when |
 |-------|--------|--------------|
-| 1. Implement | Write/modify code to meet requirements | Code written |
+| 1. Implement | Decompose work by file/concern; brief parallel implementation subagents with explicit file ownership (see Delegation section); verify all results before proceeding | All target files updated, results verified |
 | 2. Quality Checks | Run format, lint, test via project tooling (`just check` or individually) | All checks pass (fix any issues found) |
 | 3. Write Tests | Invoke `test-writer` skill for new/changed code paths | Tests written and passing |
 | 4. Review | Invoke `code-reviewer` skill via Agent tool (isolated subagent with fresh context) | Review findings returned |
@@ -43,19 +43,17 @@
 
 ### Delegation & Multi-Agent Orchestration
 
-**Rule:** For non-trivial tasks, proactively delegate to parallel subagents with fresh context windows rather than handling everything in a single conversation. Context contamination is a measured degradation — all frontier models lose quality as context grows, even with irrelevant content.
+**Rule:** Always delegate code implementation to parallel subagents. Never write code changes directly in the orchestrator context — implementation diffs bloat context and force compaction before review or revision can proceed. For non-implementation tasks, delegate when parallelism or context isolation provides clear benefit.
 
 **When to delegate (spawn subagents):**
-- Task spans 3+ files AND involves cross-cutting concerns (security + performance + correctness)
-- Task requires synthesizing multiple independent perspectives for quality
-- Accumulated context would exceed ~50% of effective window with all relevant code loaded
-- Task has clearly independent subtasks that can run in parallel (research, review lenses, test generation)
+- **Always:** Code implementation — split by file/concern; one subagent per file or per group of files sharing a broken intermediate state; sequence only when an interface is genuinely unknowable before upstream is written
+- Non-implementation tasks: when context would exceed ~50% of effective window with all relevant code loaded
+- Non-implementation tasks: when independent subtasks can run in parallel (research, review lenses, test generation)
 
 **When NOT to delegate (handle inline):**
-- Single-file, single-concern change
-- Highly sequential tasks where each step requires the previous step's actual output (not just a summary)
-- Ambiguously specified tasks — clarify scope first, then decide (ambiguity amplifies across N agents)
-- Task is simpler than the orchestration overhead justifies
+- Single-line mechanical changes (renaming a constant, fixing a typo in a string literal) — the only implementation exception
+- Highly sequential non-implementation tasks where each step requires the previous step's actual output
+- Ambiguously specified tasks — clarify scope first before spawning agents (ambiguity amplifies across N agents)
 
 **How to brief subagents (self-containment protocol):**
 Subagents have ZERO access to the parent conversation. Every briefing must include:
@@ -65,7 +63,12 @@ Subagents have ZERO access to the parent conversation. Every briefing must inclu
 4. **Scope boundaries** — explicit "do NOT research/review/implement X — another agent handles that"
 5. **Key questions** — 3-5 specific, answerable questions that serve as success criteria
 
-Implementation tasks: assign explicit file ownership per agent. Analysis tasks: `sonnet` for execution-heavy, `opus` for judgment-heavy.
+Implementation briefings additionally require:
+6. **File ownership list** — explicit list of files this agent may create or modify; prohibit touching any file not on the list
+7. **Plan context** — the relevant portion of the overall plan, including interfaces this file's changes must satisfy and what parallel agents are doing
+8. **Forbidden files** — explicitly name every file owned by another parallel agent
+
+Analysis tasks: `sonnet` for execution-heavy, `opus` for judgment-heavy.
 
 **How to synthesize subagent results:**
 - Organize output by theme, not by which agent produced it
@@ -75,7 +78,7 @@ Implementation tasks: assign explicit file ownership per agent. Analysis tasks: 
 
 **Anti-patterns (avoid):**
 - **Bag of agents**: Flat topology with no scope boundaries
-- **Over-delegation**: Spawning agents for tasks simpler than the coordination overhead
+- **Over-delegation**: Spawning multiple agents for a change with a single atomic unit of work (e.g., one two-line fix that only one file can own)
 - **Under-briefing**: Vague objectives or missing scope boundaries
 - **Open-loop execution**: No verification gate after synthesis — always validate before presenting results
 - **Echo chamber**: Same model for all perspectives — add diversity via external models when available

--- a/src/ai_rules/config/skills/pr-creator/SKILL.md
+++ b/src/ai_rules/config/skills/pr-creator/SKILL.md
@@ -16,7 +16,7 @@ model: sonnet
 
 # Create GitHub Pull Request
 
-**Usage:** `/pr-creator` - Create regular PR | `/pr-creator draft` - Create draft PR
+**Usage:** `/pr-creator` - Create draft PR (default) | `/pr-creator open` - Create regular PR
 
 Expert software engineer creating high-quality PR descriptions that facilitate efficient code review.
 
@@ -31,7 +31,7 @@ Expert software engineer creating high-quality PR descriptions that facilitate e
 
 ### Step 1: Detect Mode & PR Type
 
-**Mode:** Check `$1` equals "draft" → draft PR, else regular PR
+**Mode:** Check `$1` equals "open" → regular PR, else draft PR
 
 **Classify PR type** via `git log origin/{base}..HEAD --format="%s"`:
 - **Feature:** feat:, add, implement, create, new functionality
@@ -67,19 +67,7 @@ Use structure from `references/templates.md`. Key principles:
 
 See `references/templates.md` for detailed structure and examples.
 
-### Step 4: Present Draft & STOP
-
-Present draft to user and **STOP**. Wait for explicit approval.
-
-When presenting:
-- Indicate draft/regular PR mode
-- Ask to proceed or revise
-
-## Stage 2: Create Pull Request
-
-**Only after explicit user approval.**
-
-### Verification
+### Step 4: Verify & Create
 
 **Check for PLAN files:**
 ```bash
@@ -100,18 +88,18 @@ git push -u origin HEAD
 
 **Create** (use HEREDOC for formatting):
 
-**Regular:**
+**Draft (default):**
 ```bash
-gh pr create --title "Title" --base {base} --body "$(cat <<'EOF'
-[Full approved description]
+gh pr create --title "Title" --base {base} --draft --body "$(cat <<'EOF'
+[Full description]
 EOF
 )"
 ```
 
-**Draft:**
+**Regular (`open` override):**
 ```bash
-gh pr create --title "Title" --base {base} --draft --body "$(cat <<'EOF'
-[Full approved description]
+gh pr create --title "Title" --base {base} --body "$(cat <<'EOF'
+[Full description]
 EOF
 )"
 ```
@@ -119,8 +107,6 @@ EOF
 **Display PR URL** upon success.
 
 ## Critical Requirements
-
-**Approval Gate:** NEVER skip user approval | ALWAYS present draft and wait | Accept revisions | Only proceed after clear approval
 
 **Accuracy:** Inspect actual commits via git | Review code changes via diff | Don't rely solely on commit messages | Verify issue refs exist | Derive URLs for external references from context (never hardcode base URLs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-agent-rules"
-version = "0.52.0"
+version = "0.52.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Remove the human approval gate from the pr-creator skill and flip the default mode to draft PRs for safety. Agents now generate the description and create the PR in one continuous flow — `/pr-creator open` bypasses draft when explicitly requested.

The AGENTS.md delegation section is hardened so code implementation is always delegated to parallel subagents with explicit file ownership, keeping the orchestrator context lean and avoiding forced compaction between implementation and review. The briefing protocol gains three implementation-specific requirements (file ownership list, plan context, forbidden files).

- Remove pr-creator Step 4 approval gate and Stage 2 separation; merge into continuous Stage 1 flow
- Invert pr-creator default: `/pr-creator` creates draft, `/pr-creator open` creates regular PR
- Mandate implementation delegation in Autonomous Coding Workflow Stage 1 and Delegation section
- Add implementation-specific briefing protocol items 6-8 (file ownership, plan context, forbidden files)
- Fix `uv.lock` release drift by adding `assets = ["uv.lock"]` to PSR config