### PR TITLE
fix(sprout): include .plugin/ contents in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ include-package-data = true
 where = ["src"]
 
 [tool.setuptools.package-data]
-ai_rules = ["config/**/*", "config/**/.*"]
+ai_rules = ["config/**/*", "config/**/.*", "config/**/.*/*"]
 
 [tool.ruff.lint]
 select = ["I", "F", "UP", "B"]  # isort, pyflakes, pyupgrade, bugbear


### PR DESCRIPTION
The Sprout agent pack symlinks were never created or updated by `ai-rules install` because `plugin.json` was missing from the built wheel, causing `SproutTool._read_pack_id()` to return `None` and `symlinks` to return `[]`.

The `config/**/*` glob in `pyproject.toml` skips dotfiles and dot-directories per POSIX glob semantics. The existing `config/**/.*` pattern matched the `.plugin/` directory entry but not the files inside it. This meant `.plugin/plugin.json` was never included in the package, so the Sprout target was silently skipped during every install run — no symlinks were created, checked, or replaced.

- Add `config/**/.*/*` to `[tool.setuptools.package-data]` to capture files one level inside dot-directories
- After this fix, `_read_pack_id()` reads the pack ID correctly, `symlinks` returns the two expected symlink pairs, and stale/missing symlinks are detected and replaced on `ai-rules install`