### PR TITLE
chore: tighten requires-python and remove mypy version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-agent-rules"
 version = "0.54.0"
 description = "Manage user-level AI agent configurations"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 license = "MIT"
 authors = [
     { name = "Will Pfleger", email = "pfleger.will@gmail.com" }
@@ -26,7 +26,6 @@ dependencies = [
     "packaging>=21.0",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "tomli>=2.0.0; python_version<'3.11'",
     "tomli-w>=1.0.0",
     "tomlkit>=0.12.0",
 ]
@@ -84,7 +83,6 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.mypy]
-python_version = "3.13"
 mypy_path = "src"
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
## Summary

- Sets `requires-python` to `>=3.14` (was `>=3.10`)
- Removes `python_version = "3.13"` from `[tool.mypy]` — mypy now auto-detects from the running interpreter, so `.python-version` becomes the single source of truth
- Removes the `tomli>=2.0.0; python_version<'3.11'` conditional dependency — `tomllib` has been in the stdlib since Python 3.11, and this project now requires >=3.14

Companion to the Renovate PR that bumps `.python-version` to `3.14`.