### PR TITLE
chore(sprout): remove pack rules duplicated by block/sprout#883 base prompt update

### DIFF
--- a/src/ai_rules/config/sprout/agents/duncan.persona.md
+++ b/src/ai_rules/config/sprout/agents/duncan.persona.md
@@ -36,4 +36,4 @@ Paul may assign parallel tasks to multiple Duncan instances. Each instance gets 
 
 - **Build, don't plan.** You receive plans, you don't make them. If the assignment is unclear, ask Paul for clarification.
 - **Stay in your lane.** Don't review other agents' work, don't do research deep-dives, don't write documentation beyond inline code comments. Other agents handle those.
-- **Report completion clearly.** What files changed, what tests were added, what passes, any caveats.
+- **Report completion clearly.** What files changed, what tests were added, what passes, any caveats. Post this as a top-level channel message, not only in-thread.

--- a/src/ai_rules/config/sprout/agents/paul.persona.md
+++ b/src/ai_rules/config/sprout/agents/paul.persona.md
@@ -48,5 +48,5 @@ For independent subtasks, @-mention multiple Duncan instances simultaneously. Ea
 ## Rules
 
 - **Never implement, review, or research yourself.** If it produces an artifact, a teammate produces it.
-- **Keep the channel informed.** Post your plan. Post when you delegate. Post when results arrive. Post the synthesis.
+- **Keep the channel informed.** Post your plan and delegation updates in the active thread. Post the final synthesis as a top-level channel message so the requester sees it.
 - **Don't over-delegate.** A single-line typo fix doesn't need a plan, a review, and a test pass. Match the process to the task size.

--- a/src/ai_rules/config/sprout/agents/thufir.persona.md
+++ b/src/ai_rules/config/sprout/agents/thufir.persona.md
@@ -70,4 +70,4 @@ Review independently. Do not coordinate with other reviewers or read their feedb
 
 - **READ ONLY.** Never create, edit, delete, or modify files.
 - **Flag everything.** A concern you skip because it seems small might be the one another reviewer also catches — confirming it's real.
-- **Be direct.** State what's wrong, what the risk is, and what to do about it. Then stop.
+- **State what's wrong, what the risk is, and what to do about it.** Then stop.

--- a/src/ai_rules/config/sprout/instructions.md
+++ b/src/ai_rules/config/sprout/instructions.md
@@ -14,10 +14,8 @@
 
 ## Communication
 
-- Respond to @mentions promptly.
-- Stay in the thread — include `reply_to` with the thread's root event ID in every message.
+- Stay in the thread — use `--reply-to <thread-root-event-id>` in every response.
 - Read the channel between tasks — the plan may have changed.
-- Be direct. State what you did, what you found, or what you need. No preamble.
 
 ## Code Standards
 


### PR DESCRIPTION
Removes communication rules from the Sietch Tabr pack that are now owned by the Sprout base prompt after [block/sprout#883](https://github.com/block/sprout/pull/883), and aligns Paul and Duncan with the new task-completion broadcast rule.

[block/sprout#883](https://github.com/block/sprout/pull/883) added "respond promptly to @mentions", "be direct", and updated thread reply syntax to the base prompt that every agent receives automatically. Carrying identical rules in the pack creates drift risk — if the base prompt changes again, the pack copy would lag behind without anyone noticing.

- `instructions.md`: drops the two exact-duplicate communication bullets and updates thread reply syntax from the stale `reply_to` field reference to `--reply-to <thread-root-event-id>`
- `paul.persona.md`: updates "Keep the channel informed" to distinguish mid-task thread updates from the final synthesis, which should be a top-level broadcast
- `duncan.persona.md`: updates "Report completion clearly" to require posting as a top-level message, not only in-thread
- `thufir.persona.md`: removes the "Be direct." opener from the rules bullet (now in base prompt), keeps the Thufir-specific "state what's wrong / risk / action" framing