### PR TITLE
fix(tests): drop SchemaStore permissionRule false-positive allowlist

### DIFF
--- a/tests/integration/test_schema_validation.py
+++ b/tests/integration/test_schema_validation.py
@@ -8,17 +8,6 @@ import pytest
 
 from ai_rules.config import load_config_file
 
-# Exact permission strings that the SchemaStore permissionRule pattern
-# incorrectly rejects. The regex lookahead (?=.*[^)*?]) requires at least
-# one non-wildcard character inside the argument, so bare (*) fails.
-# Upstream issue: https://github.com/SchemaStore/schemastore/issues/5598
-KNOWN_CLAUDE_SCHEMA_FALSE_POSITIVES: frozenset[str] = frozenset(
-    {
-        "Read(*)",
-        "Skill(*)",
-    }
-)
-
 # Live URLs point at upstream main so the integration suite catches real
 # provider schema drift during normal test runs.
 SCHEMA_URLS = {
@@ -34,13 +23,6 @@ GOOSE_SCHEMA_PATH = (
 
 def _config_root() -> Path:
     return Path(str(resource_files("ai_rules") / "config"))
-
-
-def _is_known_false_positive(err: jsonschema.ValidationError) -> bool:
-    return (
-        err.validator == "pattern"
-        and err.instance in KNOWN_CLAUDE_SCHEMA_FALSE_POSITIVES
-    )
 
 
 @pytest.mark.integration
@@ -70,20 +52,7 @@ class TestProviderSchemaValidation:
 
     def test_claude_settings_validates_against_schema(self, claude_schema):
         config = load_config_file(_config_root() / "claude" / "settings.json", "json")
-        validator = jsonschema.Draft7Validator(claude_schema)
-        all_errors = list(validator.iter_errors(config))
-
-        known = [e for e in all_errors if _is_known_false_positive(e)]
-        unexpected = [e for e in all_errors if not _is_known_false_positive(e)]
-
-        if unexpected:
-            raise unexpected[0]
-
-        if known:
-            pytest.xfail(
-                f"SchemaStore permissionRule false positive "
-                f"({len(known)} instance(s): {[e.instance for e in known]})"
-            )
+        jsonschema.validate(config, claude_schema)
 
     def test_claude_settings_has_no_unknown_keys(self, claude_schema):
         """Catch keys we ship that are deprecated or never existed upstream.


### PR DESCRIPTION
Upstream SchemaStore issue #5598 is resolved (PR #5707 removed the
permissionRule lookahead that rejected Read(*) and Skill(*)). Remove the
allowlist, helper, and special-case branching so the Claude settings test
validates plainly like the codex/gemini tests.

https://claude.ai/code/session_0129WsPYeWBMH7KUwuAQqnjy