### PR TITLE
fix: filter disabled tools from reinstall prompt and warn on local installs

### DIFF
--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -50,6 +50,7 @@ def upgrade(
         ToolSource,
         check_tool_updates,
         get_effective_install_source,
+        get_tool_source,
         get_updatable_tools,
         perform_tool_upgrade,
     )
@@ -74,6 +75,8 @@ def upgrade(
     if resolved_only is None:
         tools = _filter_enabled(tools)
     missing_tools = [t for t in all_tools if not t.is_installed()]
+    if resolved_only is None:
+        missing_tools = _filter_enabled(missing_tools)
 
     for tool in missing_tools:
         print_warning(f"{tool.display_name} is not installed")
@@ -114,6 +117,14 @@ def upgrade(
             print_error(f"Could not get {tool.display_name} version: {e}")
             continue
 
+        if get_tool_source(tool.package_name) == ToolSource.LOCAL:
+            print_warning(
+                f"{tool.display_name} is installed from a local path — "
+                f"skipping update check. Reinstall from PyPI with: "
+                f"uv tool install {tool.package_name} --force"
+            )
+            continue
+
         with console.status(f"Checking {tool.display_name} for updates..."):
             try:
                 update_info = check_tool_updates(tool)
@@ -128,7 +139,7 @@ def upgrade(
 
     console.print()
 
-    if not tool_updates and not force:
+    if not tool_updates:
         print_success("All tools are up to date!")
         return
 

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -453,6 +453,58 @@ class TestIsEnabledFiltering:
 
 @pytest.mark.unit
 @pytest.mark.bootstrap
+class TestMissingToolsFilterEnabled:
+    """Tests that missing_tools respects is_enabled filtering."""
+
+    @staticmethod
+    def _make_tool(
+        tool_id: str,
+        installed: bool = True,
+        is_enabled: Callable[[], bool] | None = None,
+    ) -> ToolSpec:
+        return ToolSpec(
+            tool_id=tool_id,
+            package_name=f"{tool_id}-pkg",
+            display_name=tool_id,
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: installed,
+            is_enabled=is_enabled,
+        )
+
+    def test_disabled_missing_tool_excluded(self):
+        from ai_rules.cli.commands.upgrade import _filter_enabled
+
+        all_tools = [
+            self._make_tool("recall", installed=False, is_enabled=lambda: False)
+        ]
+        missing_tools = [t for t in all_tools if not t.is_installed()]
+        missing_tools = _filter_enabled(missing_tools)
+        assert missing_tools == []
+
+    def test_enabled_missing_tool_included(self):
+        from ai_rules.cli.commands.upgrade import _filter_enabled
+
+        all_tools = [self._make_tool("statusline", installed=False, is_enabled=None)]
+        missing_tools = [t for t in all_tools if not t.is_installed()]
+        missing_tools = _filter_enabled(missing_tools)
+        assert len(missing_tools) == 1
+
+    def test_disabled_missing_tool_included_when_explicitly_targeted(self):
+        """--only=<tool> bypasses the is_enabled check for missing tools too."""
+        from ai_rules.cli.commands.upgrade import _filter_enabled
+
+        resolved_only = "recall"
+        all_tools = [
+            self._make_tool("recall", installed=False, is_enabled=lambda: False)
+        ]
+        missing_tools = [t for t in all_tools if not t.is_installed()]
+        if resolved_only is None:
+            missing_tools = _filter_enabled(missing_tools)
+        assert len(missing_tools) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
 class TestGetToolVenvPython:
     """Tests for _get_tool_venv_python helper."""
 


### PR DESCRIPTION
Two silent failure modes in the `upgrade` command that caused confusing output when recall was disabled and when a tool was installed from a local path.

The `missing_tools` list (tools flagged for reinstall) wasn't filtered through `_filter_enabled`, so disabled tools like `recall` always appeared in the reinstall prompt. With `-y` this auto-confirmed and attempted `uv tool install recall-mcp-server` against PyPI where the package doesn't exist. Separately, tools installed from a local directory (`ToolSource.LOCAL`) were silently skipped during update checks — `check_tool_updates` returns `None` for local sources, and the loop moved on with no message, contributing to the misleading "All tools are up to date" output users saw when `ai-agent-rules` itself was locally installed.

- Apply `_filter_enabled` to `missing_tools` when `--only` is not set, matching the existing filter on the `tools` list
- Detect `ToolSource.LOCAL` before calling `check_tool_updates` and print an actionable warning with the reinstall command instead of silently skipping
- Remove the `not force` guard on the "all up to date" early return so `--force` with an all-local install doesn't exit silently with no message
- Add `TestMissingToolsFilterEnabled` (3 tests) covering disabled exclusion, enabled inclusion, and the `--only` bypass