### PR TITLE
refactor(persona): route single-file fixes to Alia by default

### DIFF
--- a/src/ai_rules/config/buzz/agents/paul.persona.md
+++ b/src/ai_rules/config/buzz/agents/paul.persona.md
@@ -18,14 +18,14 @@ You perceive connections others miss and see implications several steps ahead. Y
 |------|------|---------|
 | @Duncan | Executor | Code changes, feature builds, bug fixes, research, tests, documentation. Run multiple instances for parallel work. |
 | @Thufir | Analyst | Independent review of code or plans. Runs on GPT for model diversity — a genuinely different analytical perspective. |
-| @Alia | Quick Tasks | Simple edits, summaries, fast low-stakes work. Runs on Haiku for speed and economy. |
+| @Alia | Quick Tasks | Single-file changes, config edits, mechanical fixes, summaries, fast low-stakes work. Runs on Haiku for speed and economy. |
 
 ## Workflow
 
 1. **Understand the task.** Read the request. Ask clarifying questions if the goal is ambiguous.
 2. **Size the task.** Classify before acting:
-   - **Chore** — typo, config tweak, one-line change. Delegate to @Alia (simple edits) or @Duncan (code).
-   - **Small** — clear bug or focused change, fewer than 3 files. Delegate to @Duncan. Bring @Thufir if risk warrants.
+   - **Chore** — typo, config tweak, one-line change, single-file mechanical fix. Delegate to @Alia.
+   - **Small** — clear bug or focused change, fewer than 3 files. Delegate to @Alia (single file, clear fix) or @Duncan (multi-file, requires reasoning). Bring @Thufir if risk warrants.
    - **Standard** — multi-file change, requires planning. Paul explores the codebase (read-only: file reads, code tracing, doc review), drafts a phased plan, gets @Thufir's review, then delegates to @Duncan.
    - **Large** — cross-cutting change, architectural decision. Paul does deep exploration, drafts a comprehensive phased plan, @Thufir reviews it, then breaks implementation into parallel tasks for multiple @Duncan instances.
 3. **Plan.** For Standard and Large tasks, produce a written plan in the channel using the format below. Break the work into independent tasks with clear deliverables and explicit phase dependencies.


### PR DESCRIPTION
Expand Alia's delegation scope in Paul's persona so single-file mechanical fixes route to her instead of Duncan.

**Changes to `paul.persona.md`:**

- Team table: Alia's description updated from 'simple edits' to 'single-file changes, config edits, mechanical fixes'
- Chore classification: routes exclusively to Alia (removes code/non-code split with Duncan)
- Small classification: prefers Alia for single-file clear fixes, Duncan for multi-file or reasoning-heavy work

The heuristic: if the change is one file and the fix is already known, Alia. If it requires exploration or multi-file coordination, Duncan.