### PR TITLE
Fix upgrade ignoring configured install source over stale receipt

### DIFF
--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -403,7 +403,13 @@ def ensure_tool_installed(
                 )
 
                 update_info = check_tool_updates(spec, timeout=10)
-                if update_info and update_info.has_update:
+                if update_info and update_info.check_failed:
+                    import logging
+
+                    logging.getLogger(__name__).debug(
+                        f"Update check failed for {spec.display_name}, skipping upgrade"
+                    )
+                elif update_info and update_info.has_update:
                     if dry_run:
                         return (
                             "upgrade_available",

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -17,6 +17,7 @@ from .installer import (
     UV_NOT_FOUND_ERROR,
     ToolSource,
     _validate_package_name,
+    get_effective_install_source,
     get_tool_source,
     get_tool_version,
     is_command_available,
@@ -56,6 +57,7 @@ class UpdateInfo:
     latest_version: str
     source: str
     changelog_entries: list[tuple[str, str]] | None = None
+    check_failed: bool = False
 
 
 @dataclass
@@ -198,6 +200,7 @@ def check_index_updates(
                 current_version=current_version,
                 latest_version=current_version,
                 source="index",
+                check_failed=True,
             )
 
         output = result.stdout.strip()
@@ -234,6 +237,7 @@ def check_index_updates(
             current_version=current_version,
             latest_version=current_version,
             source="index",
+            check_failed=True,
         )
     except Exception as e:
         logger.debug(f"Index check failed: {e}")
@@ -242,6 +246,7 @@ def check_index_updates(
             current_version=current_version,
             latest_version=current_version,
             source="index",
+            check_failed=True,
         )
 
 
@@ -301,6 +306,7 @@ def check_github_updates(
             current_version=current_version,
             latest_version=current_version,
             source="github",
+            check_failed=True,
         )
 
 
@@ -404,15 +410,22 @@ def perform_tool_upgrade(
     if not is_command_available("uv"):
         return False, UV_NOT_FOUND_ERROR, False
 
-    source = get_tool_source(tool.package_name)
+    receipt_source = get_tool_source(tool.package_name)
+
+    if receipt_source == ToolSource.LOCAL:
+        return True, "Local install — upgrade manually", False
+
+    config_source, _ = get_effective_install_source(tool.tool_id)
+    if config_source in (ToolSource.GITHUB, ToolSource.LOCAL):
+        source: ToolSource = config_source
+    else:
+        source = receipt_source or ToolSource.PYPI
 
     if source == ToolSource.LOCAL:
         return True, "Local install — upgrade manually", False
 
-    # Pre-check: detect if the target version needs a newer Python than the venv has.
-    # Workaround for https://github.com/astral-sh/uv/issues/18083
     python_flag: str | None = None
-    if target_version and source is not None:
+    if target_version:
         python_flag = _compute_required_python(tool, target_version, source)
 
     if source == ToolSource.GITHUB and tool.github_install_url:
@@ -521,10 +534,19 @@ def check_tool_updates(tool: ToolSpec, timeout: int = 30) -> UpdateInfo | None:
     if current is None:
         return None
 
-    source = get_tool_source(tool.package_name)
+    receipt_source = get_tool_source(tool.package_name)
+
+    if receipt_source == ToolSource.LOCAL:
+        return None
+
+    config_source, _ = get_effective_install_source(tool.tool_id)
+    if config_source in (ToolSource.GITHUB, ToolSource.LOCAL):
+        source: ToolSource = config_source
+    else:
+        source = receipt_source or ToolSource.PYPI
 
     if source == ToolSource.LOCAL:
-        return None  # Local installs don't have a remote version to check
+        return None
 
     if source == ToolSource.GITHUB and tool.github_repo:
         return check_github_updates(tool.github_repo, current, timeout)

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -391,6 +391,15 @@ def _compute_required_python(
     return None
 
 
+def _resolve_effective_source(tool: ToolSpec) -> ToolSource:
+    """Resolve install source by consulting config, falling back to receipt."""
+    receipt_source = get_tool_source(tool.package_name)
+    config_source, _ = get_effective_install_source(tool.tool_id)
+    if config_source in (ToolSource.GITHUB, ToolSource.LOCAL):
+        return config_source
+    return receipt_source or ToolSource.PYPI
+
+
 def perform_tool_upgrade(
     tool: ToolSpec,
     target_version: str | None = None,
@@ -410,16 +419,7 @@ def perform_tool_upgrade(
     if not is_command_available("uv"):
         return False, UV_NOT_FOUND_ERROR, False
 
-    receipt_source = get_tool_source(tool.package_name)
-
-    if receipt_source == ToolSource.LOCAL:
-        return True, "Local install — upgrade manually", False
-
-    config_source, _ = get_effective_install_source(tool.tool_id)
-    if config_source in (ToolSource.GITHUB, ToolSource.LOCAL):
-        source: ToolSource = config_source
-    else:
-        source = receipt_source or ToolSource.PYPI
+    source = _resolve_effective_source(tool)
 
     if source == ToolSource.LOCAL:
         return True, "Local install — upgrade manually", False
@@ -534,16 +534,7 @@ def check_tool_updates(tool: ToolSpec, timeout: int = 30) -> UpdateInfo | None:
     if current is None:
         return None
 
-    receipt_source = get_tool_source(tool.package_name)
-
-    if receipt_source == ToolSource.LOCAL:
-        return None
-
-    config_source, _ = get_effective_install_source(tool.tool_id)
-    if config_source in (ToolSource.GITHUB, ToolSource.LOCAL):
-        source: ToolSource = config_source
-    else:
-        source = receipt_source or ToolSource.PYPI
+    source = _resolve_effective_source(tool)
 
     if source == ToolSource.LOCAL:
         return None

--- a/src/ai_rules/cli/__init__.py
+++ b/src/ai_rules/cli/__init__.py
@@ -254,6 +254,12 @@ def version_callback(ctx: click.Context, param: click.Parameter, value: bool) ->
                     f"\n[cyan]Update available:[/cyan] {update_info.current_version} → {update_info.latest_version}"
                 )
                 print_hint("Run 'ai-agent-rules upgrade' to install")
+            elif update_info and update_info.check_failed:
+                from ai_rules.cli.display import dim
+
+                console.print(
+                    f"\n{dim('Could not check for updates')}"
+                )
     except Exception as e:
         logger.debug(f"Failed to check for updates in version callback: {e}")
 

--- a/src/ai_rules/cli/__init__.py
+++ b/src/ai_rules/cli/__init__.py
@@ -257,9 +257,7 @@ def version_callback(ctx: click.Context, param: click.Parameter, value: bool) ->
             elif update_info and update_info.check_failed:
                 from ai_rules.cli.display import dim
 
-                console.print(
-                    f"\n{dim('Could not check for updates')}"
-                )
+                console.print(f"\n{dim('Could not check for updates')}")
     except Exception as e:
         logger.debug(f"Failed to check for updates in version callback: {e}")
 

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -121,9 +121,7 @@ def upgrade(
 
         receipt_src = get_tool_source(tool.package_name)
         config_src, _ = get_effective_install_source(tool.tool_id)
-        if receipt_src == ToolSource.LOCAL and config_src not in (
-            ToolSource.GITHUB,
-        ):
+        if receipt_src == ToolSource.LOCAL and config_src not in (ToolSource.GITHUB,):
             print_warning(
                 f"{tool.display_name} is installed from a local path — "
                 f"skipping update check. Reinstall from PyPI with: "
@@ -141,9 +139,7 @@ def upgrade(
         if update_info and (update_info.has_update or force):
             tool_updates.append((tool, update_info))
         elif update_info and update_info.check_failed:
-            print_warning(
-                f"Could not check {tool.display_name} for updates"
-            )
+            print_warning(f"Could not check {tool.display_name} for updates")
         elif update_info and not update_info.has_update:
             print_success(f"{tool.display_name} is already up to date!")
 

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -50,7 +50,6 @@ def upgrade(
         ToolSource,
         check_tool_updates,
         get_effective_install_source,
-        get_tool_source,
         get_updatable_tools,
         perform_tool_upgrade,
     )
@@ -117,11 +116,9 @@ def upgrade(
             print_error(f"Could not get {tool.display_name} version: {e}")
             continue
 
-        from ai_rules.bootstrap.installer import get_effective_install_source
+        from ai_rules.bootstrap.updater import _resolve_effective_source
 
-        receipt_src = get_tool_source(tool.package_name)
-        config_src, _ = get_effective_install_source(tool.tool_id)
-        if receipt_src == ToolSource.LOCAL and config_src not in (ToolSource.GITHUB,):
+        if _resolve_effective_source(tool) == ToolSource.LOCAL:
             print_warning(
                 f"{tool.display_name} is installed from a local path — "
                 f"skipping update check. Reinstall from PyPI with: "
@@ -137,6 +134,10 @@ def upgrade(
                 continue
 
         if update_info and (update_info.has_update or force):
+            if update_info.check_failed and force:
+                print_warning(
+                    f"Update check failed for {tool.display_name}, forcing upgrade"
+                )
             tool_updates.append((tool, update_info))
         elif update_info and update_info.check_failed:
             print_warning(f"Could not check {tool.display_name} for updates")

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -117,7 +117,13 @@ def upgrade(
             print_error(f"Could not get {tool.display_name} version: {e}")
             continue
 
-        if get_tool_source(tool.package_name) == ToolSource.LOCAL:
+        from ai_rules.bootstrap.installer import get_effective_install_source
+
+        receipt_src = get_tool_source(tool.package_name)
+        config_src, _ = get_effective_install_source(tool.tool_id)
+        if receipt_src == ToolSource.LOCAL and config_src not in (
+            ToolSource.GITHUB,
+        ):
             print_warning(
                 f"{tool.display_name} is installed from a local path — "
                 f"skipping update check. Reinstall from PyPI with: "
@@ -134,6 +140,10 @@ def upgrade(
 
         if update_info and (update_info.has_update or force):
             tool_updates.append((tool, update_info))
+        elif update_info and update_info.check_failed:
+            print_warning(
+                f"Could not check {tool.display_name} for updates"
+            )
         elif update_info and not update_info.has_update:
             print_success(f"{tool.display_name} is already up to date!")
 

--- a/src/ai_rules/cli/groups/tool.py
+++ b/src/ai_rules/cli/groups/tool.py
@@ -97,6 +97,8 @@ def tool_list() -> None:
             if update_info and update_info.has_update:
                 update_display = f"[cyan]{update_info.latest_version} available[/cyan]"
                 has_updates = True
+            elif update_info and update_info.check_failed:
+                update_display = dim("(check failed)")
         except Exception:
             update_display = dim("(check failed)")
 
@@ -172,6 +174,8 @@ def tool_show(tool_id: str) -> None:
             console.print(
                 f"  Update:   [cyan]{update_info.latest_version} available[/cyan]"
             )
+        elif update_info and update_info.check_failed:
+            console.print(f"  Update:   {dim('(check failed)')}")
         elif update_info:
             console.print("  Update:   [green]up to date[/green]")
     except Exception:

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 import sys
 
 import pytest
@@ -155,6 +157,89 @@ class TestRegistryLifecycle:
         output = strip_ansi(result.stdout + result.stderr)
         assert result.returncode == 1
         assert "Invalid component ID" in output
+
+
+@pytest.mark.e2e
+class TestUpgradeCheckFailed:
+    """E2E tests that a failed update check surfaces a warning, not false success."""
+
+    BROKEN_INDEX = "http://localhost:1/nonexistent"
+    RECEIPT_TOML = (
+        "[tool]\n"
+        'requirements = [{ name = "ai-agent-rules" }]\n'
+        "entrypoints = [\n"
+        '    { name = "ai-agent-rules", install-path = "/tmp/fake/ai-agent-rules",'
+        ' from = "ai-agent-rules" },\n'
+        '    { name = "ai-rules", install-path = "/tmp/fake/ai-rules",'
+        ' from = "ai-agent-rules" },\n'
+        "]\n"
+    )
+
+    @pytest.fixture
+    def broken_index_cli(self, e2e_home, tmp_path):
+        """CLI runner with a fake PYPI receipt and an unreachable index URL."""
+        import shutil
+
+        from pathlib import Path
+
+        home_dir, env_overrides = e2e_home
+        repo_root = Path(__file__).parents[2]
+        src_path = repo_root / "src"
+
+        real_tools = Path.home() / ".local" / "share" / "uv" / "tools"
+        real_ai_rules = real_tools / "ai-agent-rules"
+        if not real_ai_rules.exists():
+            pytest.skip("ai-agent-rules not installed via uv tool")
+
+        fake_tools = tmp_path / "uv-tools"
+        shutil.copytree(real_ai_rules, fake_tools / "ai-agent-rules", symlinks=True)
+        (fake_tools / "ai-agent-rules" / "uv-receipt.toml").write_text(
+            self.RECEIPT_TOML
+        )
+
+        def _run(args, extra_env=None, timeout=30):
+            base_env = {**os.environ, **env_overrides}
+            existing_pythonpath = base_env.get("PYTHONPATH", "")
+            base_env["PYTHONPATH"] = (
+                str(src_path)
+                if not existing_pythonpath
+                else os.pathsep.join([str(src_path), existing_pythonpath])
+            )
+            base_env["UV_TOOL_DIR"] = str(fake_tools)
+            base_env["UV_DEFAULT_INDEX"] = self.BROKEN_INDEX
+            base_env["UV_INDEX_URL"] = self.BROKEN_INDEX
+            base_env["PIP_INDEX_URL"] = self.BROKEN_INDEX
+            if extra_env:
+                base_env.update(extra_env)
+            return subprocess.run(
+                [sys.executable, "-m", "ai_rules.cli", *args],
+                capture_output=True,
+                encoding="utf-8",
+                check=False,
+                cwd=repo_root,
+                env=base_env,
+                timeout=timeout,
+            )
+
+        return _run
+
+    def test_upgrade_check_shows_warning(self, broken_index_cli):
+        result = broken_index_cli(["upgrade", "--check"])
+        output = strip_ansi(result.stdout + result.stderr)
+        assert "Could not check" in output
+        assert "already up to date" not in output.lower()
+
+    def test_version_shows_check_failed(self, broken_index_cli):
+        result = broken_index_cli(["--version"])
+        output = strip_ansi(result.stdout + result.stderr)
+        assert "version" in output.lower()
+        assert "Could not check for updates" in output
+
+    def test_tool_show_displays_check_failed(self, broken_index_cli):
+        result = broken_index_cli(["tool", "show", "ai-agent-rules"])
+        output = strip_ansi(result.stdout + result.stderr)
+        assert "check failed" in output.lower()
+        assert "up to date" not in output.lower()
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -638,6 +638,7 @@ class TestEnsureToolInstalled:
     def test_upgrade_available_dry_run(self, monkeypatch):
         update_info = SimpleNamespace(
             has_update=True,
+            check_failed=False,
             current_version="0.1.0",
             latest_version="0.2.0",
         )

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -802,11 +802,27 @@ class TestCheckToolUpdatesSourceResolution:
         index_called = []
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_github_updates",
-            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+            lambda repo, cur, timeout: _track(
+                github_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="github",
+                ),
+            ),
         )
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_index_updates",
-            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+            lambda pkg, cur, timeout, repo=None: _track(
+                index_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="index",
+                ),
+            ),
         )
         result = check_tool_updates(tool)
         assert result is not None
@@ -835,11 +851,27 @@ class TestCheckToolUpdatesSourceResolution:
         index_called = []
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_github_updates",
-            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+            lambda repo, cur, timeout: _track(
+                github_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="github",
+                ),
+            ),
         )
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_index_updates",
-            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+            lambda pkg, cur, timeout, repo=None: _track(
+                index_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="index",
+                ),
+            ),
         )
         result = check_tool_updates(tool)
         assert result is not None
@@ -868,11 +900,27 @@ class TestCheckToolUpdatesSourceResolution:
         index_called = []
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_github_updates",
-            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+            lambda repo, cur, timeout: _track(
+                github_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="github",
+                ),
+            ),
         )
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.check_index_updates",
-            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+            lambda pkg, cur, timeout, repo=None: _track(
+                index_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="index",
+                ),
+            ),
         )
         result = check_tool_updates(tool)
         assert result is not None

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -14,14 +14,22 @@ import pytest
 from ai_rules.bootstrap.installer import UV_NOT_FOUND_ERROR, ToolSource
 from ai_rules.bootstrap.updater import (
     ToolSpec,
+    UpdateInfo,
     _compute_required_python,
     _fetch_requires_python,
     _get_tool_venv_python,
+    check_github_updates,
     check_index_updates,
     check_tool_updates,
     get_configured_index_url,
     perform_tool_upgrade,
 )
+
+
+def _track(tracker: list[int], result: Any) -> Any:
+    """Append to tracker and return result — typed alternative to (list.append(), val)[-1]."""
+    tracker.append(1)
+    return result
 
 
 def _mock_urlopen(body: bytes) -> Callable[..., Any]:
@@ -765,3 +773,334 @@ class TestPerformToolUpgradeWithPythonSwitch:
         assert "3.14" in captured_cmd
         assert "--force" in captured_cmd
         assert "--reinstall" in captured_cmd
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestCheckToolUpdatesSourceResolution:
+    """Tests that check_tool_updates consults config when receipt doesn't match."""
+
+    def test_receipt_pypi_config_github_uses_github_check(self, monkeypatch):
+        """receipt=PYPI + config=GITHUB → check_github_updates is called."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.PYPI,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+        github_called = []
+        index_called = []
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_github_updates",
+            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_index_updates",
+            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+        )
+        result = check_tool_updates(tool)
+        assert result is not None
+        assert len(github_called) == 1
+        assert len(index_called) == 0
+
+    def test_receipt_pypi_config_pypi_uses_index_check(self, monkeypatch):
+        """receipt=PYPI + config=PYPI → check_index_updates is called (regression guard)."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.PYPI,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.PYPI, None),
+        )
+        github_called = []
+        index_called = []
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_github_updates",
+            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_index_updates",
+            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+        )
+        result = check_tool_updates(tool)
+        assert result is not None
+        assert len(index_called) == 1
+        assert len(github_called) == 0
+
+    def test_receipt_none_config_github_uses_github_check(self, monkeypatch):
+        """receipt=None + config=GITHUB → check_github_updates is called."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: None,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+        github_called = []
+        index_called = []
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_github_updates",
+            lambda repo, cur, timeout: _track(github_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="github")),
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_index_updates",
+            lambda pkg, cur, timeout, repo=None: _track(index_called, UpdateInfo(has_update=False, current_version=cur, latest_version=cur, source="index")),
+        )
+        result = check_tool_updates(tool)
+        assert result is not None
+        assert len(github_called) == 1
+        assert len(index_called) == 0
+
+    def test_receipt_local_config_github_returns_none(self, monkeypatch):
+        """receipt=LOCAL → returns None regardless of config (LOCAL receipt is sticky)."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.LOCAL,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+        result = check_tool_updates(tool)
+        assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestPerformToolUpgradeSourceResolution:
+    """Tests that perform_tool_upgrade uses the config-derived source for install."""
+
+    def test_receipt_pypi_config_github_uses_github_url(self, monkeypatch):
+        """receipt=PYPI + config=GITHUB → cmd contains github_install_url, not package name."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.PYPI,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+
+        captured_cmd = []
+
+        def mock_run(*args, **kwargs):
+            captured_cmd.extend(args[0])
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = "Installed 1 executable: test-package"
+
+            return Result()
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        success, message, was_upgraded = perform_tool_upgrade(tool)
+        assert success is True
+        assert tool.github_install_url in captured_cmd
+        assert "test-package" not in [
+            arg for arg in captured_cmd if arg == "test-package"
+        ]
+
+    def test_receipt_pypi_config_pypi_uses_package_name(self, monkeypatch):
+        """receipt=PYPI + config=PYPI → cmd contains plain package name (regression)."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.PYPI,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.PYPI, None),
+        )
+
+        captured_cmd = []
+
+        def mock_run(*args, **kwargs):
+            captured_cmd.extend(args[0])
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = "Upgraded test-package from 1.0.0 to 1.1.0"
+
+            return Result()
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        success, message, was_upgraded = perform_tool_upgrade(tool)
+        assert success is True
+        assert "test-package" in captured_cmd
+        assert tool.github_install_url not in captured_cmd
+
+    def test_receipt_local_config_github_returns_early(self, monkeypatch):
+        """receipt=LOCAL → returns early with success=True, was_upgraded=False, no subprocess."""
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+            github_repo="owner/test-package",
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.LOCAL,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+
+        subprocess_called = []
+
+        def mock_run(*args, **kwargs):
+            subprocess_called.append(args)
+
+            class Result:
+                returncode = 0
+                stderr = ""
+                stdout = ""
+
+            return Result()
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        success, message, was_upgraded = perform_tool_upgrade(tool)
+        assert success is True
+        assert was_upgraded is False
+        assert not subprocess_called
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestCheckFailedPropagation:
+    """Tests that check_failed is set correctly on UpdateInfo."""
+
+    def test_index_check_returncode_error_sets_check_failed(self, monkeypatch):
+        """Non-zero returncode from subprocess → check_failed=True."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 1
+                stdout = ""
+                stderr = "Network error"
+
+            return Result()
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        result = check_index_updates("test-package", "1.0.0")
+        assert result.check_failed is True
+
+    def test_index_check_timeout_sets_check_failed(self, monkeypatch):
+        """TimeoutExpired from subprocess → check_failed=True."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+
+        def mock_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired("uvx", 30)
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        result = check_index_updates("test-package", "1.0.0")
+        assert result.check_failed is True
+
+    def test_index_check_success_no_update_check_failed_false(self, monkeypatch):
+        """Successful parse with no update → check_failed=False."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.is_command_available", lambda cmd: True
+        )
+
+        def mock_run(*args, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "test-package (1.0.0)\nAvailable versions: 1.0.0"
+                stderr = ""
+
+            return Result()
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
+        result = check_index_updates("test-package", "1.0.0")
+        assert result.check_failed is False
+
+    def test_github_check_network_error_sets_check_failed(self, monkeypatch):
+        """URLError from urlopen → check_failed=True."""
+
+        def _raise(*args, **kwargs):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.urllib.request.urlopen", _raise)
+        result = check_github_updates("owner/test-package", "1.0.0")
+        assert result.check_failed is True
+
+    def test_github_check_success_check_failed_false(self, monkeypatch):
+        """Successful GitHub tags response → check_failed=False."""
+        import json
+
+        payload = json.dumps([{"name": "v1.0.0"}]).encode()
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.urllib.request.urlopen",
+            _mock_urlopen(payload),
+        )
+        result = check_github_updates("owner/test-package", "1.0.0")
+        assert result.check_failed is False

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -366,6 +366,10 @@ class TestCheckToolUpdatesLocalSource:
             "ai_rules.bootstrap.updater.get_tool_source",
             lambda pkg: ToolSource.LOCAL,
         )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.LOCAL, None),
+        )
         result = check_tool_updates(tool)
         assert result is None
 
@@ -383,6 +387,10 @@ class TestPerformToolUpgradeLocalSource:
         monkeypatch.setattr(
             "ai_rules.bootstrap.updater.get_tool_source",
             lambda pkg: ToolSource.LOCAL,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.LOCAL, None),
         )
 
         subprocess_called = []
@@ -927,8 +935,8 @@ class TestCheckToolUpdatesSourceResolution:
         assert len(github_called) == 1
         assert len(index_called) == 0
 
-    def test_receipt_local_config_github_returns_none(self, monkeypatch):
-        """receipt=LOCAL → returns None regardless of config (LOCAL receipt is sticky)."""
+    def test_receipt_local_config_github_uses_github_check(self, monkeypatch):
+        """receipt=LOCAL + config=GITHUB → config wins, check_github_updates is called."""
         tool = ToolSpec(
             tool_id="test",
             package_name="test-package",
@@ -945,8 +953,36 @@ class TestCheckToolUpdatesSourceResolution:
             "ai_rules.bootstrap.updater.get_effective_install_source",
             lambda tool_id: (ToolSource.GITHUB, None),
         )
+        github_called = []
+        index_called = []
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_github_updates",
+            lambda repo, cur, timeout: _track(
+                github_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="github",
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.check_index_updates",
+            lambda pkg, cur, timeout, repo=None: _track(
+                index_called,
+                UpdateInfo(
+                    has_update=False,
+                    current_version=cur,
+                    latest_version=cur,
+                    source="index",
+                ),
+            ),
+        )
         result = check_tool_updates(tool)
-        assert result is None
+        assert result is not None
+        assert len(github_called) == 1
+        assert len(index_called) == 0
 
 
 @pytest.mark.unit
@@ -1036,8 +1072,8 @@ class TestPerformToolUpgradeSourceResolution:
         assert "test-package" in captured_cmd
         assert tool.github_install_url not in captured_cmd
 
-    def test_receipt_local_config_github_returns_early(self, monkeypatch):
-        """receipt=LOCAL → returns early with success=True, was_upgraded=False, no subprocess."""
+    def test_receipt_local_config_github_uses_github_url(self, monkeypatch):
+        """receipt=LOCAL + config=GITHUB → config wins, github_install_url used."""
         tool = ToolSpec(
             tool_id="test",
             package_name="test-package",
@@ -1058,23 +1094,22 @@ class TestPerformToolUpgradeSourceResolution:
             lambda tool_id: (ToolSource.GITHUB, None),
         )
 
-        subprocess_called = []
+        captured_cmd = []
 
         def mock_run(*args, **kwargs):
-            subprocess_called.append(args)
+            captured_cmd.extend(args[0])
 
             class Result:
                 returncode = 0
                 stderr = ""
-                stdout = ""
+                stdout = "Installed 1 executable: test-package"
 
             return Result()
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(tool)
         assert success is True
-        assert was_upgraded is False
-        assert not subprocess_called
+        assert tool.github_install_url in captured_cmd
 
 
 @pytest.mark.unit
@@ -1152,3 +1187,89 @@ class TestCheckFailedPropagation:
         )
         result = check_github_updates("owner/test-package", "1.0.0")
         assert result.check_failed is False
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestResolveEffectiveSource:
+    """Tests for _resolve_effective_source helper."""
+
+    def test_config_github_overrides_receipt_pypi(self, monkeypatch):
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.PYPI,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+        from ai_rules.bootstrap.updater import _resolve_effective_source
+
+        assert _resolve_effective_source(tool) == ToolSource.GITHUB
+
+    def test_config_github_overrides_receipt_local(self, monkeypatch):
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.LOCAL,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.GITHUB, None),
+        )
+        from ai_rules.bootstrap.updater import _resolve_effective_source
+
+        assert _resolve_effective_source(tool) == ToolSource.GITHUB
+
+    def test_config_pypi_uses_receipt(self, monkeypatch):
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: ToolSource.GITHUB,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.PYPI, None),
+        )
+        from ai_rules.bootstrap.updater import _resolve_effective_source
+
+        assert _resolve_effective_source(tool) == ToolSource.GITHUB
+
+    def test_no_receipt_defaults_to_pypi(self, monkeypatch):
+        tool = ToolSpec(
+            tool_id="test",
+            package_name="test-package",
+            display_name="test",
+            get_version=lambda: "1.0.0",
+            is_installed=lambda: True,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_source",
+            lambda pkg: None,
+        )
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_effective_install_source",
+            lambda tool_id: (ToolSource.PYPI, None),
+        )
+        from ai_rules.bootstrap.updater import _resolve_effective_source
+
+        assert _resolve_effective_source(tool) == ToolSource.PYPI


### PR DESCRIPTION
This PR fixes `ai-rules upgrade` and `ai-rules --version` silently reporting "already up to date" when the tool actually has updates available.

`check_tool_updates()` and `perform_tool_upgrade()` read `uv-receipt.toml` to determine whether to check GitHub or PyPI, ignoring the active profile's `install_sources` config. On machines where the tool was originally installed from a PyPI index (before GitHub support existed in v0.15.0), the receipt has no `git` key — so every upgrade check goes through the index path. On the work laptop, this routes through corporate Artifactory, which fails silently, producing a false "already up to date" result. The receipt is never corrected because the upgrade itself also reads the receipt.

- Extract `_resolve_effective_source()` helper that consults `get_effective_install_source()` (config/profile preference) first, falling back to the receipt source; `check_tool_updates()`, `perform_tool_upgrade()`, and the `upgrade` command's LOCAL guard all delegate to it
- Config-declared `GITHUB` or `LOCAL` sources override the receipt; `LOCAL` receipt no longer short-circuits before consulting config, so `config=GITHUB` correctly wins over `receipt=LOCAL`
- The first successful GitHub upgrade rewrites `uv-receipt.toml` with the `git` key, self-healing the state permanently
- Add `check_failed: bool` to `UpdateInfo`, set on all transient error paths in `check_index_updates()` and `check_github_updates()`, so failed checks surface warnings instead of false "already up to date" messages
- Handle `check_failed` in all callers: `upgrade`, `--version`, `tool show`, `tool list`, and `ensure_tool_installed`
- Warn when `--force` overrides a failed update check
- Add E2E tests: copy real uv tool venv into temp dir with a fake PYPI receipt and unreachable index URL, verify `upgrade --check`, `--version`, and `tool show` all surface "check failed" warnings