### PR TITLE
feat: add per-skill semantic versioning and unified all-skills ZIP

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -36,6 +36,7 @@ jobs:
             skill_name="${skill_dir%/}"
             zip -r "${{ github.workspace }}/${skill_name}.zip" "$skill_name" -x "*/__pycache__/*"
           done
+          zip -r "${{ github.workspace }}/all-skills.zip" */ -x "*/__pycache__/*"
 
       - name: Upload skill ZIPs to release
         env:
@@ -60,13 +61,18 @@ jobs:
             echo ""
             echo "### Skills Downloads"
             echo ""
-            echo "Each ZIP is directly uploadable to Claude Desktop (Customize > Skills > +) or Codex Desktop."
+            skill_count=$(ls -d src/ai_rules/config/skills/*/ | wc -l | tr -d ' ')
+            echo "**[Download all ${skill_count} skills (all-skills.zip)](https://github.com/${REPO}/releases/download/${TAG}/all-skills.zip)** — one ZIP, ready to import"
             echo ""
-            echo "| Skill | Download |"
-            echo "|-------|----------|"
+            echo "Or download individual skills:"
+            echo ""
+            echo "| Skill | Version | Download |"
+            echo "|-------|---------|----------|"
             for skill_dir in src/ai_rules/config/skills/*/; do
               skill_name=$(basename "$skill_dir")
-              echo "| \`${skill_name}\` | [${skill_name}.zip](https://github.com/${REPO}/releases/download/${TAG}/${skill_name}.zip) |"
+              version=$(grep -m1 "^version:" "${skill_dir}SKILL.md" 2>/dev/null \
+                | sed 's/version:[[:space:]]*//' | tr -d '"' || echo "—")
+              echo "| \`${skill_name}\` | ${version} | [${skill_name}.zip](https://github.com/${REPO}/releases/download/${TAG}/${skill_name}.zip) |"
             done
             echo ""
             echo "**[Browse skill source on GitHub](https://github.com/${REPO}/tree/${TAG}/src/ai_rules/config/skills)**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,10 +223,11 @@ just test-e2e                   # E2E only — runs real CLI as subprocess, no m
 
 ## Skills
 
-**Skills:** Explore `config/skills/*/SKILL.md` for available skills (10 total: agents-md, code-reviewer, continue-crash, crossfire, dev-docs, doc-writer, pr-creator, prompt-critique, prompt-engineer, test-writer).
+**Skills:** Explore `config/skills/*/SKILL.md` for available skills (13 total: agents-md, code-reviewer, continue-crash, crossfire, dev-docs, doc-writer, kb, pr-creator, prompt-critique, prompt-engineer, research, session-search, test-writer).
 - **SHARED across agents** - symlinked to `~/.claude/skills/`, `~/.config/goose/skills/`, `~/.config/agents/skills/` (Amp), `~/.agents/skills/` (Codex)
 - Managed by SharedAgent (displays under "Shared:" in status)
 - To add a skill: Create subdir in `config/skills/` with `SKILL.md`
+- **Skill versioning**: Each SKILL.md has a `version` field in its frontmatter. Bump it when changing a skill's behavior — patch (1.0.x) for tweaks/fixes, minor (1.x.0) for new capabilities, major (x.0.0) for breaking prompt changes
 
 ## Key Files by Task
 

--- a/src/ai_rules/cli/groups/skill.py
+++ b/src/ai_rules/cli/groups/skill.py
@@ -62,11 +62,13 @@ def skill_list(download_url: bool) -> None:
 
     table = Table(title="Bundled Skills", show_header=True)
     table.add_column("Name", style="cyan")
+    table.add_column("Version", style="dim")
     table.add_column("Description")
 
     for s in skills:
         name = f"{s.name} [dim](disabled)[/dim]" if s.disabled else s.name
-        table.add_row(name, s.description)
+        version_str = s.version if s.version is not None else "—"
+        table.add_row(name, version_str, s.description)
 
     console.print(table)
 

--- a/src/ai_rules/config/skills/agents-md/SKILL.md
+++ b/src/ai_rules/config/skills/agents-md/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: agents-md
+version: 1.0.0
 description: Create or update AGENTS.md with repo-specific patterns, conventions, commands, and gotchas for LLM coding agents. Use after implementing features that introduce new patterns worth documenting.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
 model: sonnet

--- a/src/ai_rules/config/skills/code-reviewer/SKILL.md
+++ b/src/ai_rules/config/skills/code-reviewer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: code-reviewer
+version: 1.0.0
 description: Performs thorough code review on local changes or PRs. Use this skill proactively after implementing code changes to catch issues before commit/push. Also use when reviewing PRs from other engineers.
 agent: general-purpose
 allowed-tools: Agent, AskUserQuestion, Bash, Glob, Grep, Read, TodoWrite

--- a/src/ai_rules/config/skills/continue-crash/SKILL.md
+++ b/src/ai_rules/config/skills/continue-crash/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-crash
+version: 1.0.0
 description: Continues after a session crash while working on a task
 disable-model-invocation: true
 allowed-tools: Bash, Glob, Grep, Read, TodoWrite

--- a/src/ai_rules/config/skills/crossfire/SKILL.md
+++ b/src/ai_rules/config/skills/crossfire/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: crossfire
+version: 1.0.0
 description: Get multi-model perspectives (Codex + Gemini) on any work product. Use at any development stage — planning, design, implementation, testing — to catch blind spots the primary agent might miss.
 allowed-tools: AskUserQuestion, Bash, Glob, Grep, Read
 model: sonnet

--- a/src/ai_rules/config/skills/dev-docs/SKILL.md
+++ b/src/ai_rules/config/skills/dev-docs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: dev-docs
+version: 1.0.0
 description: Creates or updates PLAN.md based on session - auto-detects create vs update mode
 allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, TodoWrite, Write
 model: sonnet

--- a/src/ai_rules/config/skills/doc-writer/SKILL.md
+++ b/src/ai_rules/config/skills/doc-writer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: doc-writer
+version: 1.0.0
 description: Write, update, or review documentation (README, ARCHITECTURE.md, API docs, guides). Use after implementing features to document new APIs, CLI commands, or behavior changes.
 model: sonnet
 ---

--- a/src/ai_rules/config/skills/kb/SKILL.md
+++ b/src/ai_rules/config/skills/kb/SKILL.md
@@ -1,6 +1,7 @@
 ---
 disabled: true
 name: kb
+version: 1.0.0
 description: >-
   This skill should be used when recall MCP tools are available and the user
   asks to "save to knowledge base", "write a note", "persist this", "remember

--- a/src/ai_rules/config/skills/pr-creator/SKILL.md
+++ b/src/ai_rules/config/skills/pr-creator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-creator
+version: 1.0.0
 description: Creates GitHub pull requests with comprehensive descriptions by analyzing git history and code changes
 allowed-tools: AskUserQuestion, Bash, Glob, Grep, Read, TodoWrite
 model: sonnet

--- a/src/ai_rules/config/skills/prompt-critique/SKILL.md
+++ b/src/ai_rules/config/skills/prompt-critique/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prompt-critique
+version: 1.0.0
 description: Analyze your historical Claude Code prompts and get personalized feedback on how to improve your prompting technique
 disabled: true
 disable-model-invocation: true

--- a/src/ai_rules/config/skills/prompt-engineer/SKILL.md
+++ b/src/ai_rules/config/skills/prompt-engineer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: prompt-engineer
+version: 1.0.0
 description: Expert guidance for writing and optimizing LLM prompts. Use when creating or updating AGENTS.md, CLAUDE.md, SKILL.md, system prompts, or custom instructions.
 ---
 

--- a/src/ai_rules/config/skills/research/SKILL.md
+++ b/src/ai_rules/config/skills/research/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: research
+version: 1.0.0
 description: >
   Conduct multi-agent research on any topic. Use when the user asks to
   'research', 'investigate', 'deep dive', 'comprehensive analysis',

--- a/src/ai_rules/config/skills/session-search/SKILL.md
+++ b/src/ai_rules/config/skills/session-search/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: session-search
+version: 1.0.0
 description: >
   Use this skill to find, locate, or search previous coding agent sessions or
   conversations. Triggers on requests to search session transcripts or

--- a/src/ai_rules/config/skills/test-writer/SKILL.md
+++ b/src/ai_rules/config/skills/test-writer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: test-writer
+version: 1.0.0
 description: Write, update, or review tests. Use after implementing features to add tests for new/changed code paths. Covers testing strategy, framework selection, and coverage analysis.
 ---
 

--- a/src/ai_rules/skills.py
+++ b/src/ai_rules/skills.py
@@ -18,6 +18,7 @@ class SkillMetadata:
 
     name: str
     description: str
+    version: str | None = None
     disabled: bool = False
 
 
@@ -86,9 +87,11 @@ class SkillManager:
                     frontmatter = yaml.safe_load(parts[1])
                     if not isinstance(frontmatter, dict):
                         return SkillMetadata(name=skill_dir.name, description="")
+                    raw_version = frontmatter.get("version")
                     return SkillMetadata(
                         name=frontmatter.get("name", skill_dir.name),
                         description=frontmatter.get("description", ""),
+                        version=str(raw_version) if raw_version is not None else None,
                         disabled=frontmatter.get("disabled", False) is True,
                     )
                 except yaml.YAMLError:

--- a/tests/integration/test_skill_commands.py
+++ b/tests/integration/test_skill_commands.py
@@ -35,6 +35,13 @@ class TestSkillList:
         assert "prompt-critique" in result.output
         assert "disabled" in result.output
 
+    def test_version_column_displayed(self, runner):
+        result = runner.invoke(main, ["skill", "list"])
+
+        assert result.exit_code == 0
+        assert "Version" in result.output
+        assert "1.0.0" in result.output
+
 
 @pytest.mark.integration
 class TestSkillShow:

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -295,6 +295,40 @@ class TestParseSkillMd:
         assert result is not None
         assert result.disabled is False
 
+    def test_parses_version_field(self, tmp_path):
+        d = tmp_path / "my-skill"
+        d.mkdir()
+        (d / "SKILL.md").write_text(
+            "---\nname: my-skill\nversion: 1.0.0\ndescription: test\n---\n"
+        )
+
+        result = SkillManager.parse_skill_md(d)
+
+        assert result is not None
+        assert result.version == "1.0.0"
+
+    def test_version_missing_defaults_none(self, tmp_path):
+        d = tmp_path / "my-skill"
+        d.mkdir()
+        (d / "SKILL.md").write_text("---\nname: my-skill\ndescription: test\n---\n")
+
+        result = SkillManager.parse_skill_md(d)
+
+        assert result is not None
+        assert result.version is None
+
+    def test_version_numeric_coerced_to_string(self, tmp_path):
+        d = tmp_path / "my-skill"
+        d.mkdir()
+        (d / "SKILL.md").write_text(
+            "---\nname: my-skill\nversion: 1.0\ndescription: test\n---\n"
+        )
+
+        result = SkillManager.parse_skill_md(d)
+
+        assert result is not None
+        assert result.version == "1.0"
+
 
 @pytest.mark.unit
 class TestIsSkillDisabled:


### PR DESCRIPTION
Adds individual semantic versioning to skills and a combined `all-skills.zip` release asset.

Previously, skills had no per-skill version tracking — the only signal was the package-level `ai-agent-rules` release. There was also no single-file download for users who want all skills at once.

- Add `version: str | None = None` to `SkillMetadata` and parse it from SKILL.md frontmatter in `SkillManager.parse_skill_md()`, with a `str()` coercion guard for YAML float values (e.g. `version: 1.0`)
- Seed all 13 skills at `version: 1.0.0` in their SKILL.md frontmatter
- Surface version in `skill list` CLI output as a new "Version" column (renders `—` when absent)
- Extend `release-skills.yml` to build `all-skills.zip` (all skill dirs at root level) alongside individual ZIPs; update release notes to include a prominent all-skills download link and a Version column in the per-skill table
- Add versioning convention to repo `AGENTS.md`: patch for tweaks, minor for new capabilities, major for breaking prompt changes