### PR TITLE
fix(bootstrap): fix tool install source detection bugs

### DIFF
--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -78,6 +78,8 @@ def get_tool_config_dir(package_name: str = "ai-agent-rules") -> Path:
         tools_base.glob("lib/python*/site-packages/ai_rules/config"),
         reverse=True,
     )
+    if not candidates:
+        candidates = list(tools_base.glob("Lib/site-packages/ai_rules/config"))
     if candidates:
         return candidates[0]
 
@@ -114,7 +116,7 @@ def get_tool_source(package_name: str) -> ToolSource | None:
 
         first_req = requirements[0]
         if isinstance(first_req, dict):
-            if "git" in first_req:
+            if "git" in first_req and _is_github_git_reference(str(first_req["git"])):
                 return ToolSource.GITHUB
             if (
                 "path" in first_req

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -60,8 +60,8 @@ def _is_github_git_reference(git_ref: str) -> bool:
 def get_tool_config_dir(package_name: str = "ai-agent-rules") -> Path:
     """Get config directory for a uv tool installation.
 
-    Computes the expected path where uv tool install places the package:
-    $XDG_DATA_HOME/uv/tools/{package}/lib/python{version}/site-packages/ai_rules/config/
+    Discovers the actual Python version directory via glob rather than
+    assuming it matches the running interpreter.
 
     Args:
         package_name: Name of the uv tool package
@@ -72,15 +72,17 @@ def get_tool_config_dir(package_name: str = "ai-agent-rules") -> Path:
 
     from ai_rules.platform import get_lib_path_fragment, get_uv_tools_dir
 
-    python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    tools_base = get_uv_tools_dir() / package_name
 
-    return (
-        get_uv_tools_dir()
-        / package_name
-        / get_lib_path_fragment(python_version)
-        / "ai_rules"
-        / "config"
+    candidates = sorted(
+        tools_base.glob("lib/python*/site-packages/ai_rules/config"),
+        reverse=True,
     )
+    if candidates:
+        return candidates[0]
+
+    python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    return tools_base / get_lib_path_fragment(python_version) / "ai_rules" / "config"
 
 
 def get_tool_source(package_name: str) -> ToolSource | None:
@@ -112,9 +114,13 @@ def get_tool_source(package_name: str) -> ToolSource | None:
 
         first_req = requirements[0]
         if isinstance(first_req, dict):
-            if "git" in first_req and _is_github_git_reference(str(first_req["git"])):
+            if "git" in first_req:
                 return ToolSource.GITHUB
-            if "path" in first_req or "directory" in first_req:
+            if (
+                "path" in first_req
+                or "directory" in first_req
+                or "editable" in first_req
+            ):
                 return ToolSource.LOCAL
 
         return ToolSource.PYPI
@@ -270,7 +276,7 @@ def get_tool_version(tool_name: str) -> str | None:
             return None
 
         for line in result.stdout.splitlines():
-            if line.startswith(tool_name):
+            if line.startswith(tool_name + " "):
                 match = re.search(r"v?(\d+\.\d+\.\d+)", line)
                 if match:
                     return match.group(1)

--- a/src/ai_rules/cli/commands/setup.py
+++ b/src/ai_rules/cli/commands/setup.py
@@ -104,7 +104,9 @@ def setup(
         ai_rules_from_github = ai_rules_source == ToolSource.GITHUB
         current_source = get_tool_source(ai_rules_tool.package_name)
         desired_source = ai_rules_source
-        needs_source_switch = current_source != desired_source
+        needs_source_switch = (
+            current_source is not None and current_source != desired_source
+        )
 
         if needs_source_switch:
             if ai_rules_source == ToolSource.LOCAL:

--- a/src/ai_rules/cli/commands/setup.py
+++ b/src/ai_rules/cli/commands/setup.py
@@ -104,9 +104,10 @@ def setup(
         ai_rules_from_github = ai_rules_source == ToolSource.GITHUB
         current_source = get_tool_source(ai_rules_tool.package_name)
         desired_source = ai_rules_source
-        needs_source_switch = (
-            current_source is not None and current_source != desired_source
-        )
+        if current_source is None:
+            needs_source_switch = desired_source != ToolSource.PYPI
+        else:
+            needs_source_switch = current_source != desired_source
 
         if needs_source_switch:
             if ai_rules_source == ToolSource.LOCAL:

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -16,6 +16,7 @@ from ai_rules.bootstrap.installer import (
     get_effective_install_source,
     get_tool_config_dir,
     get_tool_source,
+    get_tool_version,
     install_tool,
     uninstall_tool,
 )
@@ -341,6 +342,24 @@ class TestGetToolConfigDir:
         assert "my-custom-package" in result.as_posix()
         assert "ai_rules/config" in result.as_posix()
 
+    def test_discovers_actual_python_version_via_glob(self, tmp_path, monkeypatch):
+        """Test that get_tool_config_dir finds the actual Python version dir."""
+        config_dir = (
+            tmp_path
+            / "test-pkg"
+            / "lib"
+            / "python3.99"
+            / "site-packages"
+            / "ai_rules"
+            / "config"
+        )
+        config_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = get_tool_config_dir("test-pkg")
+        assert result == config_dir
+
 
 @pytest.mark.unit
 @pytest.mark.bootstrap
@@ -395,6 +414,69 @@ class TestGetToolSource:
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("test-package")
         assert result == ToolSource.LOCAL
+
+    def test_detects_editable_installation(self, tmp_path, monkeypatch):
+        """Test that editable installations are detected as LOCAL."""
+        tools_dir = tmp_path / "test-package"
+        tools_dir.mkdir(parents=True)
+        receipt = tools_dir / "uv-receipt.toml"
+        receipt.write_text(
+            '[tool]\nrequirements = [{ name = "test-package", editable = "/home/user/dev/test-package" }]\n'
+        )
+
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = get_tool_source("test-package")
+        assert result == ToolSource.LOCAL
+
+    def test_detects_github_git_installation(self, tmp_path, monkeypatch):
+        """Test that GitHub git installations are detected."""
+        tools_dir = tmp_path / "test-package"
+        tools_dir.mkdir(parents=True)
+        receipt = tools_dir / "uv-receipt.toml"
+        receipt.write_text(
+            '[tool]\nrequirements = [{ name = "test-package", git = "ssh://git@github.com/owner/repo.git" }]\n'
+        )
+
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = get_tool_source("test-package")
+        assert result == ToolSource.GITHUB
+
+    def test_detects_non_github_git_installation(self, tmp_path, monkeypatch):
+        """Test that non-GitHub git installations are also detected as GITHUB."""
+        tools_dir = tmp_path / "test-package"
+        tools_dir.mkdir(parents=True)
+        receipt = tools_dir / "uv-receipt.toml"
+        receipt.write_text(
+            '[tool]\nrequirements = [{ name = "test-package", git = "ssh://git@gitlab.com/owner/repo.git" }]\n'
+        )
+
+        monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = get_tool_source("test-package")
+        assert result == ToolSource.GITHUB
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestGetToolVersion:
+    """Tests for get_tool_version function."""
+
+    def test_exact_match_not_prefix(self, monkeypatch):
+        """Test that tool name must match exactly, not as a prefix."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True
+        )
+
+        class Result:
+            returncode = 0
+            stdout = "ai-agent-rules-extra v0.1.0\n  - ai-agent-rules-extra\nai-agent-rules v0.62.4\n  - ai-agent-rules\n"
+            stderr = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: Result())
+        version = get_tool_version("ai-agent-rules")
+        assert version == "0.62.4"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -443,8 +443,8 @@ class TestGetToolSource:
         result = get_tool_source("test-package")
         assert result == ToolSource.GITHUB
 
-    def test_detects_non_github_git_installation(self, tmp_path, monkeypatch):
-        """Test that non-GitHub git installations are also detected as GITHUB."""
+    def test_non_github_git_falls_through_to_pypi(self, tmp_path, monkeypatch):
+        """Test that non-GitHub git installations fall through to PYPI."""
         tools_dir = tmp_path / "test-package"
         tools_dir.mkdir(parents=True)
         receipt = tools_dir / "uv-receipt.toml"
@@ -455,7 +455,7 @@ class TestGetToolSource:
         monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path))
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         result = get_tool_source("test-package")
-        assert result == ToolSource.GITHUB
+        assert result == ToolSource.PYPI
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes several bugs in `get_tool_source()` and related install logic that caused managed config symlinks to point to the local repo checkout instead of the uv tool install directory.

The root cause: `get_tool_source()` didn't recognize the `editable` key in `uv-receipt.toml`, so editable local installs were misclassified as `PYPI`. Since the tool's own status reporting (`tool show`, `tool list`) always showed the wrong source, the real install state was invisible.

- add `"editable"` key detection in `get_tool_source()` to correctly classify editable installs as `LOCAL`
- detect GitHub git installs via `_is_github_git_reference()` while letting non-GitHub git URLs fall through to `PYPI` (downstream `perform_tool_upgrade()` uses a hardcoded `github.com` URL, so broadening beyond GitHub would silently reinstall from the wrong host)
- refine the `None` guard on `needs_source_switch` in `setup.py` to prevent spurious uninstall+reinstall when the receipt is missing, while still respecting explicit user intent (`--github` flag)
- fix `get_tool_version()` `startswith` prefix collision (`ai-agent-rules` would match `ai-agent-rules-extra`)
- replace hardcoded `sys.version_info` path in `get_tool_config_dir()` with a glob that discovers the actual Python version uv used for the tool venv, with Windows `Lib/site-packages/` fallback pattern