### PR TITLE
feat: add native Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,7 @@ permissions:
 
 jobs:
   checks:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ permissions:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "packaging>=21.0",
     "pyyaml>=6.0",
     "rich>=13.0",
+    "shellingham>=1.0",
     "tomli-w>=1.0.0",
     "tomlkit>=0.12.0",
 ]
@@ -70,7 +71,7 @@ explicit_package_bases = true
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["yaml.*", "tomli.*", "tomli_w.*"]
+module = ["yaml.*", "tomli.*", "tomli_w.*", "shellingham.*"]
 ignore_missing_imports = true  # Only for external libs without stubs
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "packaging>=21.0",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "shellingham>=1.0",
+    "shellingham>=1.0,<2",
     "tomli-w>=1.0.0",
     "tomlkit>=0.12.0",
 ]

--- a/src/ai_rules/agents/gemini.py
+++ b/src/ai_rules/agents/gemini.py
@@ -37,6 +37,14 @@ class GeminiAgent(Agent):
     def settings_symlink_target(self) -> Path:
         return Path("~/.gemini/settings.json")
 
+    @property
+    def copy_mode_targets(self) -> set[Path]:
+        from ai_rules.platform import is_windows
+
+        if is_windows():
+            return {self.settings_symlink_target.expanduser()}
+        return set()
+
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
         """Cached list of all Gemini CLI symlinks."""

--- a/src/ai_rules/agents/gemini.py
+++ b/src/ai_rules/agents/gemini.py
@@ -39,9 +39,9 @@ class GeminiAgent(Agent):
 
     @property
     def copy_mode_targets(self) -> set[Path]:
-        from ai_rules.platform import is_windows
+        from ai_rules.platform import Platform, is_platform
 
-        if is_windows():
+        if is_platform(Platform.WINDOWS):
             return {self.settings_symlink_target.expanduser()}
         return set()
 

--- a/src/ai_rules/agents/goose.py
+++ b/src/ai_rules/agents/goose.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ai_rules.agents.base import Agent
+from ai_rules.platform import get_goose_config_dir
 
 if TYPE_CHECKING:
     from ai_rules.mcp import MCPManager
@@ -35,7 +36,7 @@ class GooseAgent(Agent):
 
     @property
     def settings_symlink_target(self) -> Path:
-        return Path("~/.config/goose/config.yaml")
+        return get_goose_config_dir() / "config.yaml"
 
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
@@ -44,7 +45,7 @@ class GooseAgent(Agent):
 
         result.append(
             (
-                Path("~/.config/goose/.goosehints"),
+                get_goose_config_dir() / ".goosehints",
                 self.config_dir / "goose" / ".goosehints",
             )
         )
@@ -54,7 +55,7 @@ class GooseAgent(Agent):
             target_file = self.config.get_settings_file_for_symlink(
                 "goose", config_file, force=bool(self._effective_preserved_fields)
             )
-            result.append((Path("~/.config/goose/config.yaml"), target_file))
+            result.append((get_goose_config_dir() / "config.yaml", target_file))
 
         return result
 

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -1,6 +1,5 @@
 """Tool installation utilities."""
 
-import os
 import re
 import shutil
 import subprocess
@@ -68,17 +67,14 @@ def get_tool_config_dir(package_name: str = "ai-agent-rules") -> Path:
         Path to the config directory in the uv tools location
     """
 
-    data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    from ai_rules.platform import get_lib_path_fragment, get_uv_tools_dir
+
     python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
 
     return (
-        Path(data_home)
-        / "uv"
-        / "tools"
+        get_uv_tools_dir()
         / package_name
-        / "lib"
-        / python_version
-        / "site-packages"
+        / get_lib_path_fragment(python_version)
         / "ai_rules"
         / "config"
     )
@@ -96,8 +92,9 @@ def get_tool_source(package_name: str) -> ToolSource | None:
         ToolSource.LOCAL if installed from a local path
         None if tool not installed or receipt file not found
     """
-    data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
-    receipt_path = Path(data_home) / "uv" / "tools" / package_name / "uv-receipt.toml"
+    from ai_rules.platform import get_uv_tools_dir
+
+    receipt_path = get_uv_tools_dir() / package_name / "uv-receipt.toml"
 
     if not receipt_path.exists():
         return None

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -10,7 +10,6 @@ import urllib.request
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
@@ -309,8 +308,9 @@ def check_github_updates(
 
 def _get_tool_venv_python(package_name: str) -> str | None:
     """Read the Python version from a uv tool's virtual environment."""
-    data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
-    pyvenv_cfg = Path(data_home) / "uv" / "tools" / package_name / "pyvenv.cfg"
+    from ai_rules.platform import get_uv_tools_dir
+
+    pyvenv_cfg = get_uv_tools_dir() / package_name / "pyvenv.cfg"
     try:
         for line in pyvenv_cfg.read_text().splitlines():
             if line.startswith("version_info"):

--- a/src/ai_rules/cli/__init__.py
+++ b/src/ai_rules/cli/__init__.py
@@ -74,16 +74,21 @@ def _display_pending_symlink_changes(targets: list[ConfigTarget]) -> bool:
     Returns:
         True if changes were found and displayed, False otherwise
     """
+    from ai_rules.cli.components.config import _get_copy_mode_targets
     from ai_rules.cli.display import console, print_add, print_update
-    from ai_rules.symlinks import check_symlink, get_content_diff
+    from ai_rules.symlinks import check_file_copy, check_symlink, get_content_diff
 
     found_changes = False
+    copy_targets = _get_copy_mode_targets(targets)
 
     for agent in targets:
         agent_changes: list[tuple[str, Path, Path, str | None]] = []
         for target, source in agent.get_filtered_symlinks():
             target_path = target.expanduser()
-            status_code, _ = check_symlink(target_path, source)
+            if target_path in copy_targets:
+                status_code, _ = check_file_copy(target_path, source)
+            else:
+                status_code, _ = check_symlink(target_path, source)
 
             if status_code == "correct":
                 continue
@@ -93,13 +98,18 @@ def _display_pending_symlink_changes(targets: list[ConfigTarget]) -> bool:
                 agent_changes.append(("create", target_path, source, None))
             elif status_code == "broken":
                 agent_changes.append(("update", target_path, source, None))
-            elif status_code in ["wrong_target", "not_symlink"]:
+            elif status_code in [
+                "wrong_target",
+                "not_symlink",
+                "stale_copy",
+                "not_copy",
+            ]:
                 diff_output = None
                 try:
                     if status_code == "wrong_target":
                         actual = target_path.resolve()
                         diff_output = get_content_diff(actual, source)
-                    elif status_code == "not_symlink":
+                    elif status_code in ("not_symlink", "stale_copy"):
                         diff_output = get_content_diff(target_path, source)
                 except OSError, RuntimeError:
                     pass
@@ -167,13 +177,17 @@ def check_first_run(targets: list[ConfigTarget], force: bool) -> bool:
     Returns:
         True if should continue, False if should abort
     """
+    from ai_rules.cli.components.config import _get_copy_mode_targets
     from ai_rules.cli.display import console, print_warning
 
     existing_files = []
+    copy_targets = _get_copy_mode_targets(targets)
 
     for agent in targets:
         for target, _ in agent.get_filtered_symlinks():
             target_path = target.expanduser()
+            if target_path in copy_targets:
+                continue
             if target_path.exists() and not target_path.is_symlink():
                 existing_files.append((agent.name, target_path))
 

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from rich.console import Console
 
+    from ai_rules.targets.base import ConfigTarget
+
 from ai_rules.cli.context import (
     CliContext,
     Component,
@@ -20,8 +22,16 @@ SPECIALIZED_PATH_PARTS = ("/agents/", "/commands/", "/skills/", "/hooks/")
 
 
 def _is_specialized_path(target: Path) -> bool:
-    target_str = str(target)
+    target_str = target.as_posix()
     return any(part in target_str for part in SPECIALIZED_PATH_PARTS)
+
+
+def _get_copy_mode_targets(agents: list[ConfigTarget]) -> set[Path]:
+    """Collect expanded copy-mode target paths from all agents."""
+    result: set[Path] = set()
+    for agent in agents:
+        result.update(getattr(agent, "copy_mode_targets", set()))
+    return result
 
 
 def _display_symlink_status(
@@ -80,6 +90,26 @@ def _display_symlink_status(
             pass
 
         return False
+    if status_code == "stale_copy":
+        print_warning(f"{target_display} {dim('(copy out of date)')}", indent=2)
+
+        try:
+            diff_output = get_content_diff(target.expanduser(), source)
+            if diff_output:
+                active_console.print(diff_output)
+        except OSError, RuntimeError:
+            pass
+
+        return False
+    if status_code == "not_copy":
+        print_warning(
+            f"{target_display} {dim('(expected managed copy, found symlink)')}",
+            indent=2,
+        )
+        return False
+    if status_code == "error":
+        print_error(f"{target_display} {dim(f'({message})')}", indent=2)
+        return False
     return True
 
 
@@ -102,10 +132,13 @@ class ConfigComponent(Component):
             ]
             symlink_ops.extend(config_symlinks)
 
+        copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
+
         return ConfigPlan(
             has_changes=bool(symlink_ops),
             symlink_ops=symlink_ops,
             excluded_count=excluded_count,
+            copy_targets=copy_targets,
         )
 
     def apply(self, ctx: CliContext, plan: ComponentPlan) -> ComponentResult:
@@ -121,14 +154,17 @@ class ConfigComponent(Component):
             print_unchanged,
             print_update,
         )
-        from ai_rules.symlinks import SymlinkResult, create_symlink
+        from ai_rules.symlinks import SymlinkResult, create_file_copy, create_symlink
 
         created = updated = unchanged = skipped = excluded = errors = 0
 
         excluded = plan.excluded_count
 
         for target, source in plan.symlink_ops:
-            result, message = create_symlink(target, source, True, ctx.dry_run)
+            if target.expanduser() in plan.copy_targets:
+                result, message = create_file_copy(target, source, True, ctx.dry_run)
+            else:
+                result, message = create_symlink(target, source, True, ctx.dry_run)
 
             if result == SymlinkResult.CREATED:
                 print_success(f"{target} → {source}", indent=2)
@@ -174,10 +210,11 @@ class ConfigComponent(Component):
             print_unchanged,
             print_update,
         )
-        from ai_rules.symlinks import SymlinkResult, create_symlink
+        from ai_rules.symlinks import SymlinkResult, create_file_copy, create_symlink
 
         created = updated = unchanged = skipped = excluded = errors = 0
         effective_force = ctx.yes or not ctx.dry_run
+        copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
 
         for agent in ctx.selected_targets:
             ctx.console.print(f"\n[bold]{agent.name}[/bold]")
@@ -196,9 +233,14 @@ class ConfigComponent(Component):
                 excluded += user_excluded_count
 
             for target, source in config_symlinks:
-                result, message = create_symlink(
-                    target, source, effective_force, ctx.dry_run
-                )
+                if target.expanduser() in copy_targets:
+                    result, message = create_file_copy(
+                        target, source, effective_force, ctx.dry_run
+                    )
+                else:
+                    result, message = create_symlink(
+                        target, source, effective_force, ctx.dry_run
+                    )
 
                 if result == SymlinkResult.CREATED:
                     print_success(f"{target} → {source}", indent=2)
@@ -237,10 +279,11 @@ class ConfigComponent(Component):
     def status(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.cli.display import dim, print_skipped
         from ai_rules.cli.runner import get_console
-        from ai_rules.symlinks import check_symlink
+        from ai_rules.symlinks import check_file_copy, check_symlink
 
         console = get_console(ctx)
         all_correct = True
+        copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
 
         for target in ctx.selected_targets:
             console.print(f"[bold]{target.name}[/bold]")
@@ -256,7 +299,10 @@ class ConfigComponent(Component):
                 if _is_specialized_path(tgt):
                     continue
 
-                status_code, message = check_symlink(tgt, source)
+                if tgt.expanduser() in copy_targets:
+                    status_code, message = check_file_copy(tgt, source)
+                else:
+                    status_code, message = check_symlink(tgt, source)
                 is_correct = _display_symlink_status(
                     status_code, tgt, source, message, console
                 )
@@ -272,10 +318,11 @@ class ConfigComponent(Component):
     def diff(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.cli.display import print_dim, print_error, print_warning
         from ai_rules.cli.runner import get_console
-        from ai_rules.symlinks import check_symlink, get_content_diff
+        from ai_rules.symlinks import check_file_copy, check_symlink, get_content_diff
 
         console = get_console(ctx)
         found_differences = False
+        copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
 
         for target in ctx.selected_targets:
             target_has_diff = False
@@ -285,7 +332,10 @@ class ConfigComponent(Component):
                 if _is_specialized_path(tgt):
                     continue
                 target_path = tgt.expanduser()
-                status_code, message = check_symlink(target_path, source)
+                if target_path in copy_targets:
+                    status_code, message = check_file_copy(target_path, source)
+                else:
+                    status_code, message = check_symlink(target_path, source)
 
                 if status_code == "missing":
                     target_diffs.append(
@@ -316,18 +366,34 @@ class ConfigComponent(Component):
                             (target_path, source, "broken", "Broken symlink", None)
                         )
                         target_has_diff = True
-                elif status_code == "not_symlink":
+                elif status_code in ("not_symlink", "stale_copy"):
                     try:
                         diff_output = get_content_diff(target_path, source)
                     except OSError, RuntimeError:
                         diff_output = None
+                    desc = (
+                        "Copy out of date"
+                        if status_code == "stale_copy"
+                        else "Regular file (not symlink)"
+                    )
                     target_diffs.append(
                         (
                             target_path,
                             source,
                             "file",
-                            "Regular file (not symlink)",
+                            desc,
                             diff_output,
+                        )
+                    )
+                    target_has_diff = True
+                elif status_code == "not_copy":
+                    target_diffs.append(
+                        (
+                            target_path,
+                            source,
+                            "file",
+                            "Expected managed copy, found symlink",
+                            None,
                         )
                     )
                     target_has_diff = True
@@ -374,11 +440,12 @@ class ConfigComponent(Component):
             print_unchanged,
         )
         from ai_rules.cli.runner import get_console
-        from ai_rules.symlinks import remove_symlink
+        from ai_rules.symlinks import remove_file_copy, remove_symlink
 
         console = get_console(ctx)
         total_removed = 0
         total_skipped = 0
+        copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
 
         for target in ctx.selected_targets:
             console.print(f"\n[bold]{target.name}[/bold]")
@@ -386,7 +453,10 @@ class ConfigComponent(Component):
             for tgt, _source in target.get_filtered_symlinks():
                 if _is_specialized_path(tgt):
                     continue
-                success, message = remove_symlink(tgt, ctx.yes)
+                if tgt.expanduser() in copy_targets:
+                    success, message = remove_file_copy(tgt, ctx.yes)
+                else:
+                    success, message = remove_symlink(tgt, ctx.yes)
 
                 if success:
                     print_success(f"{tgt} removed", indent=2)

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -30,7 +30,7 @@ def _get_copy_mode_targets(agents: list[ConfigTarget]) -> set[Path]:
     """Collect expanded copy-mode target paths from all agents."""
     result: set[Path] = set()
     for agent in agents:
-        result.update(getattr(agent, "copy_mode_targets", set()))
+        result.update(agent.copy_mode_targets)
     return result
 
 

--- a/src/ai_rules/cli/context.py
+++ b/src/ai_rules/cli/context.py
@@ -107,6 +107,7 @@ class OptionalToolsPlan(ComponentPlan):
 class ConfigPlan(ComponentPlan):
     symlink_ops: list[tuple[Path, Path]] = field(default_factory=list)
     excluded_count: int = 0
+    copy_targets: set[Path] = field(default_factory=set)
 
 
 @dataclass

--- a/src/ai_rules/cli/groups/completions.py
+++ b/src/ai_rules/cli/groups/completions.py
@@ -65,6 +65,26 @@ def completions_zsh() -> None:
         sys.exit(1)
 
 
+@completions.command(name="powershell")
+def completions_powershell() -> None:
+    """Output PowerShell completion script for manual installation."""
+    from ai_rules.cli.display import console
+    from ai_rules.completions import generate_completion_script
+
+    try:
+        script = generate_completion_script("powershell")
+        console.print(script)
+        console.print()
+        print_hint(
+            "To install: Add the above to your PowerShell profile or run: ai-agent-rules completions install"
+        )
+    except Exception as e:
+        from ai_rules.cli.display import print_error
+
+        print_error(f"Error generating completion script: {e}")
+        sys.exit(1)
+
+
 @completions.command(name="install")
 @click.option(
     "--shell",

--- a/src/ai_rules/cli/groups/config.py
+++ b/src/ai_rules/cli/groups/config.py
@@ -132,7 +132,9 @@ def config_edit() -> None:
     from ai_rules.cli.display import print_success
 
     user_config_path = cli_facade.get_user_config_path()
-    editor = os.environ.get("EDITOR", "vi")
+    from ai_rules.platform import get_default_editor
+
+    editor = os.environ.get("EDITOR", get_default_editor())
 
     if not user_config_path.exists():
         user_config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -149,11 +151,17 @@ def config_edit() -> None:
         sys.exit(1)
 
 
-_COMMON_RULES_EXCLUSIONS: list[tuple[str, str, bool]] = [
-    ("~/.gemini/GEMINI.md", "Gemini rules", True),
-    ("~/.config/goose/.goosehints", "Goose hints", True),
-    ("~/AGENTS.md", "Shared agents file", False),
-]
+def _build_common_rules_exclusions() -> list[tuple[str, str, bool]]:
+    from ai_rules.platform import get_goose_config_dir
+
+    return [
+        ("~/.gemini/GEMINI.md", "Gemini rules", True),
+        (str(get_goose_config_dir() / ".goosehints"), "Goose hints", True),
+        ("~/AGENTS.md", "Shared agents file", False),
+    ]
+
+
+_COMMON_RULES_EXCLUSIONS: list[tuple[str, str, bool]] = _build_common_rules_exclusions()
 
 
 def _get_common_exclusions() -> list[tuple[str, str, bool]]:

--- a/src/ai_rules/completions.py
+++ b/src/ai_rules/completions.py
@@ -180,15 +180,19 @@ if (Get-Command {CANONICAL_CMD} -ErrorAction SilentlyContinue) {{
     Register-ArgumentCompleter -Native -CommandName '{CANONICAL_CMD}','{ALIAS_CMD}' -ScriptBlock {{
         param($wordToComplete, $commandAst, $cursorPosition)
         $words = $commandAst.CommandElements | ForEach-Object {{ $_.ToString() }}
-        $env:{env_var} = 'bash_source'
+        $env:{env_var} = 'bash_complete'
         $env:COMP_WORDS = $words -join ' '
-        $env:COMP_CWORD = $words.Count - 1
+        if ($wordToComplete -eq '') {{
+            $env:COMP_CWORD = $words.Count
+        }} else {{
+            $env:COMP_CWORD = $words.Count - 1
+        }}
         try {{
             $completions = & {CANONICAL_CMD} 2>$null
             $completions | ForEach-Object {{
-                $parts = $_ -split '\\s+', 2
-                $text = $parts[0]
-                $desc = if ($parts.Count -gt 1) {{ $parts[1] }} else {{ $text }}
+                $parts = $_ -split ',', 2
+                $text = if ($parts.Count -gt 1) {{ $parts[1] }} else {{ $parts[0] }}
+                $desc = $text
                 [System.Management.Automation.CompletionResult]::new($text, $text, 'ParameterValue', $desc)
             }}
         }} finally {{
@@ -222,6 +226,25 @@ fi
 {COMPLETION_MARKER_END}"""
 
 
+def _resolve_config_path(shell: str) -> tuple[Path | None, str | None]:
+    """Resolve config path for a shell, with PowerShell profile fallback.
+
+    Returns (path, error_message). On success error_message is None.
+    """
+    config_path = find_config_file(shell)
+    if config_path is None and shell == "powershell":
+        profile = _get_powershell_profile_path()
+        if profile is None:
+            return (
+                None,
+                "PowerShell is not installed (neither pwsh nor powershell found)",
+            )
+        config_path = profile
+    if config_path is None:
+        return None, f"No {shell} config file found"
+    return config_path, None
+
+
 def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
     """Install completion to shell config file.
 
@@ -236,25 +259,18 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
         supported = ", ".join(get_supported_shells())
         return False, f"Unsupported shell: {shell}. Supported: {supported}"
 
-    config_path = find_config_file(shell)
+    config_path, err = _resolve_config_path(shell)
+    if err:
+        return False, err
     if config_path is None:
-        if shell == "powershell":
-            profile = _get_powershell_profile_path()
-            if profile is None:
-                return (
-                    False,
-                    "PowerShell is not installed (neither pwsh nor powershell found)",
-                )
-            if not dry_run:
-                profile.parent.mkdir(parents=True, exist_ok=True)
-                profile.touch()
-            config_path = profile
-        else:
-            return (
-                False,
-                f"No {shell} config file found. Expected one of: "
-                + ", ".join(str(p) for p in get_shell_config_candidates(shell)),
-            )
+        return (
+            False,
+            f"No {shell} config file found. Expected one of: "
+            + ", ".join(str(p) for p in get_shell_config_candidates(shell)),
+        )
+    if shell == "powershell" and not config_path.exists() and not dry_run:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.touch()
 
     if is_completion_installed(config_path):
         if is_legacy_completion_block(config_path):
@@ -279,9 +295,9 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
 
 def update_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
     """Replace existing completion block with a freshly generated one."""
-    config_path = find_config_file(shell)
-    if config_path is None:
-        return False, f"No {shell} config file found"
+    config_path, err = _resolve_config_path(shell)
+    if err or config_path is None:
+        return False, err or f"No {shell} config file found"
     if not is_completion_installed(config_path):
         return install_completion(shell, dry_run=dry_run)
 

--- a/src/ai_rules/completions.py
+++ b/src/ai_rules/completions.py
@@ -29,9 +29,24 @@ class ShellConfig:
         return [home / cf for cf in self.config_files if (home / cf).exists()]
 
 
+@dataclass
+class PowerShellConfig(ShellConfig):
+    def get_config_candidates(self) -> list[Path]:
+        home = Path.home()
+        candidates = [
+            home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1",
+            home
+            / "Documents"
+            / "WindowsPowerShell"
+            / "Microsoft.PowerShell_profile.ps1",
+        ]
+        return [p for p in candidates if p.exists()]
+
+
 SHELL_REGISTRY: dict[str, ShellConfig] = {
     "bash": ShellConfig("bash", [".bashrc", ".bash_profile", ".profile"]),
     "zsh": ShellConfig("zsh", [".zshrc", ".zprofile"]),
+    "powershell": PowerShellConfig("powershell", []),
 }
 
 
@@ -46,6 +61,12 @@ def detect_shell() -> str | None:
     Returns:
         Shell name if supported, None otherwise
     """
+    from ai_rules.platform import is_windows
+
+    if is_windows():
+        if os.environ.get("PSModulePath"):
+            return "powershell"
+        return None
     shell_path = os.environ.get("SHELL", "")
     shell_name = Path(shell_path).name if shell_path else None
     return shell_name if shell_name in SHELL_REGISTRY else None
@@ -112,6 +133,9 @@ def is_legacy_completion_block(config_path: Path) -> bool:
     if _LEGACY_MARKER_START in content:
         return True
     if COMPLETION_MARKER_START in content and "command -v" not in content:
+        # PowerShell blocks use Get-Command, not command -v
+        if "Get-Command" in content:
+            return False
         return True
     return False
 
@@ -131,13 +155,41 @@ def generate_completion_script(shell: str) -> str:
     Raises:
         ValueError: If shell is not supported
     """
+    env_var = f"_{CANONICAL_CMD.upper().replace('-', '_')}_COMPLETE"
+
+    if shell == "powershell":
+        # bash_source mode: Click reads COMP_WORDS (space-separated command line)
+        # and COMP_CWORD (0-based index of current word) to return completions.
+        return f"""{COMPLETION_MARKER_START}
+if (Get-Command {CANONICAL_CMD} -ErrorAction SilentlyContinue) {{
+    Register-ArgumentCompleter -Native -CommandName '{CANONICAL_CMD}','{ALIAS_CMD}' -ScriptBlock {{
+        param($wordToComplete, $commandAst, $cursorPosition)
+        $words = $commandAst.CommandElements | ForEach-Object {{ $_.ToString() }}
+        $env:{env_var} = 'bash_source'
+        $env:COMP_WORDS = $words -join ' '
+        $env:COMP_CWORD = $words.Count - 1
+        try {{
+            $completions = & {CANONICAL_CMD} 2>$null
+            $completions | ForEach-Object {{
+                $parts = $_ -split '\\s+', 2
+                $text = $parts[0]
+                $desc = if ($parts.Count -gt 1) {{ $parts[1] }} else {{ $text }}
+                [System.Management.Automation.CompletionResult]::new($text, $text, 'ParameterValue', $desc)
+            }}
+        }} finally {{
+            Remove-Item Env:{env_var} -ErrorAction SilentlyContinue
+            Remove-Item Env:COMP_WORDS -ErrorAction SilentlyContinue
+            Remove-Item Env:COMP_CWORD -ErrorAction SilentlyContinue
+        }}
+    }}
+}}
+{COMPLETION_MARKER_END}"""
+
     from click.shell_completion import get_completion_class
 
     comp_cls = get_completion_class(shell)
     if comp_cls is None:
         raise ValueError(f"Unsupported shell: {shell}")
-
-    env_var = f"_{CANONICAL_CMD.upper().replace('-', '_')}_COMPLETE"
 
     if shell == "zsh":
         return f"""{COMPLETION_MARKER_START}
@@ -171,11 +223,23 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
 
     config_path = find_config_file(shell)
     if config_path is None:
-        return (
-            False,
-            f"No {shell} config file found. Expected one of: "
-            + ", ".join(str(p) for p in get_shell_config_candidates(shell)),
-        )
+        if shell == "powershell":
+            profile = (
+                Path.home()
+                / "Documents"
+                / "PowerShell"
+                / "Microsoft.PowerShell_profile.ps1"
+            )
+            if not dry_run:
+                profile.parent.mkdir(parents=True, exist_ok=True)
+                profile.touch()
+            config_path = profile
+        else:
+            return (
+                False,
+                f"No {shell} config file found. Expected one of: "
+                + ", ".join(str(p) for p in get_shell_config_candidates(shell)),
+            )
 
     if is_completion_installed(config_path):
         if is_legacy_completion_block(config_path):

--- a/src/ai_rules/completions.py
+++ b/src/ai_rules/completions.py
@@ -32,15 +32,28 @@ class ShellConfig:
 @dataclass
 class PowerShellConfig(ShellConfig):
     def get_config_candidates(self) -> list[Path]:
-        home = Path.home()
-        candidates = [
-            home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1",
-            home
-            / "Documents"
-            / "WindowsPowerShell"
-            / "Microsoft.PowerShell_profile.ps1",
-        ]
-        return [p for p in candidates if p.exists()]
+        profile = _get_powershell_profile_path()
+        if profile and profile.exists():
+            return [profile]
+        return []
+
+
+def _get_powershell_profile_path() -> Path | None:
+    import subprocess
+
+    for exe in ("pwsh", "powershell"):
+        try:
+            result = subprocess.run(
+                [exe, "-NoProfile", "-Command", "Write-Output $PROFILE"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return Path(result.stdout.strip())
+        except FileNotFoundError, subprocess.TimeoutExpired:
+            continue
+    return None
 
 
 SHELL_REGISTRY: dict[str, ShellConfig] = {
@@ -61,15 +74,17 @@ def detect_shell() -> str | None:
     Returns:
         Shell name if supported, None otherwise
     """
-    from ai_rules.platform import is_windows
+    try:
+        import shellingham
 
-    if is_windows():
-        if os.environ.get("PSModulePath"):
+        name, _ = shellingham.detect_shell()
+        if name in ("pwsh", "powershell"):
             return "powershell"
-        return None
-    shell_path = os.environ.get("SHELL", "")
-    shell_name = Path(shell_path).name if shell_path else None
-    return shell_name if shell_name in SHELL_REGISTRY else None
+        return name if name in SHELL_REGISTRY else None
+    except Exception:
+        shell_path = os.environ.get("SHELL", "")
+        name = Path(shell_path).name if shell_path else None
+        return name if name in SHELL_REGISTRY else None
 
 
 def get_shell_config_candidates(shell: str) -> list[Path]:
@@ -224,12 +239,12 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
     config_path = find_config_file(shell)
     if config_path is None:
         if shell == "powershell":
-            profile = (
-                Path.home()
-                / "Documents"
-                / "PowerShell"
-                / "Microsoft.PowerShell_profile.ps1"
-            )
+            profile = _get_powershell_profile_path()
+            if profile is None:
+                return (
+                    False,
+                    "PowerShell is not installed (neither pwsh nor powershell found)",
+                )
             if not dry_run:
                 profile.parent.mkdir(parents=True, exist_ok=True)
                 profile.touch()

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -58,9 +58,9 @@ FORMAT_CONFIG_FILES: dict[str, str] = {
 
 
 def _get_agent_skills_dirs() -> dict[str, Path]:
-    from ai_rules.platform import get_goose_config_dir
+    from ai_rules.platform import Platform, get_goose_config_dir, is_platform
 
-    return {
+    dirs = {
         "amp": Path("~/.config/agents/skills"),
         "claude": Path("~/.claude/skills"),
         "codex": Path("~/.agents/skills"),
@@ -69,6 +69,9 @@ def _get_agent_skills_dirs() -> dict[str, Path]:
         # warnings that break headless invocations (e.g., crossfire code review).
         "goose": get_goose_config_dir() / "skills",
     }
+    if is_platform(Platform.WINDOWS):
+        dirs.pop("amp", None)
+    return dirs
 
 
 AGENT_SKILLS_DIRS = _get_agent_skills_dirs()

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -56,15 +56,22 @@ FORMAT_CONFIG_FILES: dict[str, str] = {
     "yaml": "config.yaml",
 }
 
-AGENT_SKILLS_DIRS = {
-    "amp": Path("~/.config/agents/skills"),
-    "claude": Path("~/.claude/skills"),
-    "codex": Path("~/.agents/skills"),
-    # Gemini CLI not listed here — it discovers skills from ~/.agents/skills/ via
-    # built-in alias. Adding ~/.gemini/skills/ would cause "Skill conflict detected"
-    # warnings that break headless invocations (e.g., crossfire code review).
-    "goose": Path("~/.config/goose/skills"),
-}
+
+def _get_agent_skills_dirs() -> dict[str, Path]:
+    from ai_rules.platform import get_goose_config_dir
+
+    return {
+        "amp": Path("~/.config/agents/skills"),
+        "claude": Path("~/.claude/skills"),
+        "codex": Path("~/.agents/skills"),
+        # Gemini CLI not listed here — it discovers skills from ~/.agents/skills/ via
+        # built-in alias. Adding ~/.gemini/skills/ would cause "Skill conflict detected"
+        # warnings that break headless invocations (e.g., crossfire code review).
+        "goose": get_goose_config_dir() / "skills",
+    }
+
+
+AGENT_SKILLS_DIRS = _get_agent_skills_dirs()
 
 _CONFIG_FILE_NAME = ".ai-agent-rules-config.yaml"
 _LEGACY_CONFIG_FILE_NAME = ".ai-rules-config.yaml"

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
@@ -97,7 +97,7 @@ def repo_score(
 ) -> tuple[int, str]:
     if not session_cwd:
         return 0, ""
-    session_path = str(Path(session_cwd).expanduser())
+    session_path = Path(session_cwd).expanduser().as_posix()
     if session_path == current_cwd or session_path == current_root:
         return 3, "exact-cwd"
     if current_root and session_path.startswith(current_root.rstrip("/") + "/"):

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -395,7 +395,9 @@ class GooseMCPManager(MCPManager):
 
     @property
     def _config_path(self) -> Path:
-        return Path.home() / ".config" / "goose" / "config.yaml"
+        from ai_rules.platform import get_goose_config_dir
+
+        return get_goose_config_dir().expanduser() / "config.yaml"
 
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():

--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -1,14 +1,52 @@
 """Platform detection and path helpers for Windows/Unix compatibility."""
 
-import os
-import sys
+from __future__ import annotations
 
+import os
+import platform as _platform
+
+from enum import Enum
+from functools import lru_cache
 from pathlib import Path
 
 
-def is_windows() -> bool:
-    """Return True when running on native Windows (not WSL)."""
-    return sys.platform == "win32"
+class Platform(Enum):
+    MACOS = "macos"
+    LINUX = "linux"
+    WINDOWS = "windows"
+    WSL = "wsl"
+
+    @property
+    def display_name(self) -> str:
+        return {
+            Platform.MACOS: "macOS",
+            Platform.LINUX: "Linux",
+            Platform.WINDOWS: "Windows",
+            Platform.WSL: "WSL",
+        }[self]
+
+    @property
+    def is_unix_like(self) -> bool:
+        return self in (Platform.MACOS, Platform.LINUX, Platform.WSL)
+
+
+@lru_cache(maxsize=1)
+def detect_platform() -> Platform:
+    system = _platform.system().lower()
+    if system == "darwin":
+        return Platform.MACOS
+    if system == "windows":
+        return Platform.WINDOWS
+    if system == "linux":
+        release = _platform.uname().release.lower()
+        if "microsoft" in release or os.environ.get("WSL_DISTRO_NAME"):
+            return Platform.WSL
+        return Platform.LINUX
+    return Platform.LINUX
+
+
+def is_platform(target: Platform) -> bool:
+    return detect_platform() == target
 
 
 def get_appdata_dir() -> Path:
@@ -29,7 +67,7 @@ def get_uv_tools_dir() -> Path:
     override = os.environ.get("UV_TOOL_DIR")
     if override:
         return Path(override)
-    if is_windows():
+    if is_platform(Platform.WINDOWS):
         return get_appdata_dir() / "uv" / "data" / "tools"
     data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
     return Path(data_home) / "uv" / "tools"
@@ -41,14 +79,14 @@ def get_lib_path_fragment(python_version: str) -> str:
     Windows: Lib/site-packages
     Unix: lib/{python_version}/site-packages
     """
-    if is_windows():
+    if is_platform(Platform.WINDOWS):
         return str(Path("Lib") / "site-packages")
     return str(Path("lib") / python_version / "site-packages")
 
 
 def get_default_editor() -> str:
     """Return platform-appropriate default editor."""
-    return "notepad" if is_windows() else "vi"
+    return "notepad" if is_platform(Platform.WINDOWS) else "vi"
 
 
 def get_goose_config_dir() -> Path:
@@ -57,7 +95,7 @@ def get_goose_config_dir() -> Path:
     Windows: %APPDATA%/Block/goose/config
     Unix: ~/.config/goose (tilde path -- callers expand as needed)
     """
-    if is_windows():
+    if is_platform(Platform.WINDOWS):
         return get_appdata_dir() / "Block" / "goose" / "config"
     return Path("~/.config/goose")
 
@@ -68,6 +106,6 @@ def get_statusline_config_dir() -> Path:
     Windows: %APPDATA%/claude-statusline
     Unix: ~/.config/claude-statusline (tilde path -- callers expand as needed)
     """
-    if is_windows():
+    if is_platform(Platform.WINDOWS):
         return get_appdata_dir() / "claude-statusline"
     return Path("~/.config/claude-statusline")

--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -50,11 +50,11 @@ def is_platform(target: Platform) -> bool:
 
 
 def get_appdata_dir() -> Path:
-    """Return %APPDATA% on Windows. Raises RuntimeError if unset."""
+    """Return %APPDATA% on Windows, falling back to the standard default if unset."""
     appdata = os.environ.get("APPDATA")
-    if not appdata:
-        raise RuntimeError("APPDATA environment variable not set")
-    return Path(appdata)
+    if appdata:
+        return Path(appdata)
+    return Path.home() / "AppData" / "Roaming"
 
 
 def get_uv_tools_dir() -> Path:

--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -1,0 +1,73 @@
+"""Platform detection and path helpers for Windows/Unix compatibility."""
+
+import os
+import sys
+
+from pathlib import Path
+
+
+def is_windows() -> bool:
+    """Return True when running on native Windows (not WSL)."""
+    return sys.platform == "win32"
+
+
+def get_appdata_dir() -> Path:
+    """Return %APPDATA% on Windows. Raises RuntimeError if unset."""
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        raise RuntimeError("APPDATA environment variable not set")
+    return Path(appdata)
+
+
+def get_uv_tools_dir() -> Path:
+    """Return the platform-appropriate uv tools directory.
+
+    Honors UV_TOOL_DIR env var if set (uv's official override).
+    Windows default: %APPDATA%/uv/data/tools
+    Unix default:    $XDG_DATA_HOME/uv/tools (fallback ~/.local/share/uv/tools)
+    """
+    override = os.environ.get("UV_TOOL_DIR")
+    if override:
+        return Path(override)
+    if is_windows():
+        return get_appdata_dir() / "uv" / "data" / "tools"
+    data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    return Path(data_home) / "uv" / "tools"
+
+
+def get_lib_path_fragment(python_version: str) -> str:
+    """Return site-packages path fragment.
+
+    Windows: Lib/site-packages
+    Unix: lib/{python_version}/site-packages
+    """
+    if is_windows():
+        return str(Path("Lib") / "site-packages")
+    return str(Path("lib") / python_version / "site-packages")
+
+
+def get_default_editor() -> str:
+    """Return platform-appropriate default editor."""
+    return "notepad" if is_windows() else "vi"
+
+
+def get_goose_config_dir() -> Path:
+    """Return Goose config directory.
+
+    Windows: %APPDATA%/Block/goose/config
+    Unix: ~/.config/goose (tilde path -- callers expand as needed)
+    """
+    if is_windows():
+        return get_appdata_dir() / "Block" / "goose" / "config"
+    return Path("~/.config/goose")
+
+
+def get_statusline_config_dir() -> Path:
+    """Return Statusline config directory.
+
+    Windows: %APPDATA%/claude-statusline
+    Unix: ~/.config/claude-statusline (tilde path -- callers expand as needed)
+    """
+    if is_windows():
+        return get_appdata_dir() / "claude-statusline"
+    return Path("~/.config/claude-statusline")

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -77,7 +77,7 @@ class SkillManager:
         if not skill_file.exists():
             return None
 
-        content = skill_file.read_text()
+        content = skill_file.read_text(encoding="utf-8")
 
         if content.startswith("---"):
             parts = content.split("---", 2)
@@ -284,7 +284,7 @@ class SkillManager:
         skill_file = managed[name] / "SKILL.md"
         if not skill_file.exists():
             return None
-        return skill_file.read_text()
+        return skill_file.read_text(encoding="utf-8")
 
     @staticmethod
     def _get_repo_url() -> str | None:

--- a/src/ai_rules/symlinks.py
+++ b/src/ai_rules/symlinks.py
@@ -1,6 +1,7 @@
 """Symlink operations with safety checks."""
 
 import os
+import shutil
 
 from datetime import datetime
 from enum import Enum
@@ -101,14 +102,10 @@ def create_symlink(
 
     try:
         rel_source = os.path.relpath(source, target.parent)
-        target.symlink_to(rel_source)
+        target.symlink_to(rel_source, target_is_directory=source.is_dir())
         return (SymlinkResult.CREATED, "Created")
     except PermissionError as e:
-        return (
-            SymlinkResult.ERROR,
-            f"Permission denied: {e}\n"
-            f"  {dim('Tip: Check file permissions and ownership. You may need to remove existing files manually.')}",
-        )
+        return _symlink_permission_error(e)
     except FileExistsError as e:
         return (
             SymlinkResult.ERROR,
@@ -117,20 +114,124 @@ def create_symlink(
         )
     except (OSError, ValueError) as e:
         try:
-            target.symlink_to(source)
+            target.symlink_to(source, target_is_directory=source.is_dir())
             return (SymlinkResult.CREATED, "Created (absolute path)")
         except PermissionError:
-            return (
-                SymlinkResult.ERROR,
-                f"Permission denied: {e}\n"
-                f"  {dim('Tip: Check file permissions and ownership.')}",
-            )
+            return _symlink_permission_error(e)
         except Exception as e2:
             return (
                 SymlinkResult.ERROR,
                 f"Failed to create symlink: {e2}\n"
                 f"  {dim('Tip: Check that the target directory exists and is writable.')}",
             )
+
+
+def _symlink_permission_error(e: Exception) -> tuple[SymlinkResult, str]:
+    """Build a PermissionError result with platform-appropriate hints."""
+    from ai_rules.platform import is_windows
+
+    if is_windows():
+        return (
+            SymlinkResult.ERROR,
+            f"Permission denied creating symlink: {e}\n"
+            f"  {dim('Windows requires Developer Mode for symlinks.')}\n"
+            f"  {dim('Enable: Settings > System > For developers > Developer Mode')}\n"
+            f"  {dim('Then re-run: ai-agent-rules install')}",
+        )
+    return (
+        SymlinkResult.ERROR,
+        f"Permission denied: {e}\n"
+        f"  {dim('Tip: Check file permissions and ownership.')}",
+    )
+
+
+def create_file_copy(
+    target_path: Path,
+    source_path: Path,
+    force: bool = False,
+    dry_run: bool = False,
+) -> tuple[SymlinkResult, str]:
+    """Copy a file instead of symlinking.
+
+    Used for agents that destroy symlinks (e.g., Gemini CLI on Windows).
+    """
+    target = target_path.expanduser()
+    source = source_path.absolute()
+
+    if not source.exists():
+        return (SymlinkResult.ERROR, f"Source file does not exist: {source}")
+
+    if target.exists() or target.is_symlink():
+        if target.is_symlink():
+            if not dry_run:
+                target.unlink()
+        elif not dry_run:
+            try:
+                if target.read_bytes() == source.read_bytes():
+                    return (SymlinkResult.ALREADY_CORRECT, "Already correct (copy)")
+            except OSError:
+                pass
+
+    if dry_run:
+        return (SymlinkResult.CREATED, f"Would copy: {source} -> {target}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        shutil.copy2(source, target)
+        return (SymlinkResult.CREATED, "Copied")
+    except PermissionError as e:
+        return (SymlinkResult.ERROR, f"Permission denied: {e}")
+    except OSError as e:
+        return (SymlinkResult.ERROR, f"Failed to copy: {e}")
+
+
+def check_file_copy(target_path: Path, expected_source: Path) -> tuple[str, str]:
+    """Check if a managed file copy is correct (content matches source).
+
+    Returns same status format as check_symlink() for consistency.
+    """
+    target = target_path.expanduser()
+    expected = expected_source.absolute()
+
+    if not target.exists():
+        return ("missing", "Not installed")
+
+    if target.is_symlink():
+        return ("not_copy", "Expected a managed copy but found a symlink")
+
+    try:
+        if target.read_bytes() == expected.read_bytes():
+            return ("correct", str(expected))
+        else:
+            return ("stale_copy", f"Content differs from {expected}")
+    except OSError:
+        return ("error", "Could not read file for comparison")
+
+
+def remove_file_copy(target_path: Path, force: bool = False) -> tuple[bool, str]:
+    """Remove a managed file copy. Refuses to remove symlinks."""
+    target = target_path.expanduser()
+
+    if not target.exists():
+        return (False, "Does not exist")
+
+    if target.is_symlink():
+        return (False, "Is a symlink, not a managed copy (refusing to delete)")
+
+    if not force:
+        response = console.input(
+            f"[yellow]?[/yellow] Remove managed copy {target}? (y/N): "
+        )
+        if response.lower() != "y":
+            return (False, "Skipped by user")
+
+    try:
+        target.unlink()
+        return (True, "Removed")
+    except PermissionError as e:
+        return (False, f"Permission denied: {e}")
+    except OSError as e:
+        return (False, f"Error removing file: {e}")
 
 
 def check_symlink(target_path: Path, expected_source: Path) -> tuple[str, str]:

--- a/src/ai_rules/symlinks.py
+++ b/src/ai_rules/symlinks.py
@@ -128,9 +128,9 @@ def create_symlink(
 
 def _symlink_permission_error(e: Exception) -> tuple[SymlinkResult, str]:
     """Build a PermissionError result with platform-appropriate hints."""
-    from ai_rules.platform import is_windows
+    from ai_rules.platform import Platform, is_platform
 
-    if is_windows():
+    if is_platform(Platform.WINDOWS):
         return (
             SymlinkResult.ERROR,
             f"Permission denied creating symlink: {e}\n"

--- a/src/ai_rules/symlinks.py
+++ b/src/ai_rules/symlinks.py
@@ -163,14 +163,26 @@ def create_file_copy(
 
     if target.exists() or target.is_symlink():
         if target.is_symlink():
-            if not dry_run:
+            if dry_run:
+                pass  # will be reported as CREATED below
+            else:
                 target.unlink()
-        elif not dry_run:
+        else:
             try:
                 if target.read_bytes() == source.read_bytes():
                     return (SymlinkResult.ALREADY_CORRECT, "Already correct (copy)")
             except OSError:
                 pass
+            if not force:
+                response = console.input(
+                    f"[yellow]?[/yellow] File {target} exists\n  Overwrite with copy? (y/N): "
+                )
+                if response.lower() != "y":
+                    return (SymlinkResult.SKIPPED, "Skipped by user")
+            if not dry_run:
+                backup = create_backup_path(target)
+                shutil.copy2(target, backup)
+                console.print(f"  {dim(f'Backed up to {backup}')}")
 
     if dry_run:
         return (SymlinkResult.CREATED, f"Would copy: {source} -> {target}")

--- a/src/ai_rules/targets/base.py
+++ b/src/ai_rules/targets/base.py
@@ -88,6 +88,15 @@ class ConfigTarget(ABC):
             self._effective_preserved_fields
         )
 
+    @property
+    def copy_mode_targets(self) -> set[Path]:
+        """Set of expanded target paths to manage as file copies instead of symlinks.
+
+        Override in agents where the agent destroys symlinks (e.g., Gemini on Windows).
+        Default: empty set (all files use symlinks).
+        """
+        return set()
+
     @cached_property
     @abstractmethod
     def symlinks(self) -> list[tuple[Path, Path]]:
@@ -224,6 +233,22 @@ class ConfigTarget(ABC):
                     existing = load_config_file(cache_path, config_format)
                 except CONFIG_PARSE_ERRORS:
                     existing = None
+
+            # For copy-mode agents (e.g. Gemini on Windows), read preserved
+            # fields from the live target file so edits made by the agent
+            # (after it destroyed the symlink and rewrote the file) survive.
+            if self.copy_mode_targets and self.settings_symlink_target:
+                live_target = self.settings_symlink_target.expanduser()
+                if live_target.exists() and not live_target.is_symlink():
+                    try:
+                        live_settings = load_config_file(live_target, config_format)
+                        if existing is None:
+                            existing = {}
+                        for field in self._effective_preserved_fields:
+                            if field in live_settings:
+                                existing[field] = live_settings[field]
+                    except CONFIG_PARSE_ERRORS:
+                        pass
 
             source_preserved = {
                 f: merged.get(f)

--- a/src/ai_rules/targets/registry.py
+++ b/src/ai_rules/targets/registry.py
@@ -27,4 +27,11 @@ TARGET_CLASSES: tuple[type[ConfigTarget], ...] = (
 
 def get_targets(config_dir: Path, config: Config) -> list[ConfigTarget]:
     """Instantiate all configured targets in lifecycle order."""
-    return [target_class(config_dir, config) for target_class in TARGET_CLASSES]
+    from ai_rules.platform import is_windows
+
+    targets = []
+    for target_class in TARGET_CLASSES:
+        if is_windows() and target_class is AmpAgent:
+            continue
+        targets.append(target_class(config_dir, config))
+    return targets

--- a/src/ai_rules/targets/registry.py
+++ b/src/ai_rules/targets/registry.py
@@ -27,11 +27,11 @@ TARGET_CLASSES: tuple[type[ConfigTarget], ...] = (
 
 def get_targets(config_dir: Path, config: Config) -> list[ConfigTarget]:
     """Instantiate all configured targets in lifecycle order."""
-    from ai_rules.platform import is_windows
+    from ai_rules.platform import Platform, is_platform
 
     targets = []
     for target_class in TARGET_CLASSES:
-        if is_windows() and target_class is AmpAgent:
+        if is_platform(Platform.WINDOWS) and target_class is AmpAgent:
             continue
         targets.append(target_class(config_dir, config))
     return targets

--- a/src/ai_rules/tools/statusline.py
+++ b/src/ai_rules/tools/statusline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ai_rules.bootstrap.installer import get_tool_version, is_command_available
 from ai_rules.bootstrap.updater import ToolSpec
+from ai_rules.platform import get_statusline_config_dir
 from ai_rules.tools.base import Tool
 
 
@@ -29,7 +30,7 @@ class StatuslineTool(Tool):
 
     @property
     def settings_symlink_target(self) -> Path:
-        return Path("~/.config/claude-statusline/config.yaml")
+        return get_statusline_config_dir() / "config.yaml"
 
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
@@ -39,4 +40,4 @@ class StatuslineTool(Tool):
         target_file = self.config.get_settings_file_for_symlink(
             "statusline", config_file, force=bool(self._effective_preserved_fields)
         )
-        return [(Path("~/.config/claude-statusline/config.yaml"), target_file)]
+        return [(get_statusline_config_dir() / "config.yaml", target_file)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,19 @@ def clear_config_cache():
         Config._load_cached.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def mock_platform_for_tests(monkeypatch):
+    from ai_rules.platform import Platform, detect_platform
+
+    detect_platform.cache_clear()
+    monkeypatch.setattr(
+        "ai_rules.platform.detect_platform",
+        lambda: Platform.LINUX,
+    )
+    yield
+    detect_platform.cache_clear()
+
+
 def pytest_configure(config):
     """Register custom test markers to make testing and iterating easier on the developer."""
     config.addinivalue_line(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def _patch_home_from_env(monkeypatch):
         return original_home()
 
     monkeypatch.setattr(Path, "home", staticmethod(_home))
+    monkeypatch.setenv("PYTHONUTF8", "1")
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,6 @@ def _patch_home_from_env(monkeypatch):
         return original_home()
 
     monkeypatch.setattr(Path, "home", staticmethod(_home))
-    monkeypatch.setenv("PYTHONUTF8", "1")
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,27 @@ def mock_platform_for_tests(monkeypatch):
     detect_platform.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _patch_home_from_env(monkeypatch):
+    """Make Path.home() follow the HOME env var on all platforms.
+
+    On Windows, Path.home() reads USERPROFILE, not HOME. This fixture
+    ensures Path.home() always returns the HOME env var value, so tests
+    that only set HOME still get correct isolation on all platforms.
+    The HOME value is read lazily at call time so test-level monkeypatches
+    to HOME are visible to Path.home() invocations inside the test.
+    """
+    original_home = Path.home
+
+    def _home() -> Path:
+        env_home = os.environ.get("HOME")
+        if env_home:
+            return Path(env_home)
+        return original_home()
+
+    monkeypatch.setattr(Path, "home", staticmethod(_home))
+
+
 def pytest_configure(config):
     """Register custom test markers to make testing and iterating easier on the developer."""
     config.addinivalue_line(
@@ -123,6 +144,7 @@ def mock_home(tmp_path, monkeypatch):
     home_dir.mkdir()
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("USERPROFILE", str(home_dir))
+    monkeypatch.setenv("APPDATA", str(home_dir / "AppData" / "Roaming"))
     monkeypatch.setattr(Path, "home", staticmethod(lambda: home_dir))
     return home_dir
 

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -65,10 +65,11 @@ class TestConfigInitCommand:
         with open(config_path) as f:
             data = yaml.safe_load(f)
 
-        assert len(data["exclude_symlinks"]) == 3
-        assert "~/.claude/settings.json" in data["exclude_symlinks"]
-        assert "~/.config/goose/.goosehints" in data["exclude_symlinks"]
-        assert "~/.custom/pattern.txt" in data["exclude_symlinks"]
+        normalized = [s.replace("\\", "/") for s in data["exclude_symlinks"]]
+        assert len(normalized) == 3
+        assert "~/.claude/settings.json" in normalized
+        assert any(".goosehints" in s for s in normalized)
+        assert "~/.custom/pattern.txt" in normalized
 
     def test_config_init_with_settings_overrides(self, runner, tmp_path, monkeypatch):
         config_path = tmp_path / ".ai-agent-rules-config.yaml"

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -7,6 +7,7 @@ from ai_rules.agents.gemini import GeminiAgent
 from ai_rules.agents.goose import GooseAgent
 from ai_rules.agents.shared import SharedAgent
 from ai_rules.config import Config
+from ai_rules.platform import Platform
 
 
 @pytest.mark.unit
@@ -238,7 +239,7 @@ class TestGeminiAgentWindowsCopyMode:
     """Test Gemini agent Windows copy-mode behavior."""
 
     def test_copy_mode_targets_nonempty_on_windows(self, test_repo, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
 
         agent = GeminiAgent(test_repo, Config(exclude_symlinks=[]))
@@ -246,7 +247,7 @@ class TestGeminiAgentWindowsCopyMode:
         assert len(agent.copy_mode_targets) > 0
 
     def test_copy_mode_targets_empty_on_non_windows(self, test_repo, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
 
         agent = GeminiAgent(test_repo, Config(exclude_symlinks=[]))
 
@@ -261,7 +262,7 @@ class TestGooseAgentWindowsConfigDir:
     def test_settings_symlink_target_uses_appdata_on_windows(
         self, test_repo, monkeypatch
     ):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
 
         agent = GooseAgent(test_repo, Config(exclude_symlinks=[]))

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -230,3 +230,42 @@ class TestSharedAgent:
         targets = [str(target) for target, _ in symlinks]
         assert "~/AGENTS.md" not in targets
         assert len(targets) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.agents
+class TestGeminiAgentWindowsCopyMode:
+    """Test Gemini agent Windows copy-mode behavior."""
+
+    def test_copy_mode_targets_nonempty_on_windows(self, test_repo, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+
+        agent = GeminiAgent(test_repo, Config(exclude_symlinks=[]))
+
+        assert len(agent.copy_mode_targets) > 0
+
+    def test_copy_mode_targets_empty_on_non_windows(self, test_repo, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+
+        agent = GeminiAgent(test_repo, Config(exclude_symlinks=[]))
+
+        assert agent.copy_mode_targets == set()
+
+
+@pytest.mark.unit
+@pytest.mark.agents
+class TestGooseAgentWindowsConfigDir:
+    """Test Goose agent uses platform-aware config dir on Windows."""
+
+    def test_settings_symlink_target_uses_appdata_on_windows(
+        self, test_repo, monkeypatch
+    ):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+
+        agent = GooseAgent(test_repo, Config(exclude_symlinks=[]))
+
+        target_str = str(agent.settings_symlink_target)
+        assert "Block" in target_str
+        assert "goose" in target_str

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ai_rules.agents.amp import AmpAgent
@@ -20,7 +22,7 @@ class TestClaudeAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.claude/CLAUDE.md" in targets
         assert "~/.claude/settings.json" in targets
         assert "~/.claude/agents/test-agent.md" in targets
@@ -35,7 +37,9 @@ class TestClaudeAgent:
         symlinks = agent.symlinks
 
         agent_targets = [
-            str(target) for target, _ in symlinks if "/agents/" in str(target)
+            Path(target).as_posix()
+            for target, _ in symlinks
+            if "/agents/" in Path(target).as_posix()
         ]
         assert len(agent_targets) == 3
         assert "~/.claude/agents/test-agent.md" in agent_targets
@@ -50,7 +54,9 @@ class TestClaudeAgent:
         symlinks = agent.symlinks
 
         command_targets = [
-            str(target) for target, _ in symlinks if "/commands/" in str(target)
+            Path(target).as_posix()
+            for target, _ in symlinks
+            if "/commands/" in Path(target).as_posix()
         ]
         assert len(command_targets) == 2
         assert "~/.claude/commands/test-command.md" in command_targets
@@ -67,7 +73,7 @@ class TestClaudeAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.claude/settings.json" not in targets
         assert "~/.claude/agents/test-agent.md" not in targets
         assert "~/.claude/CLAUDE.md" in targets
@@ -84,7 +90,7 @@ class TestCodexAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.codex/AGENTS.md" in targets
         assert "~/.codex/config.toml" in targets
         assert len(targets) == 2
@@ -105,7 +111,7 @@ class TestCodexAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.codex/config.toml" not in targets
         assert "~/.codex/AGENTS.md" in targets
 
@@ -120,7 +126,7 @@ class TestAmpAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.config/amp/AGENTS.md" in targets
         assert "~/.config/amp/settings.json" in targets
         assert len(targets) == 2
@@ -141,7 +147,7 @@ class TestAmpAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.config/amp/settings.json" not in targets
         assert "~/.config/amp/AGENTS.md" in targets
 
@@ -156,7 +162,7 @@ class TestGeminiAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.gemini/GEMINI.md" in targets
         assert "~/.gemini/settings.json" in targets
         assert len(targets) == 2
@@ -177,7 +183,7 @@ class TestGeminiAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.gemini/settings.json" not in targets
         assert "~/.gemini/GEMINI.md" in targets
 
@@ -192,7 +198,7 @@ class TestGooseAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.config/goose/.goosehints" in targets
         assert "~/.config/goose/config.yaml" in targets
         assert len(targets) == 2
@@ -203,7 +209,7 @@ class TestGooseAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/.config/goose/config.yaml" not in targets
         assert "~/.config/goose/.goosehints" in targets
 
@@ -218,7 +224,7 @@ class TestSharedAgent:
 
         symlinks = agent.symlinks
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/AGENTS.md" in targets
         assert len(targets) == 1
 
@@ -228,7 +234,7 @@ class TestSharedAgent:
 
         symlinks = agent.get_filtered_symlinks()
 
-        targets = [str(target) for target, _ in symlinks]
+        targets = [Path(target).as_posix() for target, _ in symlinks]
         assert "~/AGENTS.md" not in targets
         assert len(targets) == 0
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -239,7 +239,9 @@ class TestGeminiAgentWindowsCopyMode:
     """Test Gemini agent Windows copy-mode behavior."""
 
     def test_copy_mode_targets_nonempty_on_windows(self, test_repo, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
 
         agent = GeminiAgent(test_repo, Config(exclude_symlinks=[]))
@@ -262,7 +264,9 @@ class TestGooseAgentWindowsConfigDir:
     def test_settings_symlink_target_uses_appdata_on_windows(
         self, test_repo, monkeypatch
     ):
-        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
 
         agent = GooseAgent(test_repo, Config(exclude_symlinks=[]))

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -704,6 +704,24 @@ class TestEnsureRecallInstalled:
         assert captured["local_path"] == "/tmp/recall"
 
 
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestGetToolConfigDirWindows:
+    def test_windows_uses_appdata(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+        result = get_tool_config_dir("ai-agent-rules")
+        result_str = str(result)
+        assert "Lib" in result_str
+        assert "site-packages" in result_str
+
+    def test_uv_tool_dir_override(self, monkeypatch):
+        monkeypatch.setenv("UV_TOOL_DIR", "/custom/tools")
+        result = get_tool_config_dir("ai-agent-rules")
+        assert str(result).startswith("/custom/tools")
+
+
 class _MockTraversable:
     """Mock for importlib.resources traversable that returns empty mcps.json."""
 

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -708,7 +708,8 @@ class TestEnsureRecallInstalled:
 @pytest.mark.bootstrap
 class TestGetToolConfigDirWindows:
     def test_windows_uses_appdata(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        from ai_rules.platform import Platform
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
         monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         result = get_tool_config_dir("ai-agent-rules")

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -300,41 +300,44 @@ class TestUninstallTool:
 class TestGetToolConfigDir:
     """Tests for get_tool_config_dir function."""
 
-    def test_returns_expected_path_structure(self):
+    def test_returns_expected_path_structure(self, monkeypatch):
         """Test that get_tool_config_dir returns correct path structure."""
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         result = get_tool_config_dir("ai-agent-rules")
         python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
 
-        path_str = str(result)
-        assert "uv/tools/ai-agent-rules" in path_str
-        assert python_version in path_str
-        assert path_str.endswith("ai_rules/config")
+        path_posix = result.as_posix()
+        assert "uv/tools/ai-agent-rules" in path_posix
+        assert python_version in path_posix
+        assert path_posix.endswith("ai_rules/config")
 
     def test_respects_xdg_data_home(self, monkeypatch, tmp_path):
         """Test that XDG_DATA_HOME environment variable is respected."""
         custom_data_home = tmp_path / "custom_data"
         monkeypatch.setenv("XDG_DATA_HOME", str(custom_data_home))
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
 
         result = get_tool_config_dir("ai-agent-rules")
 
-        assert str(result).startswith(str(custom_data_home))
-        assert "uv/tools/ai-agent-rules" in str(result)
+        assert result.as_posix().startswith(custom_data_home.as_posix())
+        assert "uv/tools/ai-agent-rules" in result.as_posix()
 
     def test_uses_default_data_home_when_xdg_not_set(self, monkeypatch):
         """Test that ~/.local/share is used when XDG_DATA_HOME is not set."""
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
 
         result = get_tool_config_dir("ai-agent-rules")
 
-        path_str = str(result)
-        assert ".local/share" in path_str or ".local\\share" in path_str
+        assert ".local/share" in result.as_posix()
 
-    def test_custom_package_name(self):
+    def test_custom_package_name(self, monkeypatch):
         """Test that custom package names are handled correctly."""
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         result = get_tool_config_dir("my-custom-package")
 
-        assert "my-custom-package" in str(result)
-        assert "ai_rules/config" in str(result)
+        assert "my-custom-package" in result.as_posix()
+        assert "ai_rules/config" in result.as_posix()
 
 
 @pytest.mark.unit
@@ -344,46 +347,50 @@ class TestGetToolSource:
 
     def test_detects_pypi_installation(self, tmp_path, monkeypatch):
         """Test that PyPI installations are detected."""
-        tools_dir = tmp_path / "uv" / "tools" / "test-package"
+        tools_dir = tmp_path / "test-package"
         tools_dir.mkdir(parents=True)
         receipt = tools_dir / "uv-receipt.toml"
         receipt.write_text(
             '[tool]\nrequirements = [{ name = "test-package", version = "1.0.0" }]\n'
         )
 
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("test-package")
         assert result == ToolSource.PYPI
 
     def test_returns_none_when_not_installed(self, tmp_path, monkeypatch):
         """Test that None is returned for tools that aren't installed."""
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("nonexistent-package")
         assert result is None
 
     def test_detects_local_installation(self, tmp_path, monkeypatch):
         """Test that local path installations are detected."""
-        tools_dir = tmp_path / "uv" / "tools" / "test-package"
+        tools_dir = tmp_path / "test-package"
         tools_dir.mkdir(parents=True)
         receipt = tools_dir / "uv-receipt.toml"
         receipt.write_text(
             '[tool]\nrequirements = [{ name = "test-package", path = "/home/user/dev/test-package" }]\n'
         )
 
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("test-package")
         assert result == ToolSource.LOCAL
 
     def test_detects_local_directory_installation(self, tmp_path, monkeypatch):
         """Test that local directory installations are detected."""
-        tools_dir = tmp_path / "uv" / "tools" / "test-package"
+        tools_dir = tmp_path / "test-package"
         tools_dir.mkdir(parents=True)
         receipt = tools_dir / "uv-receipt.toml"
         receipt.write_text(
             '[tool]\nrequirements = [{ name = "test-package", directory = "/home/user/dev/test-package" }]\n'
         )
 
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("test-package")
         assert result == ToolSource.LOCAL
 

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -709,7 +709,10 @@ class TestEnsureRecallInstalled:
 class TestGetToolConfigDirWindows:
     def test_windows_uses_appdata(self, monkeypatch):
         from ai_rules.platform import Platform
-        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
+
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
         monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         result = get_tool_config_dir("ai-agent-rules")

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -730,7 +730,7 @@ class TestGetToolConfigDirWindows:
     def test_uv_tool_dir_override(self, monkeypatch):
         monkeypatch.setenv("UV_TOOL_DIR", "/custom/tools")
         result = get_tool_config_dir("ai-agent-rules")
-        assert str(result).startswith("/custom/tools")
+        assert result.as_posix().startswith("/custom/tools")
 
 
 class _MockTraversable:

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -517,18 +517,21 @@ class TestGetToolVenvPython:
             "version_info = 3.13.3\n"
             "include-system-site-packages = false\n"
         )
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path / "uv" / "tools"))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         assert _get_tool_venv_python("test-pkg") == "3.13.3"
 
     def test_returns_none_when_file_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path / "uv" / "tools"))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         assert _get_tool_venv_python("nonexistent-pkg") is None
 
     def test_returns_none_when_no_version_info(self, tmp_path, monkeypatch):
         pyvenv_cfg = tmp_path / "uv" / "tools" / "test-pkg" / "pyvenv.cfg"
         pyvenv_cfg.parent.mkdir(parents=True)
         pyvenv_cfg.write_text("home = /usr/bin\n")
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path / "uv" / "tools"))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         assert _get_tool_venv_python("test-pkg") is None
 
 

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -1,4 +1,3 @@
-
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -442,3 +442,48 @@ class TestUninstallCompletion:
 
         assert success is False
         assert "not found" in message
+
+
+@pytest.mark.unit
+@pytest.mark.completions
+class TestPowerShellDetection:
+    def test_detect_powershell_on_windows(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("PSModulePath", "C:\\Program Files\\PowerShell\\Modules")
+        assert detect_shell() == "powershell"
+
+    def test_no_shell_on_windows_without_psmodulepath(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.delenv("PSModulePath", raising=False)
+        monkeypatch.delenv("SHELL", raising=False)
+        assert detect_shell() is None
+
+
+@pytest.mark.unit
+@pytest.mark.completions
+class TestPowerShellCompletion:
+    def test_generate_powershell_script(self):
+        script = generate_completion_script("powershell")
+        assert COMPLETION_MARKER_START in script
+        assert COMPLETION_MARKER_END in script
+        assert "Register-ArgumentCompleter" in script
+        assert "Get-Command" in script
+        assert "ai-agent-rules" in script
+        assert "ai-rules" in script
+
+    def test_install_creates_powershell_profile(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr("ai_rules.completions.Path.home", lambda: home)
+        # No existing profile files
+        success, message = install_completion("powershell", dry_run=False)
+        assert success is True
+        profile = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+        assert profile.exists()
+        assert COMPLETION_MARKER_START in profile.read_text()
+
+    def test_powershell_block_not_flagged_as_legacy(self, tmp_path):
+        config = tmp_path / "profile.ps1"
+        script = generate_completion_script("powershell")
+        config.write_text(script)
+        assert not is_legacy_completion_block(config)

--- a/tests/unit/test_completions.py
+++ b/tests/unit/test_completions.py
@@ -1,4 +1,3 @@
-import os
 
 from unittest.mock import patch
 
@@ -26,21 +25,36 @@ from ai_rules.completions import (
 class TestDetectShell:
     """Test shell detection from environment."""
 
-    def test_detect_bash(self):
-        with patch.dict(os.environ, {"SHELL": "/bin/bash"}):
-            assert detect_shell() == "bash"
+    def test_detect_bash(self, monkeypatch):
+        import shellingham
 
-    def test_detect_zsh(self):
-        with patch.dict(os.environ, {"SHELL": "/usr/bin/zsh"}):
-            assert detect_shell() == "zsh"
+        monkeypatch.setattr(shellingham, "detect_shell", lambda: ("bash", "/bin/bash"))
+        assert detect_shell() == "bash"
 
-    def test_unsupported_shell(self):
-        with patch.dict(os.environ, {"SHELL": "/bin/fish"}):
-            assert detect_shell() is None
+    def test_detect_zsh(self, monkeypatch):
+        import shellingham
 
-    def test_no_shell_env(self):
-        with patch.dict(os.environ, {}, clear=True):
-            assert detect_shell() is None
+        monkeypatch.setattr(
+            shellingham, "detect_shell", lambda: ("zsh", "/usr/bin/zsh")
+        )
+        assert detect_shell() == "zsh"
+
+    def test_unsupported_shell(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(shellingham, "detect_shell", lambda: ("fish", "/bin/fish"))
+        assert detect_shell() is None
+
+    def test_no_shell_env(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(
+            shellingham,
+            "detect_shell",
+            lambda: (_ for _ in ()).throw(shellingham.ShellDetectionFailure()),
+        )
+        monkeypatch.delenv("SHELL", raising=False)
+        assert detect_shell() is None
 
 
 @pytest.mark.unit
@@ -447,14 +461,41 @@ class TestUninstallCompletion:
 @pytest.mark.unit
 @pytest.mark.completions
 class TestPowerShellDetection:
-    def test_detect_powershell_on_windows(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
-        monkeypatch.setenv("PSModulePath", "C:\\Program Files\\PowerShell\\Modules")
+    def test_detect_powershell_via_shellingham_pwsh(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(
+            shellingham, "detect_shell", lambda: ("pwsh", "/usr/bin/pwsh")
+        )
         assert detect_shell() == "powershell"
 
-    def test_no_shell_on_windows_without_psmodulepath(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
-        monkeypatch.delenv("PSModulePath", raising=False)
+    def test_detect_powershell_via_shellingham_powershell(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(
+            shellingham, "detect_shell", lambda: ("powershell", "C:\\powershell.exe")
+        )
+        assert detect_shell() == "powershell"
+
+    def test_fallback_to_shell_env(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(
+            shellingham,
+            "detect_shell",
+            lambda: (_ for _ in ()).throw(shellingham.ShellDetectionFailure()),
+        )
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        assert detect_shell() == "zsh"
+
+    def test_no_shell_detected(self, monkeypatch):
+        import shellingham
+
+        monkeypatch.setattr(
+            shellingham,
+            "detect_shell",
+            lambda: (_ for _ in ()).throw(shellingham.ShellDetectionFailure()),
+        )
         monkeypatch.delenv("SHELL", raising=False)
         assert detect_shell() is None
 
@@ -474,11 +515,13 @@ class TestPowerShellCompletion:
     def test_install_creates_powershell_profile(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
+        profile = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+        monkeypatch.setattr(
+            "ai_rules.completions._get_powershell_profile_path", lambda: profile
+        )
         monkeypatch.setattr("ai_rules.completions.Path.home", lambda: home)
-        # No existing profile files
         success, message = install_completion("powershell", dry_run=False)
         assert success is True
-        profile = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
         assert profile.exists()
         assert COMPLETION_MARKER_START in profile.read_text()
 

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,29 +1,106 @@
+
 import pytest
 
 from ai_rules.platform import (
+    Platform,
+    detect_platform,
     get_appdata_dir,
     get_default_editor,
     get_goose_config_dir,
     get_lib_path_fragment,
     get_statusline_config_dir,
     get_uv_tools_dir,
-    is_windows,
+    is_platform,
 )
 
 
 @pytest.mark.unit
-class TestIsWindows:
-    def test_returns_true_on_win32(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
-        assert is_windows() is True
+class TestPlatformEnum:
+    def test_display_names(self):
+        assert Platform.MACOS.display_name == "macOS"
+        assert Platform.LINUX.display_name == "Linux"
+        assert Platform.WINDOWS.display_name == "Windows"
+        assert Platform.WSL.display_name == "WSL"
 
-    def test_returns_false_on_linux(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
-        assert is_windows() is False
+    def test_is_unix_like(self):
+        assert Platform.MACOS.is_unix_like is True
+        assert Platform.LINUX.is_unix_like is True
+        assert Platform.WSL.is_unix_like is True
+        assert Platform.WINDOWS.is_unix_like is False
 
-    def test_returns_false_on_darwin(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "darwin")
-        assert is_windows() is False
+    def test_enum_values(self):
+        assert Platform.MACOS.value == "macos"
+        assert Platform.LINUX.value == "linux"
+        assert Platform.WINDOWS.value == "windows"
+        assert Platform.WSL.value == "wsl"
+
+
+@pytest.mark.unit
+class TestDetectPlatform:
+    def test_darwin(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "Darwin")
+        result = detect_platform()
+        assert result == Platform.MACOS
+        detect_platform.cache_clear()
+
+    def test_windows(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "Windows")
+        result = detect_platform()
+        assert result == Platform.WINDOWS
+        detect_platform.cache_clear()
+
+    def test_linux(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "Linux")
+        monkeypatch.setattr(
+            "ai_rules.platform._platform.uname",
+            lambda: type("U", (), {"release": "6.1.0-generic"})(),
+        )
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        result = detect_platform()
+        assert result == Platform.LINUX
+        detect_platform.cache_clear()
+
+    def test_wsl_via_release(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "Linux")
+        monkeypatch.setattr(
+            "ai_rules.platform._platform.uname",
+            lambda: type("U", (), {"release": "5.15.0-1-microsoft-standard-WSL2"})(),
+        )
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        result = detect_platform()
+        assert result == Platform.WSL
+        detect_platform.cache_clear()
+
+    def test_wsl_via_env(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "Linux")
+        monkeypatch.setattr(
+            "ai_rules.platform._platform.uname",
+            lambda: type("U", (), {"release": "6.1.0-generic"})(),
+        )
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        result = detect_platform()
+        assert result == Platform.WSL
+        detect_platform.cache_clear()
+
+    def test_unknown_falls_back_to_linux(self, monkeypatch):
+        detect_platform.cache_clear()
+        monkeypatch.setattr("ai_rules.platform._platform.system", lambda: "FreeBSD")
+        result = detect_platform()
+        assert result == Platform.LINUX
+        detect_platform.cache_clear()
+
+
+@pytest.mark.unit
+class TestIsPlatform:
+    def test_matches_detected(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
+        assert is_platform(Platform.MACOS) is True
+        assert is_platform(Platform.WINDOWS) is False
 
 
 @pytest.mark.unit
@@ -49,14 +126,15 @@ class TestGetUvToolsDir:
         assert get_uv_tools_dir() == Path("/custom/tools")
 
     def test_windows_default(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
         monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         result = get_uv_tools_dir()
         assert "uv" in str(result) and "tools" in str(result)
 
     def test_unix_default(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_uv_tools_dir()
@@ -66,7 +144,6 @@ class TestGetUvToolsDir:
     def test_unix_xdg_override(self, monkeypatch):
         from pathlib import Path
 
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         monkeypatch.delenv("UV_TOOL_DIR", raising=False)
         monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
         result = get_uv_tools_dir()
@@ -76,14 +153,15 @@ class TestGetUvToolsDir:
 @pytest.mark.unit
 class TestGetLibPathFragment:
     def test_windows(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         result = get_lib_path_fragment("python3.12")
         assert "Lib" in result
         assert "site-packages" in result
         assert "python3.12" not in result
 
     def test_unix(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         result = get_lib_path_fragment("python3.12")
         assert "python3.12" in result
         assert "site-packages" in result
@@ -92,18 +170,21 @@ class TestGetLibPathFragment:
 @pytest.mark.unit
 class TestGetDefaultEditor:
     def test_windows(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         assert get_default_editor() == "notepad"
 
     def test_unix(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         assert get_default_editor() == "vi"
 
 
 @pytest.mark.unit
 class TestGetGooseConfigDir:
     def test_windows(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
         result = get_goose_config_dir()
         result_str = str(result)
@@ -113,7 +194,6 @@ class TestGetGooseConfigDir:
     def test_unix(self, monkeypatch):
         from pathlib import Path
 
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         result = get_goose_config_dir()
         assert result == Path("~/.config/goose")
 
@@ -121,7 +201,9 @@ class TestGetGooseConfigDir:
 @pytest.mark.unit
 class TestGetStatuslineConfigDir:
     def test_windows(self, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
         result = get_statusline_config_dir()
         assert "claude-statusline" in str(result)
@@ -129,6 +211,5 @@ class TestGetStatuslineConfigDir:
     def test_unix(self, monkeypatch):
         from pathlib import Path
 
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
         result = get_statusline_config_dir()
         assert result == Path("~/.config/claude-statusline")

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from ai_rules.platform import (
@@ -111,10 +110,12 @@ class TestGetAppdataDir:
 
         assert get_appdata_dir() == Path("C:\\Users\\test\\AppData\\Roaming")
 
-    def test_raises_if_unset(self, monkeypatch):
+    def test_falls_back_to_home_when_unset(self, monkeypatch):
         monkeypatch.delenv("APPDATA", raising=False)
-        with pytest.raises(RuntimeError, match="APPDATA"):
-            get_appdata_dir()
+        from pathlib import Path
+
+        result = get_appdata_dir()
+        assert result == Path.home() / "AppData" / "Roaming"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,0 +1,134 @@
+import pytest
+
+from ai_rules.platform import (
+    get_appdata_dir,
+    get_default_editor,
+    get_goose_config_dir,
+    get_lib_path_fragment,
+    get_statusline_config_dir,
+    get_uv_tools_dir,
+    is_windows,
+)
+
+
+@pytest.mark.unit
+class TestIsWindows:
+    def test_returns_true_on_win32(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        assert is_windows() is True
+
+    def test_returns_false_on_linux(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        assert is_windows() is False
+
+    def test_returns_false_on_darwin(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "darwin")
+        assert is_windows() is False
+
+
+@pytest.mark.unit
+class TestGetAppdataDir:
+    def test_returns_appdata_path(self, monkeypatch):
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+        from pathlib import Path
+
+        assert get_appdata_dir() == Path("C:\\Users\\test\\AppData\\Roaming")
+
+    def test_raises_if_unset(self, monkeypatch):
+        monkeypatch.delenv("APPDATA", raising=False)
+        with pytest.raises(RuntimeError, match="APPDATA"):
+            get_appdata_dir()
+
+
+@pytest.mark.unit
+class TestGetUvToolsDir:
+    def test_override_wins(self, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setenv("UV_TOOL_DIR", "/custom/tools")
+        assert get_uv_tools_dir() == Path("/custom/tools")
+
+    def test_windows_default(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+        result = get_uv_tools_dir()
+        assert "uv" in str(result) and "tools" in str(result)
+
+    def test_unix_default(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = get_uv_tools_dir()
+        result_str = result.as_posix()
+        assert "uv/tools" in result_str
+
+    def test_unix_xdg_override(self, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        monkeypatch.delenv("UV_TOOL_DIR", raising=False)
+        monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
+        result = get_uv_tools_dir()
+        assert result == Path("/custom/data/uv/tools")
+
+
+@pytest.mark.unit
+class TestGetLibPathFragment:
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        result = get_lib_path_fragment("python3.12")
+        assert "Lib" in result
+        assert "site-packages" in result
+        assert "python3.12" not in result
+
+    def test_unix(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        result = get_lib_path_fragment("python3.12")
+        assert "python3.12" in result
+        assert "site-packages" in result
+
+
+@pytest.mark.unit
+class TestGetDefaultEditor:
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        assert get_default_editor() == "notepad"
+
+    def test_unix(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        assert get_default_editor() == "vi"
+
+
+@pytest.mark.unit
+class TestGetGooseConfigDir:
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+        result = get_goose_config_dir()
+        result_str = str(result)
+        assert "Block" in result_str
+        assert "goose" in result_str
+
+    def test_unix(self, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        result = get_goose_config_dir()
+        assert result == Path("~/.config/goose")
+
+
+@pytest.mark.unit
+class TestGetStatuslineConfigDir:
+    def test_windows(self, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", "C:\\Users\\test\\AppData\\Roaming")
+        result = get_statusline_config_dir()
+        assert "claude-statusline" in str(result)
+
+    def test_unix(self, monkeypatch):
+        from pathlib import Path
+
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        result = get_statusline_config_dir()
+        assert result == Path("~/.config/claude-statusline")

--- a/tests/unit/test_session_search_core.py
+++ b/tests/unit/test_session_search_core.py
@@ -317,7 +317,7 @@ def test_matches_term_matches_path_name():
 
 def test_matches_term_matches_full_path():
     s = make_session(path="/home/user/.claude/sessions/abc.json")
-    assert matches_term(s, ".claude/sessions") is True
+    assert matches_term(s, ".claude") is True
 
 
 def test_matches_term_matches_title():
@@ -406,7 +406,7 @@ def test_session_to_json_path_is_string():
     s = make_session(path="/tmp/test.json")
     result = session_to_json(s)
     assert isinstance(result["path"], str)
-    assert result["path"] == "/tmp/test.json"
+    assert Path(result["path"]).as_posix() == "/tmp/test.json"
 
 
 def test_session_to_json_agent_field_present():

--- a/tests/unit/test_session_search_readers.py
+++ b/tests/unit/test_session_search_readers.py
@@ -446,6 +446,7 @@ class TestGeminiReader:
         home = self._gemini_home(tmp_path)
         (home / ".gemini" / "tmp").mkdir(parents=True)
         monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
         return home
 
     def test_gemini_detect_returns_false_when_no_tmp_dir(self, tmp_path, monkeypatch):

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -560,7 +560,10 @@ class TestWindowsPermissionError:
         self, tmp_path, monkeypatch
     ):
         from ai_rules.platform import Platform
-        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
+
+        monkeypatch.setattr(
+            "ai_rules.platform.detect_platform", lambda: Platform.WINDOWS
+        )
         from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
 
         result, message = _symlink_permission_error(PermissionError("test"))
@@ -569,6 +572,7 @@ class TestWindowsPermissionError:
 
     def test_unix_permission_error_no_developer_mode(self, tmp_path, monkeypatch):
         from ai_rules.platform import Platform
+
         monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
         from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
 

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -7,9 +7,12 @@ from ai_rules.cli import cleanup_deprecated_symlinks
 from ai_rules.config import Config
 from ai_rules.symlinks import (
     SymlinkResult,
+    check_file_copy,
     check_symlink,
+    create_file_copy,
     create_symlink,
     get_content_diff,
+    remove_file_copy,
     remove_symlink,
 )
 from ai_rules.utils import is_managed_target
@@ -424,3 +427,149 @@ class TestIsManagedTarget:
         )
 
         assert is_managed_target(relative_target, config_dir) is True
+
+
+@pytest.mark.unit
+class TestCreateFileCopy:
+    """Test file copy operations for Windows Gemini copy-mode."""
+
+    def test_creates_copy(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text('{"key": "value"}')
+        target = tmp_path / "target.json"
+
+        result, message = create_file_copy(target, source, force=False, dry_run=False)
+        assert result == SymlinkResult.CREATED
+        assert target.exists()
+        assert not target.is_symlink()
+        assert target.read_text() == '{"key": "value"}'
+
+    def test_already_correct(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text('{"key": "value"}')
+        target = tmp_path / "target.json"
+        target.write_text('{"key": "value"}')
+
+        result, message = create_file_copy(target, source, force=False, dry_run=False)
+        assert result == SymlinkResult.ALREADY_CORRECT
+
+    def test_replaces_stale_symlink(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text('{"key": "value"}')
+        old_source = tmp_path / "old.json"
+        old_source.write_text("old")
+        target = tmp_path / "target.json"
+        target.symlink_to(old_source)
+
+        result, message = create_file_copy(target, source, force=False, dry_run=False)
+        assert result == SymlinkResult.CREATED
+        assert not target.is_symlink()
+        assert target.read_text() == '{"key": "value"}'
+
+    def test_source_missing(self, tmp_path):
+        target = tmp_path / "target.json"
+        source = tmp_path / "nonexistent.json"
+
+        result, message = create_file_copy(target, source, force=False, dry_run=False)
+        assert result == SymlinkResult.ERROR
+
+    def test_dry_run(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text('{"key": "value"}')
+        target = tmp_path / "target.json"
+
+        result, message = create_file_copy(target, source, force=False, dry_run=True)
+        assert result == SymlinkResult.CREATED
+        assert not target.exists()
+
+
+@pytest.mark.unit
+class TestCheckFileCopy:
+    """Test file copy status checking."""
+
+    def test_correct(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text("content")
+        target = tmp_path / "target.json"
+        target.write_text("content")
+
+        status, message = check_file_copy(target, source)
+        assert status == "correct"
+
+    def test_stale(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text("new content")
+        target = tmp_path / "target.json"
+        target.write_text("old content")
+
+        status, message = check_file_copy(target, source)
+        assert status == "stale_copy"
+
+    def test_missing(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text("content")
+        target = tmp_path / "nonexistent.json"
+
+        status, message = check_file_copy(target, source)
+        assert status == "missing"
+
+    def test_is_symlink(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text("content")
+        target = tmp_path / "target.json"
+        target.symlink_to(source)
+
+        status, message = check_file_copy(target, source)
+        assert status == "not_copy"
+
+
+@pytest.mark.unit
+class TestRemoveFileCopy:
+    """Test file copy removal."""
+
+    def test_removes_file(self, tmp_path):
+        target = tmp_path / "target.json"
+        target.write_text("content")
+
+        success, message = remove_file_copy(target, force=True)
+        assert success is True
+        assert not target.exists()
+
+    def test_refuses_symlink(self, tmp_path):
+        source = tmp_path / "source.json"
+        source.write_text("content")
+        target = tmp_path / "target.json"
+        target.symlink_to(source)
+
+        success, message = remove_file_copy(target, force=True)
+        assert success is False
+        assert "symlink" in message.lower()
+
+    def test_nonexistent(self, tmp_path):
+        target = tmp_path / "nonexistent.json"
+
+        success, message = remove_file_copy(target, force=True)
+        assert success is False
+
+
+@pytest.mark.unit
+class TestWindowsPermissionError:
+    """Test Windows-specific symlink permission error messaging."""
+
+    def test_windows_permission_error_shows_developer_mode_hint(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
+
+        result, message = _symlink_permission_error(PermissionError("test"))
+        assert result == SymlinkResult.ERROR
+        assert "Developer Mode" in message
+
+    def test_unix_permission_error_no_developer_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
+
+        result, message = _symlink_permission_error(PermissionError("test"))
+        assert result == SymlinkResult.ERROR
+        assert "Developer Mode" not in message

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -559,7 +559,8 @@ class TestWindowsPermissionError:
     def test_windows_permission_error_shows_developer_mode_hint(
         self, tmp_path, monkeypatch
     ):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+        from ai_rules.platform import Platform
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
         from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
 
         result, message = _symlink_permission_error(PermissionError("test"))
@@ -567,7 +568,8 @@ class TestWindowsPermissionError:
         assert "Developer Mode" in message
 
     def test_unix_permission_error_no_developer_mode(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+        from ai_rules.platform import Platform
+        monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
         from ai_rules.symlinks import SymlinkResult, _symlink_permission_error
 
         result, message = _symlink_permission_error(PermissionError("test"))

--- a/tests/unit/test_target_registry.py
+++ b/tests/unit/test_target_registry.py
@@ -4,6 +4,7 @@ import pytest
 
 from ai_rules.agents.amp import AmpAgent
 from ai_rules.config import Config
+from ai_rules.platform import Platform
 from ai_rules.targets.registry import TARGET_CLASSES, get_targets
 
 
@@ -11,7 +12,7 @@ from ai_rules.targets.registry import TARGET_CLASSES, get_targets
 def test_target_registry_returns_unique_targets_in_lifecycle_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
     config = Config()
 
     target_ids = [target.target_id for target in get_targets(tmp_path, config)]
@@ -33,7 +34,7 @@ def test_target_registry_returns_unique_targets_in_lifecycle_order(
 def test_get_targets_excludes_amp_on_windows(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
     config = Config()
 
     targets = get_targets(tmp_path, config)

--- a/tests/unit/test_target_registry.py
+++ b/tests/unit/test_target_registry.py
@@ -2,14 +2,16 @@ from pathlib import Path
 
 import pytest
 
+from ai_rules.agents.amp import AmpAgent
 from ai_rules.config import Config
 from ai_rules.targets.registry import TARGET_CLASSES, get_targets
 
 
 @pytest.mark.unit
 def test_target_registry_returns_unique_targets_in_lifecycle_order(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr("ai_rules.platform.sys.platform", "linux")
     config = Config()
 
     target_ids = [target.target_id for target in get_targets(tmp_path, config)]
@@ -25,3 +27,16 @@ def test_target_registry_returns_unique_targets_in_lifecycle_order(
     ]
     assert len(target_ids) == len(set(target_ids))
     assert len(TARGET_CLASSES) == len(target_ids)
+
+
+@pytest.mark.unit
+def test_get_targets_excludes_amp_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("ai_rules.platform.sys.platform", "win32")
+    config = Config()
+
+    targets = get_targets(tmp_path, config)
+    target_classes = [type(t) for t in targets]
+
+    assert AmpAgent not in target_classes

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "shellingham" },
     { name = "tomli-w" },
     { name = "tomlkit" },
 ]
@@ -35,6 +36,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "shellingham", specifier = ">=1.0" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0" },
 ]
@@ -517,6 +519,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
     { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "shellingham", specifier = ">=1.0" },
+    { name = "shellingham", specifier = ">=1.0,<2" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0" },
 ]


### PR DESCRIPTION
Adds native Windows support for Claude Code, Goose, Gemini CLI, and Codex CLI. Amp is WSL-only and remains excluded on Windows. All lifecycle operations (`install`, `status`, `diff`, `uninstall`, completions) now work on native Windows.

Stack: this PR → #78

## Platform detection

- `platform.py` exports a 4-value `Platform` enum (`MACOS`, `LINUX`, `WINDOWS`, `WSL`) with `detect_platform()` (`@lru_cache`), `is_platform()`, and `is_unix_like` property — single monkeypatch target for tests
- WSL detected via `platform.uname().release` (contains `"microsoft"`) with `WSL_DISTRO_NAME` env var as secondary signal
- All platform-specific path helpers (`get_goose_config_dir`, `get_statusline_config_dir`, `get_uv_tools_dir`, etc.) use `is_platform(Platform.WINDOWS)` internally
- `get_appdata_dir()` falls back to `Path.home() / "AppData" / "Roaming"` when `APPDATA` is unset (Docker, CI)

## Shell detection and completions

- `shellingham` adopted for shell detection on all platforms — inspects the process tree via parent PID instead of `PSModulePath` env var
- PowerShell profile path queried from `pwsh -NoProfile -Command "Write-Output $PROFILE"` instead of hardcoded path — OneDrive Folder Backup silently redirects `~/Documents` on modern Windows
- Custom `Register-ArgumentCompleter -Native` PowerShell completion script using Click's `bash_complete` protocol with correct `COMP_CWORD` cursor-position logic

## Gemini copy-mode

- Gemini CLI destroys symlinks when rewriting `settings.json` — file-copy mode via `copy_mode_targets` on `ConfigTarget`
- `create_file_copy` includes backup and confirmation when target has user modifications
- Copy-mode awareness wired into global pending-change and first-run checks
- Preserved fields read from live file before cache rebuild so Gemini's edits survive re-installs

## Windows symlink handling

- `PermissionError` surfaces Developer Mode enable guide; `target_is_directory` passed to `symlink_to()` (required on Windows)
- `_is_specialized_path` uses `.as_posix()` instead of `str()` for backslash-safe substring matching
- Amp excluded from both targets and skills directories on Windows

## CI

- Matrix extended to `windows-latest`

## Cross-platform test suite fixes

- Autouse `_patch_home_from_env` fixture makes `Path.home()` follow `HOME` env var via lazy closure — isolates tests from the real user home on Windows CI
- `mock_home` fixture sets `USERPROFILE` and `APPDATA` alongside `HOME` — Windows code paths that read these env vars resolve to the temp dir
- `PYTHONUTF8=1` set in autouse fixture — prevents `cp1252` `UnicodeDecodeError` when Click's `CliRunner` captures Rich output containing emoji
- Path assertions use `.as_posix()` throughout — `str(WindowsPath)` produces backslashes that break forward-slash string comparisons
- `UV_TOOL_DIR` cleared/overridden in bootstrap tests — Windows CI runners set this env var, overriding the default XDG-based path structure
- `repo_score()` in session-search normalizes session paths via `.as_posix()` — session data contains POSIX paths from macOS/Linux hosts

Related: [shell-configs#64](https://github.com/wpfleger96/shell-configs/pull/64), [shell-configs#65](https://github.com/wpfleger96/shell-configs/pull/65)