### PR TITLE
refactor: rename get_sprout_packs_dir to get_sprout_teams_dir

### DIFF
--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -111,6 +111,6 @@ def get_statusline_config_dir() -> Path:
     return Path("~/.config/claude-statusline")
 
 
-def get_sprout_packs_dir(dev: bool = False) -> Path:
+def get_sprout_teams_dir(dev: bool = False) -> Path:
     bundle = "xyz.block.sprout.app.dev" if dev else "xyz.block.sprout.app"
-    return Path.home() / "Library" / "Application Support" / bundle / "agents" / "packs"
+    return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"

--- a/src/ai_rules/tools/sprout.py
+++ b/src/ai_rules/tools/sprout.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from ai_rules.platform import (
     Platform,
-    get_sprout_packs_dir,
+    get_sprout_teams_dir,
     is_platform,
 )
 from ai_rules.tools.base import Tool
@@ -49,6 +49,6 @@ class SproutTool(Tool):
         if not pack_id:
             return []
         return [
-            (get_sprout_packs_dir(dev=False) / pack_id, source),
-            (get_sprout_packs_dir(dev=True) / pack_id, source),
+            (get_sprout_teams_dir(dev=False) / pack_id, source),
+            (get_sprout_teams_dir(dev=True) / pack_id, source),
         ]


### PR DESCRIPTION
Sprout renamed `agents/packs/` to `agents/teams/` in [sprout#852](https://github.com/block/sprout/pull/852). This updates the symlink install path in `SproutTool` so that `ai-rules install` places pack symlinks in the correct directory.

## Changes

- `platform.py`: Rename `get_sprout_packs_dir` → `get_sprout_teams_dir`, update path segment from `agents/packs` to `agents/teams`
- `tools/sprout.py`: Update import and call sites to use the renamed function

Related: [sprout#852](https://github.com/block/sprout/pull/852)