### PR TITLE
feat(teams): add agent team support with subagent definitions and skill migrations

### DIFF
--- a/src/ai_rules/agents/claude.py
+++ b/src/ai_rules/agents/claude.py
@@ -45,7 +45,7 @@ class ClaudeAgent(Agent):
 
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Claude Code symlinks including dynamic agents/commands."""
+        """Cached list of all Claude Code symlinks including dynamic commands."""
         result = []
 
         result.append(
@@ -58,16 +58,6 @@ class ClaudeAgent(Agent):
                 "claude", settings_file, force=bool(self._effective_preserved_fields)
             )
             result.append((Path("~/.claude/settings.json"), target_file))
-
-        agents_dir = self.config_dir / "claude" / "agents"
-        if agents_dir.exists():
-            for agent_file in sorted(agents_dir.glob("*.md")):
-                result.append(
-                    (
-                        Path(f"~/.claude/agents/{agent_file.name}"),
-                        agent_file,
-                    )
-                )
 
         commands_dir = self.config_dir / "claude" / "commands"
         if commands_dir.exists():

--- a/src/ai_rules/agents/shared.py
+++ b/src/ai_rules/agents/shared.py
@@ -34,12 +34,18 @@ class SharedAgent(Agent):
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
         """Cached list of shared symlinks for agent-agnostic configurations."""
-        from ai_rules.config import AGENT_SKILLS_DIRS
+        from ai_rules.config import AGENT_AGENTS_DIRS, AGENT_SKILLS_DIRS
         from ai_rules.skills import SkillManager
 
         result = []
 
         result.append((Path("~/AGENTS.md"), self.config_dir / "AGENTS.md"))
+
+        agents_dir = self.config_dir / "agents"
+        if agents_dir.exists():
+            for agent_file in sorted(agents_dir.glob("*.md")):
+                for agent_agents_dir in AGENT_AGENTS_DIRS.values():
+                    result.append((agent_agents_dir / agent_file.name, agent_file))
 
         skills_dir = self.config_dir / "skills"
         if skills_dir.exists():

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "Config",
+    "AGENT_AGENTS_DIRS",
     "AGENT_FORMATS",
     "FORMAT_CONFIG_FILES",
     "AGENT_SKILLS_DIRS",
@@ -59,6 +60,11 @@ FORMAT_CONFIG_FILES: dict[str, str] = {
     "json": "settings.json",
     "toml": "config.toml",
     "yaml": "config.yaml",
+}
+
+AGENT_AGENTS_DIRS = {
+    "claude": Path("~/.claude/agents"),
+    "gemini": Path("~/.gemini/agents"),
 }
 
 AGENT_SKILLS_DIRS = {

--- a/src/ai_rules/config/agents/impl-worker.md
+++ b/src/ai_rules/config/agents/impl-worker.md
@@ -1,0 +1,28 @@
+---
+name: impl-worker
+description: General-purpose implementation agent for parallel feature work. Receives file ownership boundaries in its spawn prompt.
+model: sonnet
+effort: high
+color: green
+isolation: worktree
+---
+
+Implementation agent with explicit file ownership boundaries provided in the spawn prompt.
+
+Before writing code: read the relevant codebase context, understand existing patterns, and
+confirm you understand the interfaces your changes must satisfy.
+
+Follow existing patterns in the codebase. Do not introduce new abstractions unless the
+plan explicitly calls for them.
+
+After making changes: run format and lint. If a Justfile exists, use `just format` and
+`just lint`. Otherwise use the project's configured tooling.
+
+Check the task list for your assigned work. If you need interface clarification from a
+parallel agent, send them a message rather than guessing.
+
+Never touch files not on your ownership list. If you discover a needed change in an
+out-of-scope file, message the appropriate teammate or flag it in your completion report.
+
+Mark your task complete only when: code compiles or passes lint, existing patterns are
+followed, and all changes are confined to your owned files.

--- a/src/ai_rules/config/agents/perf-reviewer.md
+++ b/src/ai_rules/config/agents/perf-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: perf-reviewer
+description: Reviews code for performance issues including algorithmic complexity, N+1 queries, memory allocation, and hot path inefficiencies
+tools: Read, Grep, Glob, Bash
+model: sonnet
+effort: high
+color: orange
+---
+
+Performance-focused reviewer. Only concern is performance.
+
+Checks: O(n²)+ algorithms where linear exists, N+1 queries, allocations in tight loops,
+missing pagination on unbounded results, unbounded collection growth, sync blocking in
+async contexts, redundant computation, inefficient data structure choices.
+
+Distinguishes hot paths (called frequently or on large data) from cold paths (startup,
+one-time config). Only flag issues on hot paths unless the cold-path issue is severe.
+
+For each finding, report:
+- Location: file:line
+- Perf impact: why this matters at scale
+- Fix: concrete change with expected improvement
+
+Do not flag micro-optimizations with negligible real-world impact.

--- a/src/ai_rules/config/agents/research-synthesizer.md
+++ b/src/ai_rules/config/agents/research-synthesizer.md
@@ -1,0 +1,31 @@
+---
+name: research-synthesizer
+description: Synthesizes research findings from multiple researcher teammates into a coherent report. Identifies agreements, conflicts, and gaps.
+tools: Read, Write, Bash
+model: opus
+effort: high
+color: yellow
+---
+
+Synthesizes findings from multiple researcher agents into a coherent report.
+
+Wait for research tasks to complete before synthesizing. Check task statuses before
+proceeding.
+
+Produce connected reasoning, not concatenation. Do not summarize each researcher's output
+in sequence — find the underlying structure across all findings.
+
+Agreement: when multiple HIGH-confidence findings converge on the same point, call it out
+as strongly supported. Conflicts: surface both sides explicitly, do not silently pick one.
+
+Weight findings by confidence level. Challenge weak findings: a LOW-confidence claim with
+no corroboration from other angles should be flagged as unverified, not presented as fact.
+
+Check for saturation: if multiple researchers returned overlapping information, note it
+rather than repeating it.
+
+Flag gaps: questions that remain open after all research is complete.
+
+Write the Bottom Line section last, after completing full synthesis across all inputs.
+
+Follow the report format specified in the task description.

--- a/src/ai_rules/config/agents/researcher.md
+++ b/src/ai_rules/config/agents/researcher.md
@@ -1,0 +1,30 @@
+---
+name: researcher
+description: Focused web research agent that investigates a specific angle of a research question. Returns structured findings with confidence levels.
+tools: Read, WebSearch, WebFetch, Bash
+model: sonnet
+effort: high
+color: purple
+---
+
+Focused research agent for one specific angle of a research question.
+
+Issue parallel tool calls: run 3+ searches simultaneously with different keyword
+combinations rather than sequentially. Prefer authoritative sources: official documentation,
+academic papers, reputable journalism, primary sources over secondary summaries.
+
+Verify key claims against 2+ independent sources before reporting HIGH confidence. If only
+one source supports a claim, mark it MEDIUM or LOW.
+
+When you find information clearly outside your assigned angle that would help a teammate,
+send them a message rather than expanding your own scope.
+
+Stop when searches return overlapping results with no new information (diminishing returns).
+
+Return structured findings:
+- Key Facts: each fact with confidence (HIGH / MEDIUM / LOW) and source
+- Evidence Base: primary sources used
+- Open Questions: what remains unresolved within your angle
+- Confidence Assessment: overall confidence in the findings and why
+
+Synthesize findings into coherent points. Do not dump raw search results.

--- a/src/ai_rules/config/agents/security-reviewer.md
+++ b/src/ai_rules/config/agents/security-reviewer.md
@@ -1,0 +1,22 @@
+---
+name: security-reviewer
+description: Reviews code for security vulnerabilities including OWASP top 10, injection, auth issues, and secrets exposure
+tools: Read, Grep, Glob, Bash
+model: opus
+effort: high
+color: red
+---
+
+Security-focused reviewer. Only concern is security.
+
+Checks: injection (SQL, command, XSS, template), auth/authz bypasses, hard-coded secrets,
+insecure deserialization, path traversal, SSRF, info-leaking error handling, missing input
+validation at trust boundaries, weak crypto.
+
+For each finding, report:
+- Severity: CRITICAL / HIGH / MEDIUM / LOW
+- Location: file:line
+- Exploit scenario: concrete, realistic attack vector
+- Fix: specific code change or mitigation
+
+If nothing is found, say so clearly. Do not invent findings to appear thorough.

--- a/src/ai_rules/config/agents/test-coverage-reviewer.md
+++ b/src/ai_rules/config/agents/test-coverage-reviewer.md
@@ -1,0 +1,24 @@
+---
+name: test-coverage-reviewer
+description: Reviews code changes for missing test coverage, untested edge cases, and test quality issues
+tools: Read, Grep, Glob
+model: sonnet
+effort: medium
+color: blue
+---
+
+Test coverage reviewer. Only concern is coverage and test quality.
+
+Identifies missing coverage: untested error/edge paths, missing boundary tests, integration
+points lacking tests, new public APIs without tests, changed behavior without test updates.
+
+Evaluates existing tests: tests behavior not implementation details, assertions are
+meaningful, tests are deterministic and independent, names follow test_<scenario>_<result>.
+
+Does not require 100% coverage. Prioritizes: business logic with branches, data corruption
+paths, error conditions that affect callers, security-relevant input handling.
+
+For each finding, report:
+- Location: file:line (the code missing coverage, not the test file)
+- What is untested: specific scenario or path
+- Suggested test case: describe what to assert, not full code

--- a/src/ai_rules/config/agents/test-writer-agent.md
+++ b/src/ai_rules/config/agents/test-writer-agent.md
@@ -1,0 +1,26 @@
+---
+name: test-writer-agent
+description: Writes behavior-focused tests for completed implementation tasks. Emphasizes testing behavior over implementation details.
+model: sonnet
+effort: high
+color: cyan
+---
+
+Writes tests for completed implementations. Tests behavior, not implementation details.
+
+Structure: arrange-act-assert. Names: test_<scenario>_<result>.
+
+Prioritize: business logic with decision branches, error conditions, edge cases that could
+corrupt data, integration points between components, public API contracts.
+
+Skip: trivial getters/setters, framework boilerplate, private implementation details that
+will change, one-line functions with no branches.
+
+Use the project's existing test framework and conventions. Check existing tests first to
+match style, fixture patterns, and naming conventions before writing new ones.
+
+Do not mock internal implementation details. Mock only at external boundaries (network,
+filesystem, third-party APIs).
+
+After writing tests, run the test suite to confirm all new tests pass and no existing
+tests regress.

--- a/src/ai_rules/config/claude/CLAUDE.md
+++ b/src/ai_rules/config/claude/CLAUDE.md
@@ -1,1 +1,11 @@
 @~/AGENTS.md
+
+# Agent Teams
+
+When agent teams are available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), the following shared agent definitions can be used as teammates:
+
+**Code Review:** `security-reviewer` (opus/red), `perf-reviewer` (sonnet/orange), `test-coverage-reviewer` (sonnet/blue)
+**Implementation:** `impl-worker` (sonnet/green, worktree-isolated), `test-writer-agent` (sonnet/cyan)
+**Research:** `researcher` (sonnet/purple), `research-synthesizer` (opus/yellow)
+
+Reference them by name when creating teammates (e.g., "spawn a security-reviewer teammate").

--- a/src/ai_rules/config/profiles/personal.yaml
+++ b/src/ai_rules/config/profiles/personal.yaml
@@ -4,6 +4,8 @@ extends: default
 settings_overrides:
   claude:
     model: opusplan
+    env:
+      CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
     hooks:
       Stop:
         - hooks:

--- a/src/ai_rules/config/skills/code-reviewer/SKILL.md
+++ b/src/ai_rules/config/skills/code-reviewer/SKILL.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Performs thorough code review on local changes or PRs. Use this skill proactively after implementing code changes to catch issues before commit/push. Also use when reviewing PRs from other engineers.
 agent: general-purpose
-allowed-tools: Agent, AskUserQuestion, Bash, Glob, Grep, Read, TodoWrite
+allowed-tools: Agent, AskUserQuestion, Bash, Glob, Grep, Read, SendMessage, TaskCreate, TaskGet, TaskList, TeamCreate, TodoWrite
 model: opus
 ---
 
@@ -141,6 +141,8 @@ For Small complexity diffs, execute the review inline using all four lenses sequ
 After applying all lenses, proceed directly to Phase 3.
 
 ### Phase 2B: Orchestrated Review (Medium/Large Diffs)
+
+**Teams optimization (optional):** If the `TeamCreate` tool is available, you may use agent teams instead of parallel Agent calls below. Create teammates using the `security-reviewer`, `test-coverage-reviewer`, and (when `performance_relevant = true`) `perf-reviewer` subagent types. Benefits: shared task list and peer messaging for cross-cutting concerns. If `TeamCreate` is unavailable, proceed with Agent calls as described below.
 
 For Medium and Large complexity diffs, spawn parallel Claude subagents — each with a fresh context window focused on a single review lens. This produces higher quality findings because each agent dedicates its full context to one concern without cross-lens contamination.
 

--- a/src/ai_rules/config/skills/research/SKILL.md
+++ b/src/ai_rules/config/skills/research/SKILL.md
@@ -6,7 +6,7 @@ description: >
   'what do we know about', or when a question requires synthesizing information
   from multiple sources. Scales from simple inline answers to 10 parallel
   research agents based on query complexity.
-allowed-tools: Agent, AskUserQuestion, Bash, Read, WebFetch, WebSearch, Write
+allowed-tools: Agent, AskUserQuestion, Bash, Read, SendMessage, TaskCreate, TaskGet, TaskList, TeamCreate, WebFetch, WebSearch, Write
 model: opus
 ---
 
@@ -68,6 +68,8 @@ Then build a subagent manifest. For each subagent, define:
 **Parallelizability**: Most agents should run in parallel. Only introduce sequencing dependencies when an agent genuinely needs another's output (rare — avoid unless truly necessary).
 
 ## Phase 3: Parallel execution
+
+**Teams optimization (optional):** If the `TeamCreate` tool is available, you may use agent teams instead of parallel Agent calls below. Create teammates using the `researcher` and `research-synthesizer` subagent types. Benefits: shared task list, peer messaging between researchers, and task dependencies for synthesis ordering. If `TeamCreate` is unavailable, proceed with Agent calls as described below.
 
 Load the subagent briefing template from `references/subagent-template.md` in this skill's directory.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,14 +132,14 @@ def test_repo(tmp_path):
 
     (config_root / "AGENTS.md").write_text("# Shared Agent Rules\nTest content")
 
+    shared_agents = config_root / "agents"
+    shared_agents.mkdir()
+    (shared_agents / "test-agent.md").write_text("# Test Agent\nAgent content")
+
     claude_dir = config_root / "claude"
     claude_dir.mkdir()
     (claude_dir / "settings.json").write_text('{"test": "settings"}')
     (claude_dir / "CLAUDE.md").write_text("@~/AGENTS.md\n")
-
-    claude_agents = claude_dir / "agents"
-    claude_agents.mkdir()
-    (claude_agents / "test-agent.md").write_text("# Test Agent\nAgent content")
 
     claude_commands = claude_dir / "commands"
     claude_commands.mkdir()

--- a/tests/integration/test_install_flow.py
+++ b/tests/integration/test_install_flow.py
@@ -129,20 +129,22 @@ class TestInstallFlow:
             assert not (Path(str(path).replace("~", str(mock_home)))).exists()
 
     def test_install_with_multiple_agent_files(self, test_repo, mock_home):
-        agents_dir = test_repo / "claude" / "agents"
+        agents_dir = test_repo / "agents"
         (agents_dir / "agent1.md").write_text("# Agent 1")
         (agents_dir / "agent2.md").write_text("# Agent 2")
         (agents_dir / "agent3.md").write_text("# Agent 3")
 
-        config = Config(exclude_symlinks=[])
-        claude = ClaudeAgent(test_repo, config)
+        from ai_rules.agents.shared import SharedAgent
 
-        for target, source in claude.symlinks:
+        config = Config(exclude_symlinks=[])
+        shared = SharedAgent(test_repo, config)
+
+        for target, source in shared.symlinks:
             target_path = Path(str(target).replace("~", str(mock_home)))
             create_symlink(target_path, source, dry_run=False, force=False)
 
-        agent_dir = mock_home / ".claude" / "agents"
-        agent_files = list(agent_dir.glob("*.md"))
+        claude_agent_dir = mock_home / ".claude" / "agents"
+        agent_files = list(claude_agent_dir.glob("*.md"))
         assert len(agent_files) == 4
         assert all(f.is_symlink() for f in agent_files)
 

--- a/tests/integration/test_uninstall_safety.py
+++ b/tests/integration/test_uninstall_safety.py
@@ -53,11 +53,14 @@ class TestUninstallSafety:
         assert not target_path.exists()
 
     def test_complete_uninstall_cleanup(self, test_repo, mock_home):
+        from ai_rules.agents.shared import SharedAgent
+
         config = Config(exclude_symlinks=[])
         claude = ClaudeAgent(test_repo, config)
         goose = GooseAgent(test_repo, config)
+        shared = SharedAgent(test_repo, config)
 
-        for agent in [claude, goose]:
+        for agent in [claude, goose, shared]:
             for target, source in agent.symlinks:
                 target_path = Path(str(target).replace("~", str(mock_home)))
                 create_symlink(target_path, source, force=False, dry_run=False)
@@ -76,7 +79,7 @@ class TestUninstallSafety:
         for file in claude_files + goose_files:
             assert file.is_symlink()
 
-        for agent in [claude, goose]:
+        for agent in [claude, goose, shared]:
             for target, _source in agent.symlinks:
                 target_path = Path(str(target).replace("~", str(mock_home)))
                 remove_symlink(target_path, force=True)

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -22,24 +22,7 @@ class TestClaudeAgent:
         targets = [str(target) for target, _ in symlinks]
         assert "~/.claude/CLAUDE.md" in targets
         assert "~/.claude/settings.json" in targets
-        assert "~/.claude/agents/test-agent.md" in targets
         assert "~/.claude/commands/test-command.md" in targets
-
-    def test_dynamic_discovery_of_multiple_agents(self, test_repo):
-        agents_dir = test_repo / "claude" / "agents"
-        (agents_dir / "another-agent.md").write_text("# Another Agent")
-        (agents_dir / "third-agent.md").write_text("# Third Agent")
-
-        agent = ClaudeAgent(test_repo, Config(exclude_symlinks=[]))
-        symlinks = agent.symlinks
-
-        agent_targets = [
-            str(target) for target, _ in symlinks if "/agents/" in str(target)
-        ]
-        assert len(agent_targets) == 3
-        assert "~/.claude/agents/test-agent.md" in agent_targets
-        assert "~/.claude/agents/another-agent.md" in agent_targets
-        assert "~/.claude/agents/third-agent.md" in agent_targets
 
     def test_dynamic_discovery_of_multiple_commands(self, test_repo):
         commands_dir = test_repo / "claude" / "commands"
@@ -59,7 +42,6 @@ class TestClaudeAgent:
         config = Config(
             exclude_symlinks=[
                 "~/.claude/settings.json",
-                "~/.claude/agents/test-agent.md",
             ]
         )
         agent = ClaudeAgent(test_repo, config)
@@ -68,7 +50,6 @@ class TestClaudeAgent:
 
         targets = [str(target) for target, _ in symlinks]
         assert "~/.claude/settings.json" not in targets
-        assert "~/.claude/agents/test-agent.md" not in targets
         assert "~/.claude/CLAUDE.md" in targets
         assert "~/.claude/commands/test-command.md" in targets
 
@@ -219,7 +200,21 @@ class TestSharedAgent:
 
         targets = [str(target) for target, _ in symlinks]
         assert "~/AGENTS.md" in targets
-        assert len(targets) == 1
+        assert "~/.claude/agents/test-agent.md" in targets
+        assert "~/.gemini/agents/test-agent.md" in targets
+
+    def test_discovers_multiple_agent_definitions(self, test_repo):
+        agents_dir = test_repo / "agents"
+        (agents_dir / "another-agent.md").write_text("# Another Agent")
+
+        agent = SharedAgent(test_repo, Config(exclude_symlinks=[]))
+        symlinks = agent.symlinks
+
+        targets = [str(target) for target, _ in symlinks]
+        assert "~/.claude/agents/test-agent.md" in targets
+        assert "~/.claude/agents/another-agent.md" in targets
+        assert "~/.gemini/agents/test-agent.md" in targets
+        assert "~/.gemini/agents/another-agent.md" in targets
 
     def test_excludes_filtered_symlinks(self, test_repo):
         config = Config(exclude_symlinks=["~/AGENTS.md"])
@@ -229,4 +224,3 @@ class TestSharedAgent:
 
         targets = [str(target) for target, _ in symlinks]
         assert "~/AGENTS.md" not in targets
-        assert len(targets) == 0


### PR DESCRIPTION
This PR adds Claude Code agent team support — a library of 7 subagent role definitions and migrations of `/research` and `/code-reviewer` to use native teams instead of ad-hoc `Agent` spawning.

Claude Code's experimental agent teams feature allows spawning coordinated teammates with shared task lists and peer-to-peer messaging. The version-controllable primitive is subagent definitions (`.claude/agents/*.md`), which ai-rules already symlinks from `src/ai_rules/config/claude/agents/` — the directory just needed to be created and populated. Teams are gated to the personal profile so default-profile users don't get the experimental feature; `work` inherits it via `extends: personal`.

- `src/ai_rules/config/claude/agents/` — 7 role definitions symlinked to `~/.claude/agents/`: `security-reviewer` (opus), `perf-reviewer`, `test-coverage-reviewer`, `impl-worker` (worktree-isolated), `test-writer-agent`, `researcher`, and `research-synthesizer`
- `/research` Standard+ tiers migrated to `TeamCreate` + `TaskCreate` with `researcher` and `research-synthesizer` teammates; lead reviews synthesizer output before delivery; falls back to parallel `Agent` calls when teams unavailable
- `/code-reviewer` Medium/Large path migrated: lead handles Design & Functionality inline while `security-reviewer`, `test-coverage-reviewer`, and optionally `perf-reviewer` run as teammates; crossfire path unchanged
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` added to `personal.yaml` under `settings_overrides.claude.env`; `work` profile inherits via `extends: personal`