### PR TITLE
fix: restore orphaned hook cleanup lost in component refactor

### DIFF
--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -146,6 +146,7 @@ class ClaudeExtensionManager:
         return {
             "commands": self.get_orphaned_symlinks(Path("~/.claude/commands"), "*.md"),
             "agents": self.get_orphaned_symlinks(Path("~/.claude/agents"), "*.md"),
+            "hooks": self.get_orphaned_symlinks(Path("~/.claude/hooks"), "*.py"),
         }
 
     def _get_configured_hooks(self, settings: dict[str, Any]) -> set[str]:

--- a/src/ai_rules/cli/components/extensions.py
+++ b/src/ai_rules/cli/components/extensions.py
@@ -31,10 +31,10 @@ class ClaudeExtensionsComponent(Component):
             print_unchanged,
             print_update,
         )
-        from ai_rules.symlinks import SymlinkResult, create_symlink
+        from ai_rules.symlinks import SymlinkResult, create_symlink, remove_symlink
 
         ext_manager = ClaudeExtensionManager(ctx.config_dir)
-        created = updated = unchanged = skipped = errors = 0
+        created = updated = unchanged = skipped = errors = cleaned = 0
 
         ctx.console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
         for ext_type in ClaudeExtensionManager.USER_DIRS:
@@ -75,15 +75,31 @@ class ClaudeExtensionsComponent(Component):
                     print_error(f"{target_path}: {message}", indent=2)
                     errors += 1
 
+        all_orphaned = ext_manager.get_all_orphaned()
+        for ext_type, orphaned in all_orphaned.items():
+            for name, orphan_path in sorted(orphaned.items()):
+                if ctx.dry_run:
+                    print_absent(
+                        f"{orphan_path} {dim('(would remove orphan)')}", indent=2
+                    )
+                else:
+                    success, message = remove_symlink(orphan_path, force=True)
+                    if success:
+                        print_success(
+                            f"Removed orphaned {ext_type[:-1]}: {name}", indent=2
+                        )
+                        cleaned += 1
+
         return ComponentResult(
             ok=errors == 0,
-            changed=bool(created or updated),
+            changed=bool(created or updated or cleaned),
             counts={
                 "created": created,
                 "updated": updated,
                 "unchanged": unchanged,
                 "skipped": skipped,
                 "errors": errors,
+                "cleaned": cleaned,
             },
         )
 
@@ -319,6 +335,8 @@ class ClaudeExtensionsComponent(Component):
                     console.print(f"  {name:<20} {dim('Unmanaged')}")
 
             for name in sorted(orphaned_hooks.keys()):
+                if name in all_orphaned.get("hooks", {}):
+                    continue
                 console.print(
                     f"  {name:<20} [yellow]No configuration[/yellow] {dim('(orphaned)')}"
                 )


### PR DESCRIPTION
Fixes two bugs that left `~/.claude/hooks/recall_stop.py` as a broken orphaned symlink after upgrading to v0.55.5, and caused `ai-agent-rules status` to report it twice.

`8ebee1b` added orphan hook cleanup to the monolithic `cli.py` install function. When `e0925ba` split the CLI into component classes, `ClaudeExtensionsComponent.install()` was rewritten from scratch — it ported orphan detection for `status` but dropped the install cleanup pass entirely. Separately, `get_all_orphaned()` excluded hooks from its results, so the `status` display loop couldn't deduplicate against the `orphaned_hooks` pass, producing two lines for the same broken symlink.

- Adds `"hooks"` to `get_all_orphaned()` so broken hook symlinks are detected alongside commands and agents
- Deduplicates the `orphaned_hooks` display loop in `status()` to skip entries already shown as "Orphaned" via `all_orphaned`
- Restores orphan cleanup to `ClaudeExtensionsComponent.install()`: after the create/update loop, calls `get_all_orphaned()` and removes any broken managed symlinks with `remove_symlink(force=True)`