### PR TITLE
fix: switch PyPI upgrade to uv tool install --force

### DIFF
--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -429,7 +429,7 @@ def perform_tool_upgrade(
     else:
         if not _validate_package_name(tool.package_name):
             return False, f"Invalid package name: {tool.package_name}", False
-        cmd = ["uv", "tool", "upgrade", tool.package_name, "--no-cache"]
+        cmd = ["uv", "tool", "install", "--force", "--reinstall", tool.package_name]
 
         if index_url := get_configured_index_url():
             cmd.extend(["--default-index", index_url])


### PR DESCRIPTION
## Summary

- Replace `uv tool upgrade <pkg> --no-cache` with `uv tool install --force --reinstall <pkg>` for PyPI upgrades in `updater.py`
- `uv tool upgrade --no-cache` silently returned "Nothing to upgrade" even when a newer version was available on PyPI (observed after v0.55.4 publish with user on v0.55.3)
- The PyPI path now matches the GitHub path, which already uses `uv tool install --force --reinstall`