### PR TITLE
Add rebase agent skill

### DIFF
--- a/src/ai_rules/config/skills/rebase/SKILL.md
+++ b/src/ai_rules/config/skills/rebase/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Rebase a branch onto main (or a target). Squash-first strategy, semantic
   verification of auto-merged files, generated-file regeneration, and safe
   force-push. Use when rebasing PRs or branches that are behind their base.
-allowed-tools: Agent, AskUserQuestion, Bash, Edit, Read, Write
+allowed-tools: Agent, AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
 model: opus
 ---
 
@@ -14,10 +14,21 @@ model: opus
 - Arguments: `${ARGS}`
 - Project root: !`git rev-parse --show-toplevel 2>/dev/null || echo "NOT_IN_GIT_REPO"`
 - Current branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "NO_BRANCH"`
-- Default base: !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"`
+- Default base: !`sh -c 'ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed "s@^refs/remotes/origin/@@"); echo "${ref:-main}"'`
 - Commits ahead: !`git rev-list --count HEAD --not --remotes 2>/dev/null || echo "unknown"`
-- Ecosystem: !`[ -f Cargo.toml ] && echo "rust" || { [ -f package.json ] && echo "node" || { [ -f pyproject.toml ] && echo "python" || { [ -f go.mod ] && echo "go" || echo "unknown"; }; }; }`
+- Ecosystem: !`sh -c 'e=""; [ -f Cargo.toml ] && e="${e:+$e,}rust"; [ -f package.json ] && e="${e:+$e,}node"; [ -f pyproject.toml ] && e="${e:+$e,}python"; [ -f go.mod ] && e="${e:+$e,}go"; echo "${e:-unknown}"'`
 - Tooling: !`[ -f Justfile ] && echo "just" || { [ -f Makefile ] && echo "make" || echo "none"; }`
+
+## Ecosystem Defaults
+
+Use project tooling (Justfile/Makefile) first. Fall back to these only when no project recipe exists:
+
+| Ecosystem | Build | Lint | Format | Test | Lock Regen |
+|---|---|---|---|---|---|
+| Rust | `cargo build --workspace` | `cargo clippy --workspace --all-targets -- -D warnings` | `cargo fmt --all` | `cargo test --workspace` | `cargo update` |
+| Node | `npm run build` | `npm run lint` | `npm run format` or `npx prettier --write .` | `npm test` | `npm install` |
+| Python | `uv build` or `python -m build` | `ruff check .` | `ruff format .` | `pytest` | `uv lock` |
+| Go | `go build ./...` | `golangci-lint run` | `gofmt -w .` | `go test ./...` | `go mod tidy` |
 
 # Rebase Skill
 
@@ -32,8 +43,12 @@ If "Project root" is "NOT_IN_GIT_REPO" or "Current branch" is "NO_BRANCH" or "HE
 | Args | Action |
 |---|---|
 | Empty | Rebase onto the default base from Context |
-| Branch name (e.g. `main`, `upstream/main`) | Rebase onto that branch |
+| Branch name (e.g. `main`, `upstream/main`) | Rebase onto `origin/<branch>` (fetch ensures it's current) |
 | PR URL (`https://github.com/.../pull/123`) | `gh pr view <number> --json baseRefName` to extract base, rebase onto `origin/<base>` |
+
+**Important:** Always rebase onto the remote tracking ref (`origin/<branch>`), not the local branch — `git fetch origin` updates remote refs but not local branches.
+
+For PR URLs, this extracts the PR's base branch (the branch it merges into). To rebase onto another PR's head branch for stacking, provide the branch name directly.
 
 Set `TARGET` to the resolved target ref. Run `git fetch origin` to ensure it's current.
 
@@ -42,6 +57,23 @@ Set `TARGET` to the resolved target ref. Run `git fetch origin` to ensure it's c
 git status --porcelain
 ```
 If non-empty — ask user: stash, or abort. Do not proceed with uncommitted changes.
+
+If user chooses stash:
+```bash
+git stash push -m "rebase-skill: pre-rebase stash"
+```
+
+**Check for in-progress rebase:**
+```bash
+ls .git/rebase-merge .git/rebase-apply 2>/dev/null
+```
+If either directory exists — a prior rebase is in progress. Ask user to `git rebase --abort` first, or abort the skill.
+
+**Check for rerere:**
+```bash
+git config rerere.enabled
+```
+If true — warn user that git may silently auto-apply recorded conflict resolutions from prior rebases. These bypass Phase 3's manual review. Consider running `git rerere forget` for affected paths if prior resolutions were incorrect.
 
 ## Phase 1: Pre-flight Analysis
 
@@ -55,7 +87,11 @@ git diff --name-only $MERGE_BASE..HEAD       # Files WE changed
 git diff --name-only $MERGE_BASE..$TARGET    # Files THEY changed
 ```
 
-Compute: `COMMIT_COUNT` (our commits), `BEHIND_COUNT` (their commits), `OVERLAP_FILES` (files both sides touched).
+Compute: `COMMIT_COUNT` (our commits), `BEHIND_COUNT` (their commits), `OUR_BRANCH_FILES` (files we changed), `THEIR_FILES` (files they changed), `OVERLAP_FILES` (intersection of both).
+
+### 1a-fast. Fast path for simple rebases
+
+If `OVERLAP_FILES` is empty and `BEHIND_COUNT` is small (< 20): skip Phase 1c (structural risk analysis) and Phase 4b (verification subagents). Proceed with a direct rebase followed by build/test verification only.
 
 ### 1b. Classify overlapping files
 
@@ -66,6 +102,7 @@ For each file in `OVERLAP_FILES`:
 - Schema files: `*.schema.json`, `openapi.json`, `openapi.yaml`, `acp-schema.json`, `acp-meta.json`
 - Codegen output: files containing `// This file is auto-generated`, `// DO NOT EDIT`, `/* auto-generated */`, or living in directories named `generated/`
 - Protobuf/gRPC: `*.pb.rs`, `*.pb.go`, `*_grpc.rs`
+- Heuristic fallback: any file whose first 5 lines contain `auto-generated`, `DO NOT EDIT`, or `@generated`; any `*.lock*` file; any file in a directory named `generated/`, `dist/`, or `build/`
 
 **Hand-written files** — everything else.
 
@@ -82,7 +119,7 @@ For each relevant commit, check for:
 
 1. FILE RENAMES/MOVES
    git log $MERGE_BASE..$TARGET --diff-filter=R --name-status --find-renames
-   
+
 2. FILE → DIRECTORY TRANSITIONS
    Deletion of foo.rs + creation of foo/mod.rs
 
@@ -103,6 +140,8 @@ Output a RISK MATRIX:
   FILE | RISK_TYPE | WHAT_CHANGED | IMPACT_ON_OUR_CODE | CONFIDENCE
 ```
 
+**Important:** Substitute the actual SHA/ref values for `$MERGE_BASE` and `$TARGET` when constructing the subagent prompt — subagents cannot access the orchestrator's shell variables.
+
 ### 1d. Present pre-flight summary
 
 ```
@@ -120,21 +159,23 @@ Strategy: squash to 1 commit, then rebase
 
 Ask user to confirm before proceeding.
 
+**Persist the risk matrix** — record it in full. It will be referenced in Phase 3 (conflict resolution) and Phase 4 (semantic verification). Do not rely on it remaining in context across many tool calls.
+
 ## Phase 2: Squash & Rebase
 
 ### 2a. Squash if multiple commits (HARD RULE — no exceptions)
 
-Resolving a conflict once on 1 commit is strictly better than resolving it N times across N commits. Always squash when `COMMIT_COUNT > 1`.
+Resolving a conflict once on 1 commit is strictly better than resolving it N times across N commits. Always squash when `COMMIT_COUNT > 1`. **If `COMMIT_COUNT` is 1, skip to Phase 2b.**
 
 ```bash
 MERGE_BASE=$(git merge-base HEAD $TARGET)
 ```
 
-Read the branch's commit messages (`git log --reverse --format="%s%n%b" $MERGE_BASE..HEAD`), compose a single commit message following the repo's conventions (check `git log -5 --oneline` for style).
+Read the branch's commit messages (`git log --reverse --format="%s%n%b" $MERGE_BASE..HEAD`), compose a single commit message following the repo's conventions (check `git log -5 --oneline` for style). Write the message to a temp file to avoid shell escaping issues with quotes and newlines.
 
 ```bash
 git reset --soft $MERGE_BASE
-git commit -s -m "<composed message>"
+git commit -F <message-file>
 ```
 
 ### 2b. Rebase
@@ -144,6 +185,8 @@ git rebase $TARGET
 ```
 
 ## Phase 3: Conflict Resolution
+
+**Variable reminder:** Re-derive `TARGET` if needed — shell variables do not persist across Bash tool calls.
 
 Check `git status` for conflicts after each rebase step.
 
@@ -164,9 +207,13 @@ git add <file>
 
 After resolving all files: `git add <resolved files> && git rebase --continue`
 
+Use `GIT_EDITOR=true git rebase --continue` to prevent editor prompts in the agent context.
+
 If another conflict round occurs, repeat. If rebase aborts unexpectedly: `git rebase --abort`, explain, ask user.
 
 ## Phase 4: Semantic Verification
+
+**Variable reminder:** Re-derive `TARGET` from the Context section if needed — shell variables do not persist across Bash tool calls.
 
 **This phase runs after a "successful" rebase. A clean rebase is NOT a correct rebase.** This is the critical differentiator.
 
@@ -180,7 +227,7 @@ Every one of these files must be verified — not just the ones that conflicted.
 
 ### 4b. Launch parallel verification subagents
 
-Only launch agents for risk categories that appeared in the Phase 1 risk matrix. Load the briefing approach from `references/semantic-verification-template.md`. Launch all applicable agents in a single response for parallelism.
+Only launch agents for risk categories that appeared in the Phase 1 risk matrix. Load the briefing approach from `references/semantic-verification-template.md` **in this skill's directory**. Launch all applicable agents in a single response for parallelism.
 
 **Agent: Stale Imports** (if risk matrix has RENAME/MOVE/SPLIT entries)
 Check every branch file for import/use paths referencing old crate names, old module paths, or old file locations. For Rust: `use old_crate::`, Cargo.toml deps. For Node: `import from 'old/path'`. For Python: `from old.module import`.
@@ -199,74 +246,60 @@ For each finding: read the file, apply the correction, `git add`.
 
 ### 4d. Build
 
-Use project tooling. Check Justfile/Makefile first for a build target. Fall back to ecosystem default:
-
-| Ecosystem | Fallback |
-|---|---|
-| Rust | `cargo build --workspace` |
-| Node | `npm run build` |
-| Python | `uv build` or `python -m build` |
-| Go | `go build ./...` |
+Use project tooling. Check Justfile/Makefile first for a build target. Fall back to the Ecosystem Defaults table above.
 
 If build fails: read error, fix, re-run. Repeat until clean.
 
-### 4e. Lint
-
-| Ecosystem | Fallback |
-|---|---|
-| Rust | `cargo clippy --workspace --all-targets -- -D warnings` |
-| Node | `npm run lint` |
-| Python | `ruff check .` |
-| Go | `golangci-lint run` |
-
-Notable Rust pattern: `needless_borrow` after rebase often means a function changed from returning `T` to `&T`. Our `&var` creates `&&T` — remove the extra `&`.
-
-Fix all lint errors.
-
 ## Phase 5: Regeneration
 
-### 5a. Discover generators
+### 5a. Regenerate lockfiles
 
-1. `just --list 2>/dev/null` — targets containing: generate, gen, schema, openapi, codegen, types
-2. `grep -E '^[a-zA-Z_-]+:' Makefile 2>/dev/null` — same keywords
-3. Read `package.json` scripts for: generate, codegen, schema, build:types
-4. Check `.github/workflows/*.yml` for generation steps — these reveal canonical commands with correct flags
+If any lockfile was accepted from TARGET in Phase 3, regenerate it using the package manager (see Ecosystem Defaults table — Lock Regen column). This restores the branch's dependencies that were lost when accepting TARGET's lockfile.
 
-### 5b. Regenerate
+### 5b. Discover and run generators
 
-Run each discovered generator using project tooling (Justfile/Makefile recipe, not bare commands). **Never substitute a bare compiler command for a project recipe** — recipes often add required feature flags, environment variables, or pre/post steps that change the output.
+Check project tooling (just/make/package.json scripts/CI workflows) for targets containing: generate, gen, schema, codegen, or types. Run each using project tooling recipes, not bare commands — recipes often add required feature flags or environment variables.
 
 After each generator: `git add` the regenerated files.
 
 ### 5c. Format
 
-| Ecosystem | Fallback |
-|---|---|
-| Rust | `cargo fmt --all` |
-| Node | `npm run format` or `npx prettier --write .` |
-| Python | `ruff format .` |
-| Go | `gofmt -w .` |
+Use project tooling or Ecosystem Defaults table above.
 
 ### 5d. Amend commit
 
+Stage only files that were regenerated, formatted, or fixed in Phase 4c — do NOT use `git add -A` which stages unrelated untracked files. This phase runs unconditionally, even if Phases 5a-5c found nothing to do, to capture any staged changes from Phase 4c.
+
 ```bash
-git add -A
+git add <changed-files>
 git commit --amend --no-edit
 ```
 
+If regeneration introduced changes, a build check follows in Phase 6a.
+
 ## Phase 6: Final Verification & Push
 
-### 6a. Tests
+### 6a. Build
+
+Run build using project tooling or Ecosystem Defaults. This catches compile errors from regeneration before running tests.
+
+### 6b. Tests
 
 Run via project tooling, fall back to ecosystem default (`cargo test`, `npm test`, `pytest`, `go test ./...`).
 
+Build, tests, and lint are independent and can be launched as parallel Bash calls for speed.
+
 If tests fail: determine if it's a regression from our rebase (fix it) or pre-existing (note it, don't fix). Fix regressions, amend, re-test.
 
-### 6b. Final lint pass
+### 6c. Final lint pass
 
 One more lint run after regeneration and amendments.
 
-### 6c. Summary & push
+Notable Rust pattern: `needless_borrow` after rebase often means a function changed from returning `T` to `&T`. Our `&var` creates `&&T` — remove the extra `&`.
+
+Fix all lint errors.
+
+### 6d. Summary & push
 
 Present to user:
 ```
@@ -293,7 +326,7 @@ git push --force-with-lease origin HEAD
 
 Use `--force-with-lease`, never `--force`. If lease fails (someone else pushed), report it and ask — do NOT retry with `--force`.
 
-If stash was created in Phase 0: `git stash pop` after push.
+If stash was created in Phase 0: `git stash pop` to restore working changes.
 
 ## Rules (Never Violate)
 
@@ -304,3 +337,11 @@ If stash was created in Phase 0: `git stash pop` after push.
 5. **Build must pass** before committing. Never push broken code.
 6. **`--force-with-lease`**, never `--force`. Prevents clobbering others' pushes.
 7. **Ask before force-pushing.** Always get explicit user confirmation.
+
+## Abort & Cleanup
+
+If the skill aborts at any phase or the user requests a stop:
+
+1. If a rebase is in progress: `git rebase --abort`
+2. If a stash was created in Phase 0: check `git stash list` for "rebase-skill: pre-rebase stash" and `git stash pop` it
+3. Report what phase was reached and what state the repo is in

--- a/src/ai_rules/config/skills/rebase/SKILL.md
+++ b/src/ai_rules/config/skills/rebase/SKILL.md
@@ -30,6 +30,8 @@ Use project tooling (Justfile/Makefile) first. Fall back to these only when no p
 | Python | `uv build` or `python -m build` | `ruff check .` | `ruff format .` | `pytest` | `uv lock` |
 | Go | `go build ./...` | `golangci-lint run` | `gofmt -w .` | `go test ./...` | `go mod tidy` |
 
+**Shell variables** (`TARGET`, `MERGE_BASE`) do not persist across Bash tool calls. Re-derive from Context when needed.
+
 # Rebase Skill
 
 Expert git operator performing safe, semantically-correct rebases. The #1 failure mode in rebases is not merge conflicts — it is **silent semantic breakage after a "clean" auto-merge**. Your primary job is to prevent that.
@@ -52,28 +54,10 @@ For PR URLs, this extracts the PR's base branch (the branch it merges into). To 
 
 Set `TARGET` to the resolved target ref. Run `git fetch origin` to ensure it's current.
 
-**Check working tree:**
-```bash
-git status --porcelain
-```
-If non-empty — ask user: stash, or abort. Do not proceed with uncommitted changes.
-
-If user chooses stash:
-```bash
-git stash push -m "rebase-skill: pre-rebase stash"
-```
-
-**Check for in-progress rebase:**
-```bash
-ls .git/rebase-merge .git/rebase-apply 2>/dev/null
-```
-If either directory exists — a prior rebase is in progress. Ask user to `git rebase --abort` first, or abort the skill.
-
-**Check for rerere:**
-```bash
-git config rerere.enabled
-```
-If true — warn user that git may silently auto-apply recorded conflict resolutions from prior rebases. These bypass Phase 3's manual review. Consider running `git rerere forget` for affected paths if prior resolutions were incorrect.
+**Pre-flight checks:**
+1. `git status --porcelain` — if non-empty, ask user: stash (`git stash push -m "rebase-skill: pre-rebase stash"`) or abort
+2. `ls .git/rebase-merge .git/rebase-apply 2>/dev/null` — if either exists, ask user to `git rebase --abort` first
+3. `git config rerere.enabled` — if true, warn user: git may silently auto-apply prior conflict resolutions, bypassing Phase 3 review
 
 ## Phase 1: Pre-flight Analysis
 
@@ -108,70 +92,31 @@ For each file in `OVERLAP_FILES`:
 
 ### 1c. Detect structural risks on TARGET
 
-This is the most critical intelligence-gathering step. Launch ONE Explore subagent:
+Launch ONE Explore subagent to analyze commits from MERGE_BASE to TARGET (substitute actual SHA/ref values — subagents cannot access shell variables):
 
 ```
-Analyze commits from $MERGE_BASE to $TARGET in <project root>.
-Focus ONLY on commits touching files in OUR_BRANCH_FILES or structural files
-(Cargo.toml, package.json, tsconfig.json, mod.rs, __init__.py, index.ts, lib.rs).
+Analyze commits from <MERGE_BASE_SHA> to <TARGET_REF> in <project root>.
+Focus on commits touching OUR_BRANCH_FILES or structural files (Cargo.toml, package.json, tsconfig.json, mod.rs, __init__.py, index.ts, lib.rs).
 
-For each relevant commit, check for:
-
-1. FILE RENAMES/MOVES
-   git log $MERGE_BASE..$TARGET --diff-filter=R --name-status --find-renames
-
-2. FILE → DIRECTORY TRANSITIONS
-   Deletion of foo.rs + creation of foo/mod.rs
-
-3. CRATE/PACKAGE RENAMES OR SPLITS
-   Cargo.toml [package] name changes, new crates created from old ones,
-   re-export patterns (pub use new_crate::module)
-
-4. TYPE/API RENAMES
-   pub struct/fn/const/type renamed in files we also touch
-
-5. NAMESPACE CHANGES
-   Route prefixes, module path restructuring
-
-6. SIGNATURE CHANGES
-   Functions we call that changed return type, borrow semantics, or parameters
+Check for: file renames/moves (--diff-filter=R), file→directory transitions, crate/package renames or splits, type/API renames, namespace changes, function signature changes.
 
 Output a RISK MATRIX:
   FILE | RISK_TYPE | WHAT_CHANGED | IMPACT_ON_OUR_CODE | CONFIDENCE
 ```
 
-**Important:** Substitute the actual SHA/ref values for `$MERGE_BASE` and `$TARGET` when constructing the subagent prompt — subagents cannot access the orchestrator's shell variables.
-
 ### 1d. Present pre-flight summary
 
-```
-## Rebase Pre-flight
+Present to user: TARGET, commit counts, overlapping files (generated vs hand-written), structural risks from the risk matrix. Ask to confirm before proceeding.
 
-Target: <TARGET>
-Our commits: <N> | Behind: <M>
-Overlapping files: <count> (generated: <n>, hand-written: <m>)
-
-Structural risks:
-  <risk matrix entries, or "None detected">
-
-Strategy: squash to 1 commit, then rebase
-```
-
-Ask user to confirm before proceeding.
-
-**Persist the risk matrix** — record it in full. It will be referenced in Phase 3 (conflict resolution) and Phase 4 (semantic verification). Do not rely on it remaining in context across many tool calls.
+**Persist the risk matrix** in full — it's referenced in Phases 3 and 4.
 
 ## Phase 2: Squash & Rebase
 
 ### 2a. Squash if multiple commits (HARD RULE — no exceptions)
 
-Resolving a conflict once on 1 commit is strictly better than resolving it N times across N commits. Always squash when `COMMIT_COUNT > 1`. **If `COMMIT_COUNT` is 1, skip to Phase 2b.**
+Always squash when `COMMIT_COUNT > 1`. **If `COMMIT_COUNT` is 1, skip to Phase 2b.**
 
-```bash
-MERGE_BASE=$(git merge-base HEAD $TARGET)
-```
-
-Read the branch's commit messages (`git log --reverse --format="%s%n%b" $MERGE_BASE..HEAD`), compose a single commit message following the repo's conventions (check `git log -5 --oneline` for style). Write the message to a temp file to avoid shell escaping issues with quotes and newlines.
+Compute `MERGE_BASE=$(git merge-base HEAD $TARGET)`. Read the branch's commit messages (`git log --reverse --format="%s%n%b" $MERGE_BASE..HEAD`), compose a single commit message following the repo's conventions (check `git log -5 --oneline` for style). Write to a temp file for shell safety.
 
 ```bash
 git reset --soft $MERGE_BASE
@@ -180,28 +125,15 @@ git commit -F <message-file>
 
 ### 2b. Rebase
 
-```bash
-git rebase $TARGET
-```
+Run `git rebase $TARGET`.
 
 ## Phase 3: Conflict Resolution
 
-**Variable reminder:** Re-derive `TARGET` if needed — shell variables do not persist across Bash tool calls.
-
 Check `git status` for conflicts after each rebase step.
 
-**Generated files** — accept TARGET's version:
-```bash
-git checkout $TARGET -- <file>
-git add <file>
-```
+**Generated files** — accept TARGET's version: `git checkout $TARGET -- <file>` then `git add <file>`.
 
-**Hand-written files** — intelligent merge:
-1. Read conflict markers (both sides + base)
-2. Consult the risk matrix for this file
-3. If TARGET renamed a type/module our code uses → use the NEW name
-4. If TARGET moved a module → update our import paths to the new location
-5. Preserve BOTH sides' functional changes
+**Hand-written files** — read conflict markers, consult the risk matrix, use TARGET's new names/paths for renamed types or moved modules, preserve both sides' functional changes.
 
 **When ambiguous** — ask the user. Never guess on conflicts you can't resolve with certainty.
 
@@ -213,32 +145,21 @@ If another conflict round occurs, repeat. If rebase aborts unexpectedly: `git re
 
 ## Phase 4: Semantic Verification
 
-**Variable reminder:** Re-derive `TARGET` from the Context section if needed — shell variables do not persist across Bash tool calls.
-
-**This phase runs after a "successful" rebase. A clean rebase is NOT a correct rebase.** This is the critical differentiator.
+**A clean rebase is NOT a correct rebase.** This is the critical differentiator.
 
 ### 4a. Identify all branch files
 
-```bash
-git diff --name-only $TARGET..HEAD
-```
-
-Every one of these files must be verified — not just the ones that conflicted.
+Run `git diff --name-only $TARGET..HEAD`. Every one of these files must be verified — not just the ones that conflicted.
 
 ### 4b. Launch parallel verification subagents
 
-Only launch agents for risk categories that appeared in the Phase 1 risk matrix. Load the briefing approach from `references/semantic-verification-template.md` **in this skill's directory**. Launch all applicable agents in a single response for parallelism.
+Only launch agents for risk categories from the Phase 1 risk matrix. Load the briefing from `references/semantic-verification-template.md` **in this skill's directory**. Launch all applicable agents in a single response:
 
-**Agent: Stale Imports** (if risk matrix has RENAME/MOVE/SPLIT entries)
-Check every branch file for import/use paths referencing old crate names, old module paths, or old file locations. For Rust: `use old_crate::`, Cargo.toml deps. For Node: `import from 'old/path'`. For Python: `from old.module import`.
+- **Stale Imports** — if RENAME/MOVE/SPLIT risks
+- **Stale API References** — if TYPE/API/NAMESPACE risks
+- **Signature Compatibility** — if SIGNATURE risks
 
-**Agent: Stale API References** (if risk matrix has TYPE/API/NAMESPACE entries)
-Grep branch files for old type/function/constant names from the risk matrix. Report each stale usage with file, line, old reference, and correct replacement.
-
-**Agent: Signature Compatibility** (if risk matrix has SIGNATURE entries)
-For each changed function signature, find our call sites and verify they match the new signature (borrow semantics, argument count, field names).
-
-If the risk matrix was empty (no structural risks detected), skip subagents — proceed directly to the build check.
+Skip if risk matrix was empty.
 
 ### 4c. Fix all reported issues
 
@@ -268,14 +189,12 @@ Use project tooling or Ecosystem Defaults table above.
 
 ### 5d. Amend commit
 
-Stage only files that were regenerated, formatted, or fixed in Phase 4c — do NOT use `git add -A` which stages unrelated untracked files. This phase runs unconditionally, even if Phases 5a-5c found nothing to do, to capture any staged changes from Phase 4c.
+Stage only regenerated/formatted/fixed files (not `git add -A`). Runs unconditionally to capture Phase 4c changes.
 
 ```bash
 git add <changed-files>
 git commit --amend --no-edit
 ```
-
-If regeneration introduced changes, a build check follows in Phase 6a.
 
 ## Phase 6: Final Verification & Push
 
@@ -301,30 +220,7 @@ Fix all lint errors.
 
 ### 6d. Summary & push
 
-Present to user:
-```
-## Rebase Complete
-
-Branch: <branch> onto <TARGET>
-Commits: 1 (squashed from <N>)
-Files changed: <count>
-
-Verification:
-  Build: passed
-  Lint: passed
-  Tests: passed (or "N pre-existing failures noted")
-  Semantic checks: <N issues fixed | clean>
-  Regenerated: <list of generators run>
-
-Ready to force-push.
-```
-
-Wait for explicit confirmation. Then:
-```bash
-git push --force-with-lease origin HEAD
-```
-
-Use `--force-with-lease`, never `--force`. If lease fails (someone else pushed), report it and ask — do NOT retry with `--force`.
+Present completion summary: branch, target, files changed, verification results (build/lint/tests/semantic checks/regenerated files). Wait for explicit push confirmation, then `git push --force-with-lease origin HEAD`. Never `--force`. If lease fails, report and ask — do NOT retry with `--force`.
 
 If stash was created in Phase 0: `git stash pop` to restore working changes.
 
@@ -340,8 +236,4 @@ If stash was created in Phase 0: `git stash pop` to restore working changes.
 
 ## Abort & Cleanup
 
-If the skill aborts at any phase or the user requests a stop:
-
-1. If a rebase is in progress: `git rebase --abort`
-2. If a stash was created in Phase 0: check `git stash list` for "rebase-skill: pre-rebase stash" and `git stash pop` it
-3. Report what phase was reached and what state the repo is in
+On abort: `git rebase --abort` if in progress, `git stash pop` the named stash if created in Phase 0, report phase reached and repo state.

--- a/src/ai_rules/config/skills/rebase/SKILL.md
+++ b/src/ai_rules/config/skills/rebase/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: rebase
+version: 1.0.0
+description: >
+  Rebase a branch onto main (or a target). Squash-first strategy, semantic
+  verification of auto-merged files, generated-file regeneration, and safe
+  force-push. Use when rebasing PRs or branches that are behind their base.
+allowed-tools: Agent, AskUserQuestion, Bash, Edit, Read, Write
+model: opus
+---
+
+## Context
+
+- Arguments: `${ARGS}`
+- Project root: !`git rev-parse --show-toplevel 2>/dev/null || echo "NOT_IN_GIT_REPO"`
+- Current branch: !`git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "NO_BRANCH"`
+- Default base: !`git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"`
+- Commits ahead: !`git rev-list --count HEAD --not --remotes 2>/dev/null || echo "unknown"`
+- Ecosystem: !`[ -f Cargo.toml ] && echo "rust" || { [ -f package.json ] && echo "node" || { [ -f pyproject.toml ] && echo "python" || { [ -f go.mod ] && echo "go" || echo "unknown"; }; }; }`
+- Tooling: !`[ -f Justfile ] && echo "just" || { [ -f Makefile ] && echo "make" || echo "none"; }`
+
+# Rebase Skill
+
+Expert git operator performing safe, semantically-correct rebases. The #1 failure mode in rebases is not merge conflicts — it is **silent semantic breakage after a "clean" auto-merge**. Your primary job is to prevent that.
+
+## Phase 0: Pre-flight Validation
+
+If "Project root" is "NOT_IN_GIT_REPO" or "Current branch" is "NO_BRANCH" or "HEAD" — stop and inform user.
+
+**Resolve target branch from `${ARGS}`:**
+
+| Args | Action |
+|---|---|
+| Empty | Rebase onto the default base from Context |
+| Branch name (e.g. `main`, `upstream/main`) | Rebase onto that branch |
+| PR URL (`https://github.com/.../pull/123`) | `gh pr view <number> --json baseRefName` to extract base, rebase onto `origin/<base>` |
+
+Set `TARGET` to the resolved target ref. Run `git fetch origin` to ensure it's current.
+
+**Check working tree:**
+```bash
+git status --porcelain
+```
+If non-empty — ask user: stash, or abort. Do not proceed with uncommitted changes.
+
+## Phase 1: Pre-flight Analysis
+
+### 1a. Compute divergence
+
+```bash
+MERGE_BASE=$(git merge-base HEAD $TARGET)
+git log --oneline $MERGE_BASE..HEAD          # Our commits
+git log --oneline $MERGE_BASE..$TARGET       # Commits to rebase over
+git diff --name-only $MERGE_BASE..HEAD       # Files WE changed
+git diff --name-only $MERGE_BASE..$TARGET    # Files THEY changed
+```
+
+Compute: `COMMIT_COUNT` (our commits), `BEHIND_COUNT` (their commits), `OVERLAP_FILES` (files both sides touched).
+
+### 1b. Classify overlapping files
+
+For each file in `OVERLAP_FILES`:
+
+**Generated files** (never manually merge — accept TARGET's version, regenerate after):
+- Lock files: `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `uv.lock`, `go.sum`
+- Schema files: `*.schema.json`, `openapi.json`, `openapi.yaml`, `acp-schema.json`, `acp-meta.json`
+- Codegen output: files containing `// This file is auto-generated`, `// DO NOT EDIT`, `/* auto-generated */`, or living in directories named `generated/`
+- Protobuf/gRPC: `*.pb.rs`, `*.pb.go`, `*_grpc.rs`
+
+**Hand-written files** — everything else.
+
+### 1c. Detect structural risks on TARGET
+
+This is the most critical intelligence-gathering step. Launch ONE Explore subagent:
+
+```
+Analyze commits from $MERGE_BASE to $TARGET in <project root>.
+Focus ONLY on commits touching files in OUR_BRANCH_FILES or structural files
+(Cargo.toml, package.json, tsconfig.json, mod.rs, __init__.py, index.ts, lib.rs).
+
+For each relevant commit, check for:
+
+1. FILE RENAMES/MOVES
+   git log $MERGE_BASE..$TARGET --diff-filter=R --name-status --find-renames
+   
+2. FILE → DIRECTORY TRANSITIONS
+   Deletion of foo.rs + creation of foo/mod.rs
+
+3. CRATE/PACKAGE RENAMES OR SPLITS
+   Cargo.toml [package] name changes, new crates created from old ones,
+   re-export patterns (pub use new_crate::module)
+
+4. TYPE/API RENAMES
+   pub struct/fn/const/type renamed in files we also touch
+
+5. NAMESPACE CHANGES
+   Route prefixes, module path restructuring
+
+6. SIGNATURE CHANGES
+   Functions we call that changed return type, borrow semantics, or parameters
+
+Output a RISK MATRIX:
+  FILE | RISK_TYPE | WHAT_CHANGED | IMPACT_ON_OUR_CODE | CONFIDENCE
+```
+
+### 1d. Present pre-flight summary
+
+```
+## Rebase Pre-flight
+
+Target: <TARGET>
+Our commits: <N> | Behind: <M>
+Overlapping files: <count> (generated: <n>, hand-written: <m>)
+
+Structural risks:
+  <risk matrix entries, or "None detected">
+
+Strategy: squash to 1 commit, then rebase
+```
+
+Ask user to confirm before proceeding.
+
+## Phase 2: Squash & Rebase
+
+### 2a. Squash if multiple commits (HARD RULE — no exceptions)
+
+Resolving a conflict once on 1 commit is strictly better than resolving it N times across N commits. Always squash when `COMMIT_COUNT > 1`.
+
+```bash
+MERGE_BASE=$(git merge-base HEAD $TARGET)
+```
+
+Read the branch's commit messages (`git log --reverse --format="%s%n%b" $MERGE_BASE..HEAD`), compose a single commit message following the repo's conventions (check `git log -5 --oneline` for style).
+
+```bash
+git reset --soft $MERGE_BASE
+git commit -s -m "<composed message>"
+```
+
+### 2b. Rebase
+
+```bash
+git rebase $TARGET
+```
+
+## Phase 3: Conflict Resolution
+
+Check `git status` for conflicts after each rebase step.
+
+**Generated files** — accept TARGET's version:
+```bash
+git checkout $TARGET -- <file>
+git add <file>
+```
+
+**Hand-written files** — intelligent merge:
+1. Read conflict markers (both sides + base)
+2. Consult the risk matrix for this file
+3. If TARGET renamed a type/module our code uses → use the NEW name
+4. If TARGET moved a module → update our import paths to the new location
+5. Preserve BOTH sides' functional changes
+
+**When ambiguous** — ask the user. Never guess on conflicts you can't resolve with certainty.
+
+After resolving all files: `git add <resolved files> && git rebase --continue`
+
+If another conflict round occurs, repeat. If rebase aborts unexpectedly: `git rebase --abort`, explain, ask user.
+
+## Phase 4: Semantic Verification
+
+**This phase runs after a "successful" rebase. A clean rebase is NOT a correct rebase.** This is the critical differentiator.
+
+### 4a. Identify all branch files
+
+```bash
+git diff --name-only $TARGET..HEAD
+```
+
+Every one of these files must be verified — not just the ones that conflicted.
+
+### 4b. Launch parallel verification subagents
+
+Only launch agents for risk categories that appeared in the Phase 1 risk matrix. Load the briefing approach from `references/semantic-verification-template.md`. Launch all applicable agents in a single response for parallelism.
+
+**Agent: Stale Imports** (if risk matrix has RENAME/MOVE/SPLIT entries)
+Check every branch file for import/use paths referencing old crate names, old module paths, or old file locations. For Rust: `use old_crate::`, Cargo.toml deps. For Node: `import from 'old/path'`. For Python: `from old.module import`.
+
+**Agent: Stale API References** (if risk matrix has TYPE/API/NAMESPACE entries)
+Grep branch files for old type/function/constant names from the risk matrix. Report each stale usage with file, line, old reference, and correct replacement.
+
+**Agent: Signature Compatibility** (if risk matrix has SIGNATURE entries)
+For each changed function signature, find our call sites and verify they match the new signature (borrow semantics, argument count, field names).
+
+If the risk matrix was empty (no structural risks detected), skip subagents — proceed directly to the build check.
+
+### 4c. Fix all reported issues
+
+For each finding: read the file, apply the correction, `git add`.
+
+### 4d. Build
+
+Use project tooling. Check Justfile/Makefile first for a build target. Fall back to ecosystem default:
+
+| Ecosystem | Fallback |
+|---|---|
+| Rust | `cargo build --workspace` |
+| Node | `npm run build` |
+| Python | `uv build` or `python -m build` |
+| Go | `go build ./...` |
+
+If build fails: read error, fix, re-run. Repeat until clean.
+
+### 4e. Lint
+
+| Ecosystem | Fallback |
+|---|---|
+| Rust | `cargo clippy --workspace --all-targets -- -D warnings` |
+| Node | `npm run lint` |
+| Python | `ruff check .` |
+| Go | `golangci-lint run` |
+
+Notable Rust pattern: `needless_borrow` after rebase often means a function changed from returning `T` to `&T`. Our `&var` creates `&&T` — remove the extra `&`.
+
+Fix all lint errors.
+
+## Phase 5: Regeneration
+
+### 5a. Discover generators
+
+1. `just --list 2>/dev/null` — targets containing: generate, gen, schema, openapi, codegen, types
+2. `grep -E '^[a-zA-Z_-]+:' Makefile 2>/dev/null` — same keywords
+3. Read `package.json` scripts for: generate, codegen, schema, build:types
+4. Check `.github/workflows/*.yml` for generation steps — these reveal canonical commands with correct flags
+
+### 5b. Regenerate
+
+Run each discovered generator using project tooling (Justfile/Makefile recipe, not bare commands). **Never substitute a bare compiler command for a project recipe** — recipes often add required feature flags, environment variables, or pre/post steps that change the output.
+
+After each generator: `git add` the regenerated files.
+
+### 5c. Format
+
+| Ecosystem | Fallback |
+|---|---|
+| Rust | `cargo fmt --all` |
+| Node | `npm run format` or `npx prettier --write .` |
+| Python | `ruff format .` |
+| Go | `gofmt -w .` |
+
+### 5d. Amend commit
+
+```bash
+git add -A
+git commit --amend --no-edit
+```
+
+## Phase 6: Final Verification & Push
+
+### 6a. Tests
+
+Run via project tooling, fall back to ecosystem default (`cargo test`, `npm test`, `pytest`, `go test ./...`).
+
+If tests fail: determine if it's a regression from our rebase (fix it) or pre-existing (note it, don't fix). Fix regressions, amend, re-test.
+
+### 6b. Final lint pass
+
+One more lint run after regeneration and amendments.
+
+### 6c. Summary & push
+
+Present to user:
+```
+## Rebase Complete
+
+Branch: <branch> onto <TARGET>
+Commits: 1 (squashed from <N>)
+Files changed: <count>
+
+Verification:
+  Build: passed
+  Lint: passed
+  Tests: passed (or "N pre-existing failures noted")
+  Semantic checks: <N issues fixed | clean>
+  Regenerated: <list of generators run>
+
+Ready to force-push.
+```
+
+Wait for explicit confirmation. Then:
+```bash
+git push --force-with-lease origin HEAD
+```
+
+Use `--force-with-lease`, never `--force`. If lease fails (someone else pushed), report it and ask — do NOT retry with `--force`.
+
+If stash was created in Phase 0: `git stash pop` after push.
+
+## Rules (Never Violate)
+
+1. **Squash before rebase** when branch has >1 commit. No exceptions.
+2. **Never manually merge generated files.** Accept TARGET, regenerate.
+3. **Always use project tooling** (just/make) over bare commands. Feature flags matter.
+4. **Run semantic verification** before declaring success. Clean rebase != correct rebase.
+5. **Build must pass** before committing. Never push broken code.
+6. **`--force-with-lease`**, never `--force`. Prevents clobbering others' pushes.
+7. **Ask before force-pushing.** Always get explicit user confirmation.

--- a/src/ai_rules/config/skills/rebase/references/semantic-verification-template.md
+++ b/src/ai_rules/config/skills/rebase/references/semantic-verification-template.md
@@ -1,0 +1,117 @@
+# Semantic Verification Subagent Briefing
+
+Use this template to construct briefings for Phase 4 subagents. Subagents have NO conversation context — every briefing must be fully self-contained.
+
+## Briefing Template
+
+```
+You are a focused semantic verification agent. Your scope is narrow — verify exactly what is assigned.
+
+REPO: [absolute path to repository root]
+ECOSYSTEM: [rust|node|python|go|unknown]
+
+ASSIGNMENT: [STALE_IMPORTS | STALE_API | SIGNATURE_COMPAT]
+
+RISK MATRIX ENTRIES:
+[paste relevant entries from Phase 1c — one per line, format: FILE | RISK_TYPE | WHAT_CHANGED]
+
+OUR BRANCH FILES:
+[one file path per line — all files the branch touches, from git diff --name-only TARGET..HEAD]
+
+TASK:
+[copy the assignment-specific instructions below verbatim]
+
+OUTPUT FORMAT:
+
+## Findings: [Assignment]
+
+### Issues
+For each issue:
+- **File**: `<path>:<line>`
+  **Stale**: `<old reference>`
+  **Correct**: `<new reference>`
+  **Confidence**: HIGH / MEDIUM / LOW
+
+### Clean Files
+[list files checked with no issues — explicit confirmation]
+
+### Ambiguous Cases
+[cases where correctness cannot be determined with certainty]
+
+RULES:
+- Read FULL file contents for files with suspected issues — grep line numbers alone miss context
+- List every file checked, even if clean
+- Do NOT fix issues — only report. The orchestrator handles fixes.
+- If a reference was already corrected by the rebase, mark it "already correct"
+```
+
+## Assignment-Specific Instructions
+
+### STALE_IMPORTS
+
+Check every file in OUR BRANCH FILES for import/use paths that reference names or paths that no longer exist after TARGET's refactoring.
+
+**Rust:**
+- `use <old_crate_name>::` where crate was renamed or split (check Cargo.toml [dependencies] for the correct crate name)
+- `use crate::<old_module>::` where a module was moved (e.g., `mod.rs` relocated)
+- `use super::<name>` where a sibling module was deleted or merged
+
+**TypeScript/JavaScript:**
+- `import ... from '<old_path>'` where file was moved or renamed
+- `require('<old_path>')` — same
+- Barrel file re-exports (`export * from '<old_path>'`)
+
+**Python:**
+- `from <old_module> import` where module was renamed or reorganized
+- `import <old_module>` — same
+
+**Go:**
+- `import "<old_package_path>"` where package was moved
+
+For each risk matrix entry of type RENAME/MOVE/SPLIT, grep OUR BRANCH FILES for the old name.
+
+### STALE_API
+
+For each renamed type, function, constant, or method in the risk matrix:
+1. Identify the OLD name and the NEW name
+2. Grep OUR BRANCH FILES for usages of the OLD name
+3. For each hit, verify it's actually a usage (not a definition or comment)
+
+Common patterns:
+- `pub struct OldName` → `pub struct NewName` — grep for `OldName` in type positions
+- Method rename — grep for `.old_method(` calls
+- Constant rename — grep for `OLD_CONST` usages
+- Route/namespace prefix change (e.g., `_goose/foo` → `_goose/unstable/foo`) — grep for the old prefix in string literals
+
+### SIGNATURE_COMPAT
+
+For each function/method with a changed signature in the risk matrix:
+1. Read the NEW signature from TARGET's version of the file
+2. Find all call sites in OUR BRANCH FILES
+3. Verify each call site matches the new signature:
+
+**Rust-specific checks:**
+- Ownership/borrow: `fn foo(x: Config)` → `fn foo(x: &Config)` — callers passing `&x` now create `&&Config`
+- Return type: `fn bar() -> Config` → `fn bar() -> &Config` — callers doing `&bar()` create `&&Config`
+- Added parameters — callers missing the new argument
+- Changed generics — callers using old concrete type
+
+**TypeScript-specific checks:**
+- Optional → required parameter
+- Type narrowing changes
+- Return type changes (Promise wrapping, union changes)
+
+## Risk Category Signals
+
+Use these to identify what to look for when the risk matrix mentions each category:
+
+| Risk Type | What Changed | Where to Look |
+|---|---|---|
+| RENAME | File moved to new path | Import/require/use statements in all branch files |
+| MOVE | Module relocated in directory tree | Same as RENAME plus re-export files (mod.rs, index.ts, __init__.py) |
+| SPLIT | One crate/package split into two | Cargo.toml deps, package.json deps, all import statements |
+| FILE_TO_DIR | `foo.rs` deleted, `foo/mod.rs` created | `use crate::foo::Item` may need `use crate::foo::submod::Item` |
+| TYPE_RENAME | `pub struct Foo` → `pub struct Bar` | All usages of `Foo` in branch files |
+| API_RENAME | Method/function name changed | All call sites `.old_name(` in branch files |
+| NAMESPACE | Route prefix or module path restructured | String literals containing old prefix, use paths |
+| SIGNATURE | Function params or return type changed | All call sites, may compile but be semantically wrong |

--- a/src/ai_rules/config/skills/rebase/references/semantic-verification-template.md
+++ b/src/ai_rules/config/skills/rebase/references/semantic-verification-template.md
@@ -32,9 +32,6 @@ For each issue:
   **Correct**: `<new reference>`
   **Confidence**: HIGH / MEDIUM / LOW
 
-### Clean Files
-[list files checked with no issues — explicit confirmation]
-
 ### Ambiguous Cases
 [cases where correctness cannot be determined with certainty]
 
@@ -100,18 +97,3 @@ For each function/method with a changed signature in the risk matrix:
 - Optional → required parameter
 - Type narrowing changes
 - Return type changes (Promise wrapping, union changes)
-
-## Risk Category Signals
-
-Use these to identify what to look for when the risk matrix mentions each category:
-
-| Risk Type | What Changed | Where to Look |
-|---|---|---|
-| RENAME | File moved to new path | Import/require/use statements in all branch files |
-| MOVE | Module relocated in directory tree | Same as RENAME plus re-export files (mod.rs, index.ts, __init__.py) |
-| SPLIT | One crate/package split into two | Cargo.toml deps, package.json deps, all import statements |
-| FILE_TO_DIR | `foo.rs` deleted, `foo/mod.rs` created | `use crate::foo::Item` may need `use crate::foo::submod::Item` |
-| TYPE_RENAME | `pub struct Foo` → `pub struct Bar` | All usages of `Foo` in branch files |
-| API_RENAME | Method/function name changed | All call sites `.old_name(` in branch files |
-| NAMESPACE | Route prefix or module path restructured | String literals containing old prefix, use paths |
-| SIGNATURE | Function params or return type changed | All call sites, may compile but be semantically wrong |


### PR DESCRIPTION
New `/rebase` skill that performs safe, semantically-correct git rebases. Born from two complex rebase sessions on a Rust+TypeScript monorepo (goose PR #9197) where auto-merged files were silently broken by crate renames, module restructuring, and function signature changes.

The skill's key differentiator is a **semantic verification phase** (Phase 4) that catches issues in non-conflicting files — the ones git marks "applied cleanly" but are actually wrong. It uses parallel subagents to check for stale imports, renamed types, and signature drift across all branch files, not just conflicted ones.

## Workflow

- **Phase 0**: Pre-flight validation — in-progress rebase detection, `rerere` warning, explicit stash handling with named ref, always rebase onto `origin/<branch>` not stale local
- **Phase 1**: Pre-flight analysis with structural risk detection via Explore subagent, plus fast path for simple rebases with no overlapping files
- **Phase 2**: Squash-first rebase (when `COMMIT_COUNT > 1`; single-commit branches skip squash), commit message via temp file for shell safety
- **Phase 3**: Conflict resolution — generated files accepted from target then regenerated, hand-written merged with risk matrix context
- **Phase 4**: Semantic verification via parallel subagents (stale imports, stale API refs, signature compatibility), followed by build
- **Phase 5**: Lockfile regeneration + code generation using project tooling, targeted staging (never `git add -A`)
- **Phase 6**: Build, lint, test (parallelizable) and safe `--force-with-lease` push with abort/cleanup path

## Design decisions

- Consolidated ecosystem defaults table (build/lint/format/test/lock-regen) referenced from all phases
- Multi-ecosystem detection for monorepos (comma-separated, not first-match-wins)
- Shell variable persistence note at top — variables don't persist across Bash tool calls
- `GIT_EDITOR=true` for `rebase --continue` in non-interactive agent context
- Template path qualified with "in this skill's directory" for correct resolution
- Token-optimized: 239 lines with all semantic intent preserved (inlined single-command code blocks, removed self-evident rationale, compressed output templates)

## Files

- `src/ai_rules/config/skills/rebase/SKILL.md` — main skill prompt (239 lines)
- `src/ai_rules/config/skills/rebase/references/semantic-verification-template.md` — subagent briefing template for Phase 4