### PR TITLE
chore: bump mypy target to Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 mypy_path = "src"
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
## Summary

- Bump mypy `python_version` from `"3.13"` to `"3.14"` to match the Python 3.14 runtime

`.python-version` bump handled separately by Renovate.