### PR TITLE
fix: detect orphaned symlinks across Python version changes

### DIFF
--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -125,19 +125,16 @@ class ClaudeExtensionManager:
 
             try:
                 target = item.resolve()
-                if is_managed_target(target, self.config_dir) and not target.exists():
-                    orphaned[item.stem] = item
             except OSError, RuntimeError:
                 try:
-                    raw_target = str(item.readlink())
-                    if (
-                        "ai_rules/config" in raw_target
-                        or "ai-agent-rules" in raw_target
-                        or "ai-rules" in raw_target
-                    ):
-                        orphaned[item.stem] = item
+                    target = item.readlink()
+                    if not target.is_absolute():
+                        target = item.parent / target
                 except OSError, RuntimeError:
-                    pass
+                    continue
+
+            if is_managed_target(target, self.config_dir) and not target.exists():
+                orphaned[item.stem] = item
 
         return orphaned
 

--- a/src/ai_rules/cli/components/__init__.py
+++ b/src/ai_rules/cli/components/__init__.py
@@ -7,6 +7,7 @@ from ai_rules.cli.components.config import ConfigComponent
 from ai_rules.cli.components.extensions import ClaudeExtensionsComponent
 from ai_rules.cli.components.mcp import MCPComponent
 from ai_rules.cli.components.optional_tools import OptionalToolsComponent
+from ai_rules.cli.components.orphan_sweep import OrphanSweepComponent
 from ai_rules.cli.components.plugins import ClaudePluginComponent
 from ai_rules.cli.components.settings import SettingsComponent
 from ai_rules.cli.components.skills import SkillsComponent
@@ -22,6 +23,7 @@ INSTALL_COMPONENTS: tuple[Component, ...] = (
     MCPComponent(),
     ClaudePluginComponent(),
     CompletionsComponent(),
+    OrphanSweepComponent(),
 )
 
 STATUS_COMPONENTS: tuple[Component, ...] = (
@@ -33,6 +35,7 @@ STATUS_COMPONENTS: tuple[Component, ...] = (
     SkillsComponent(),
     OptionalToolsComponent(),
     CompletionsComponent(),
+    OrphanSweepComponent(),
 )
 
 DIFF_COMPONENTS: tuple[Component, ...] = (

--- a/src/ai_rules/cli/components/orphan_sweep.py
+++ b/src/ai_rules/cli/components/orphan_sweep.py
@@ -1,0 +1,132 @@
+"""Centralized orphan symlink sweep component."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_rules.cli.context import (
+    CliContext,
+    Component,
+    ComponentPlan,
+    ComponentResult,
+    OrphanSweepPlan,
+)
+from ai_rules.config import AGENT_SKILLS_DIRS
+from ai_rules.utils import is_managed_target
+
+_FILE_DIRS: list[tuple[Path, str]] = [
+    (Path("~/.claude/commands"), "*.md"),
+    (Path("~/.claude/agents"), "*.md"),
+    (Path("~/.claude/hooks"), "*.py"),
+]
+
+
+def _collect_orphans(config_dir: Path) -> list[Path]:
+    """Scan all managed directories and return orphaned symlink paths."""
+    orphans: list[Path] = []
+
+    for dir_path, pattern in _FILE_DIRS:
+        user_dir = dir_path.expanduser()
+        if not user_dir.exists():
+            continue
+
+        for item in user_dir.glob(pattern):
+            if not item.is_symlink() or item.is_dir():
+                continue
+
+            try:
+                target = item.resolve()
+            except OSError, RuntimeError:
+                try:
+                    target = item.readlink()
+                    if not target.is_absolute():
+                        target = item.parent / target
+                except OSError, RuntimeError:
+                    continue
+
+            if is_managed_target(target, config_dir) and not target.exists():
+                orphans.append(item)
+
+    for skills_dir_path in AGENT_SKILLS_DIRS.values():
+        user_dir = skills_dir_path.expanduser()
+        if not user_dir.exists():
+            continue
+
+        for item in user_dir.glob("*"):
+            if not item.is_symlink():
+                continue
+            # is_dir() follows symlinks — False for broken ones; check is_symlink+not exists
+            if item.is_dir() or not item.exists():
+                pass  # process both live dir symlinks and broken dir symlinks
+            else:
+                continue  # live non-directory symlink — not a skill dir, skip
+
+            try:
+                target = item.resolve()
+            except OSError, RuntimeError:
+                try:
+                    target = item.readlink()
+                    if not target.is_absolute():
+                        target = item.parent / target
+                except OSError, RuntimeError:
+                    continue
+
+            if is_managed_target(target, config_dir) and not target.exists():
+                orphans.append(item)
+
+    return orphans
+
+
+class OrphanSweepComponent(Component):
+    label = "Orphan Sweep"
+    component_id = "orphan-sweep"
+
+    def plan(self, ctx: CliContext) -> ComponentPlan:
+        orphans = _collect_orphans(ctx.config_dir)
+        return OrphanSweepPlan(has_changes=bool(orphans), orphans=orphans)
+
+    def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
+        if not isinstance(plan, OrphanSweepPlan) or not plan.orphans:
+            return ComponentResult()
+
+        from ai_rules.cli.display import dim, print_absent, print_success
+        from ai_rules.symlinks import remove_symlink
+
+        ctx.console.print("\n[bold cyan]Orphan Sweep[/bold cyan]")
+        cleaned = 0
+
+        for orphan_path in sorted(plan.orphans):
+            if ctx.dry_run:
+                print_absent(f"{orphan_path} {dim('(would remove orphan)')}", indent=2)
+            else:
+                success, _message = remove_symlink(orphan_path, force=True)
+                if success:
+                    print_success(f"Removed orphaned symlink: {orphan_path}", indent=2)
+                    cleaned += 1
+
+        return ComponentResult(
+            ok=True,
+            changed=cleaned > 0,
+            counts={"cleaned": cleaned},
+        )
+
+    def install(self, ctx: CliContext) -> ComponentResult:
+        plan = self.plan(ctx)
+        return self.apply(ctx, plan)
+
+    def status(self, ctx: CliContext) -> ComponentResult:
+        from ai_rules.cli.runner import get_console
+
+        orphans = _collect_orphans(ctx.config_dir)
+        if not orphans:
+            return ComponentResult()
+
+        console = get_console(ctx)
+        console.print("[bold]Orphan Sweep[/bold]")
+
+        for orphan_path in sorted(orphans):
+            console.print(f"  {orphan_path!s:<50} [yellow]Orphaned[/yellow]")
+
+        console.print()
+
+        return ComponentResult(ok=False, changed=True)

--- a/src/ai_rules/cli/components/skills.py
+++ b/src/ai_rules/cli/components/skills.py
@@ -14,6 +14,7 @@ from ai_rules.cli.context import (
     ComponentResult,
     SkillsPlan,
 )
+from ai_rules.utils import is_managed_target
 
 
 def _enabled_skill_folders(skills_source_dir: Path) -> list[Path]:
@@ -84,19 +85,13 @@ class SkillsComponent(Component):
                         if link_target is None:
                             existing_raw = Path(os.readlink(existing))
                             if not existing_raw.is_absolute():
-                                existing_raw = (
-                                    existing.parent / existing_raw
-                                ).resolve()
-                            try:
-                                existing_raw.relative_to(config_skills_abs)
-                            except ValueError:
+                                existing_raw = existing.parent / existing_raw
+                            if not is_managed_target(existing_raw, config_skills_abs):
                                 continue
                             cleanup_ops.append(existing)
                             continue
 
-                        try:
-                            link_target.relative_to(config_skills_abs)
-                        except ValueError:
+                        if not is_managed_target(link_target, config_skills_abs):
                             continue
 
                         if not link_target.exists():
@@ -217,19 +212,13 @@ class SkillsComponent(Component):
                         if link_target is None:
                             existing_raw = Path(os.readlink(existing))
                             if not existing_raw.is_absolute():
-                                existing_raw = (
-                                    existing.parent / existing_raw
-                                ).resolve()
-                            try:
-                                existing_raw.relative_to(config_skills_abs)
-                            except ValueError:
+                                existing_raw = existing.parent / existing_raw
+                            if not is_managed_target(existing_raw, config_skills_abs):
                                 continue
                             remove_symlink(existing, force=True)
                             continue
 
-                        try:
-                            link_target.relative_to(config_skills_abs)
-                        except ValueError:
+                        if not is_managed_target(link_target, config_skills_abs):
                             continue
 
                         if not link_target.exists():
@@ -279,8 +268,14 @@ class SkillsComponent(Component):
                         continue
                     try:
                         link_target = existing.resolve()
-                        link_target.relative_to(config_skills_abs)
-                    except ValueError, OSError, RuntimeError:
+                    except OSError, RuntimeError:
+                        try:
+                            link_target = existing.readlink()
+                            if not link_target.is_absolute():
+                                link_target = existing.parent / link_target
+                        except OSError, RuntimeError:
+                            continue
+                    if not is_managed_target(link_target, config_skills_abs):
                         continue
 
                     success, _msg = remove_symlink(existing, force=ctx.yes)

--- a/src/ai_rules/cli/context.py
+++ b/src/ai_rules/cli/context.py
@@ -115,6 +115,11 @@ class SkillsPlan(ComponentPlan):
 
 
 @dataclass
+class OrphanSweepPlan(ComponentPlan):
+    orphans: list[Path] = field(default_factory=list)
+
+
+@dataclass
 class ClaudeExtensionsPlan(ComponentPlan):
     symlink_ops: list[tuple[str, Path, Path]] = field(default_factory=list)
 

--- a/src/ai_rules/utils.py
+++ b/src/ai_rules/utils.py
@@ -5,6 +5,14 @@ import copy
 from pathlib import Path
 from typing import Any
 
+# Substrings that identify a symlink target as belonging to this package,
+# regardless of which Python version's site-packages path it resolves under.
+PACKAGE_MARKERS: tuple[str, ...] = (
+    "ai_rules/config",
+    "ai-agent-rules",
+    "ai-rules",
+)
+
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """Deep merge two dictionaries, with override values taking precedence.
@@ -29,15 +37,21 @@ def is_managed_target(target_path: Path, config_dir: Path) -> bool:
     """Check if a symlink target points to ai-rules managed location.
 
     Args:
-        target_path: Path that symlink points to
+        target_path: Path that symlink points to (resolved or raw readlink result)
         config_dir: ai-rules config directory
 
     Returns:
-        True if target is under the config directory
+        True if target is under the config directory or contains package-identifying markers
     """
     try:
         target_resolved = target_path.resolve()
         config_resolved = config_dir.resolve()
-        return target_resolved.is_relative_to(config_resolved)
+        if target_resolved.is_relative_to(config_resolved):
+            return True
     except ValueError, OSError, RuntimeError:
-        return False
+        pass
+
+    # Fallback: check raw path string for package markers. Catches symlinks
+    # pointing to a previous Python version's site-packages path.
+    target_str = str(target_path)
+    return any(marker in target_str for marker in PACKAGE_MARKERS)

--- a/tests/unit/test_cli_components.py
+++ b/tests/unit/test_cli_components.py
@@ -20,6 +20,7 @@ def test_install_components_run_in_expected_order():
         "MCPs",
         "Claude Plugins",
         "Shell Completions",
+        "Orphan Sweep",
     ]
 
 
@@ -34,6 +35,7 @@ def test_status_components_cover_managed_lifecycle_surfaces():
         "Skills",
         "Optional Tools",
         "Shell Completions",
+        "Orphan Sweep",
     ]
 
 

--- a/tests/unit/test_orphan_sweep.py
+++ b/tests/unit/test_orphan_sweep.py
@@ -1,0 +1,164 @@
+"""Tests for OrphanSweepComponent."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from rich.console import Console
+
+import ai_rules.cli.components.orphan_sweep as orphan_sweep_mod
+
+from ai_rules.cli.components.orphan_sweep import OrphanSweepComponent
+from ai_rules.cli.context import CliContext
+from ai_rules.config import Config
+
+
+def make_context(tmp_path: Path, *, dry_run: bool = False) -> CliContext:
+    # config_dir contains "ai-agent-rules" so is_managed_target() recognizes
+    # symlinks pointing into it as managed via the string-marker fallback.
+    config_dir = (
+        tmp_path
+        / "uv"
+        / "tools"
+        / "ai-agent-rules"
+        / "lib"
+        / "python3.14"
+        / "site-packages"
+        / "ai_rules"
+        / "config"
+    )
+    config_dir.mkdir(parents=True)
+    return CliContext(
+        console=Console(file=StringIO()),
+        config_dir=config_dir,
+        config=Config(),
+        profile_name=None,
+        all_targets=(),
+        selected_targets=(),
+        dry_run=dry_run,
+    )
+
+
+@pytest.mark.unit
+class TestOrphanSweepInstall:
+    def test_removes_dangling_managed_symlink(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+        dangling_target = ctx.config_dir / "hooks" / "old_hook.py"  # does not exist
+        symlink = hooks_dir / "old_hook.py"
+        symlink.symlink_to(dangling_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        OrphanSweepComponent().install(ctx)
+
+        assert not symlink.exists()
+        assert not symlink.is_symlink()
+
+    def test_leaves_live_managed_symlink_alone(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+        live_target = ctx.config_dir / "hooks" / "active_hook.py"
+        live_target.parent.mkdir(parents=True, exist_ok=True)
+        live_target.write_text("# hook")
+
+        symlink = hooks_dir / "active_hook.py"
+        symlink.symlink_to(live_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        OrphanSweepComponent().install(ctx)
+
+        assert symlink.is_symlink()
+
+    def test_leaves_unmanaged_dangling_symlink_alone(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+        unmanaged_target = tmp_path / "some-other-tool" / "hook.py"  # does not exist
+        symlink = hooks_dir / "hook.py"
+        symlink.symlink_to(unmanaged_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        OrphanSweepComponent().install(ctx)
+
+        assert symlink.is_symlink()
+
+    def test_dry_run_does_not_remove_symlink(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path, dry_run=True)
+        dangling_target = ctx.config_dir / "hooks" / "old_hook.py"
+        symlink = hooks_dir / "old_hook.py"
+        symlink.symlink_to(dangling_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        OrphanSweepComponent().install(ctx)
+
+        assert symlink.is_symlink()
+
+    def test_removes_dangling_skill_dir_symlink(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+        dangling_target = ctx.config_dir / "skills" / "old-skill"  # dir does not exist
+        symlink = skills_dir / "old-skill"
+        symlink.symlink_to(dangling_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [])
+        monkeypatch.setattr(
+            orphan_sweep_mod, "AGENT_SKILLS_DIRS", {"claude": skills_dir}
+        )
+
+        OrphanSweepComponent().install(ctx)
+
+        assert not symlink.exists()
+        assert not symlink.is_symlink()
+
+
+@pytest.mark.unit
+class TestOrphanSweepStatus:
+    def test_reports_orphaned_symlinks(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+        dangling_target = ctx.config_dir / "hooks" / "old_hook.py"
+        symlink = hooks_dir / "old_hook.py"
+        symlink.symlink_to(dangling_target)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        result = OrphanSweepComponent().status(ctx)
+
+        assert result.ok is False
+
+    def test_returns_clean_when_no_orphans(self, tmp_path, monkeypatch):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+
+        ctx = make_context(tmp_path)
+
+        monkeypatch.setattr(orphan_sweep_mod, "_FILE_DIRS", [(hooks_dir, "*.py")])
+        monkeypatch.setattr(orphan_sweep_mod, "AGENT_SKILLS_DIRS", {})
+
+        result = OrphanSweepComponent().status(ctx)
+
+        assert result.ok is True

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -12,6 +12,7 @@ from ai_rules.symlinks import (
     get_content_diff,
     remove_symlink,
 )
+from ai_rules.utils import is_managed_target
 
 
 @pytest.mark.unit
@@ -364,3 +365,62 @@ class TestGetContentDiffJsonNormalization:
 
         result = get_content_diff(file_a, file_b)
         assert result is not None
+
+
+@pytest.mark.unit
+class TestIsManagedTarget:
+    """Test is_managed_target() ownership detection, including cross-version fallback."""
+
+    def test_same_version_path_returns_true(self, tmp_path):
+        config_dir = tmp_path / "python3.14" / "site-packages" / "ai_rules" / "config"
+        config_dir.mkdir(parents=True)
+        target = config_dir / "hooks" / "foo.py"
+
+        assert is_managed_target(target, config_dir) is True
+
+    def test_cross_version_path_returns_true(self, tmp_path):
+        # config_dir moved to python3.14, symlink still points to python3.13
+        config_dir = tmp_path / "python3.14" / "site-packages" / "ai_rules" / "config"
+        old_target = (
+            tmp_path
+            / "python3.13"
+            / "site-packages"
+            / "ai-agent-rules"
+            / "ai_rules"
+            / "config"
+            / "hooks"
+            / "foo.py"
+        )
+
+        assert is_managed_target(old_target, config_dir) is True
+
+    def test_unrelated_path_returns_false(self, tmp_path):
+        config_dir = tmp_path / "ai_rules" / "config"
+        unrelated = Path("/usr/share/other-package/file.md")
+
+        assert is_managed_target(unrelated, config_dir) is False
+
+    def test_legacy_package_name_returns_true(self, tmp_path):
+        config_dir = tmp_path / "python3.14" / "site-packages" / "ai_rules" / "config"
+        # Old path with legacy package name "ai-rules" (no "ai-agent-rules")
+        legacy_target = (
+            tmp_path
+            / "python3.13"
+            / "site-packages"
+            / "ai-rules"
+            / "config"
+            / "hooks"
+            / "foo.py"
+        )
+
+        assert is_managed_target(legacy_target, config_dir) is True
+
+    def test_relative_path_with_markers_returns_true(self, tmp_path):
+        config_dir = tmp_path / "python3.14" / "site-packages" / "ai_rules" / "config"
+        # Raw readlink result — relative path containing the package marker
+        relative_target = Path(
+            "../../.local/share/uv/tools/ai-agent-rules/lib/python3.13"
+            "/site-packages/ai_rules/config/hooks/foo.py"
+        )
+
+        assert is_managed_target(relative_target, config_dir) is True


### PR DESCRIPTION
## Summary

- Enhances `is_managed_target()` in `utils.py` with a string-marker fallback (`ai_rules/config`, `ai-agent-rules`, `ai-rules`) so ownership detection survives any site-packages path change — Python version upgrades, uv tool path changes, etc. All callers benefit automatically.
- Adds `OrphanSweepComponent` as the final step in install: a centralized scan of all managed directories (`~/.claude/{commands,agents,hooks}` and all `AGENT_SKILLS_DIRS`) that removes any dangling managed symlink regardless of which component originally created it. Structural safety net — survives future component additions/removals.
- Consolidates the inline `relative_to(config_skills_abs)` ownership checks in `SkillsComponent.plan/install/uninstall` to use `is_managed_target()`, and removes the now-redundant hardcoded marker strings from `get_orphaned_symlinks()` in `claude_extensions.py`.

Fixes the live orphans on my machine: `~/.claude/hooks/recall_stop.py` and `~/.claude/skills/kb` both pointed to `python3.13` site-packages after a uv upgrade to 3.14 and survived multiple `ai-rules install` runs until this fix.