### PR TITLE
refactor: codebase-wide simplification and consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,6 @@ uv run ai-agent-rules setup --github  # Install from GitHub instead of PyPI
 # Key CLI commands
 uv run ai-agent-rules install        # Install symlinks
 uv run ai-agent-rules status         # Check symlink status (shows diffs)
-uv run ai-agent-rules info           # Show installation method and version info
 uv run ai-agent-rules upgrade        # Upgrade to latest (shows changelogs)
 uv run ai-agent-rules validate       # Validate config files
 uv run ai-agent-rules diff           # Show diffs between repo and installed
@@ -53,7 +52,7 @@ uv run ai-agent-rules profile switch <name>  # Switch to different profile
 
 ## Tech Stack
 
-- Python 3.10+ with strict type checking (mypy)
+- Python 3.14+ with strict type checking (mypy)
 - **uv** for dependency management
 - **Click** for CLI framework
 - **Rich** for console output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,7 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]
@@ -71,7 +68,7 @@ explicit_package_bases = true
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["yaml.*", "tomli.*", "tomli_w.*", "shellingham.*"]
+module = ["yaml.*", "tomli_w.*", "shellingham.*"]
 ignore_missing_imports = true  # Only for external libs without stubs
 
 [[tool.mypy.overrides]]

--- a/src/ai_rules/agents/amp.py
+++ b/src/ai_rules/agents/amp.py
@@ -1,6 +1,5 @@
 """Amp agent implementation."""
 
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,46 +12,13 @@ if TYPE_CHECKING:
 class AmpAgent(Agent):
     """Agent for Amp configuration."""
 
-    @property
-    def name(self) -> str:
-        return "Amp"
-
-    @property
-    def agent_id(self) -> str:
-        return "amp"
-
-    @property
-    def config_file_name(self) -> str:
-        return "settings.json"
-
-    @property
-    def config_file_format(self) -> str:
-        return "json"
-
-    @property
-    def settings_symlink_target(self) -> Path:
-        return Path("~/.config/amp/settings.json")
-
-    @cached_property
-    def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Amp symlinks."""
-        result = []
-
-        result.append(
-            (
-                Path("~/.config/amp/AGENTS.md"),
-                self.config_dir / "amp" / "AGENTS.md",
-            )
-        )
-
-        config_file = self.config_dir / "amp" / "settings.json"
-        if config_file.exists():
-            target_file = self.config.get_settings_file_for_symlink(
-                "amp", config_file, force=bool(self._effective_preserved_fields)
-            )
-            result.append((Path("~/.config/amp/settings.json"), target_file))
-
-        return result
+    name = "Amp"
+    agent_id = "amp"
+    config_file_name = "settings.json"
+    config_file_format = "json"
+    settings_symlink_target = Path("~/.config/amp/settings.json")
+    instructions_target = "~/.config/amp/AGENTS.md"
+    instructions_source = "AGENTS.md"
 
     def get_mcp_manager(self) -> MCPManager:
         from ai_rules.mcp import AmpMCPManager

--- a/src/ai_rules/agents/base.py
+++ b/src/ai_rules/agents/base.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ai_rules.targets.base import ConfigTarget
 
@@ -15,6 +16,11 @@ if TYPE_CHECKING:
 
 class Agent(ConfigTarget):
     """Base class for AI agent configuration managers."""
+
+    # Declarative instruction-file symlink. Agents with a runtime-resolved
+    # location (e.g. Goose) override _instruction_symlinks() instead.
+    instructions_target: ClassVar[str | None] = None
+    instructions_source: ClassVar[str | None] = None
 
     @property
     def target_id(self) -> str:
@@ -29,6 +35,41 @@ class Agent(ConfigTarget):
     def agent_id(self) -> str:
         """Short identifier for the agent (e.g., 'claude', 'goose')."""
         pass
+
+    def _instruction_symlinks(self) -> list[tuple[Path, Path]]:
+        """Symlinks for the agent's instruction file (CLAUDE.md, AGENTS.md, ...)."""
+        if self.instructions_target is None or self.instructions_source is None:
+            return []
+        return [
+            (
+                Path(self.instructions_target),
+                self.config_dir / self.target_id / self.instructions_source,
+            )
+        ]
+
+    def _settings_symlinks(self) -> list[tuple[Path, Path]]:
+        """Symlink for the agent's settings file, if the bundled file exists."""
+        config_file = self._base_settings_path
+        target = self.settings_symlink_target
+        if target is None or not config_file.exists():
+            return []
+        target_file = self.config.get_settings_file_for_symlink(
+            self.target_id, config_file, force=bool(self._effective_preserved_fields)
+        )
+        return [(target, target_file)]
+
+    def _extra_symlinks(self) -> list[tuple[Path, Path]]:
+        """Hook for additional agent-specific symlinks (e.g. Claude extensions)."""
+        return []
+
+    @cached_property
+    def symlinks(self) -> list[tuple[Path, Path]]:
+        """Cached list of all agent symlinks (instructions, settings, extras)."""
+        return (
+            self._instruction_symlinks()
+            + self._settings_symlinks()
+            + self._extra_symlinks()
+        )
 
     def get_mcp_manager(self) -> MCPManager | None:
         """Return the agent-specific MCPManager, or None if MCP is unsupported."""

--- a/src/ai_rules/agents/claude.py
+++ b/src/ai_rules/agents/claude.py
@@ -1,6 +1,5 @@
 """Claude Code agent implementation."""
 
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -19,45 +18,18 @@ class ClaudeAgent(Agent):
         Path("~/CLAUDE.md"),
     ]
 
-    @property
-    def name(self) -> str:
-        return "Claude Code"
+    name = "Claude Code"
+    agent_id = "claude"
+    config_file_name = "settings.json"
+    config_file_format = "json"
+    preserved_fields = ["enabledPlugins", "hooks"]
+    settings_symlink_target = Path("~/.claude/settings.json")
+    instructions_target = "~/.claude/CLAUDE.md"
+    instructions_source = "CLAUDE.md"
 
-    @property
-    def agent_id(self) -> str:
-        return "claude"
-
-    @property
-    def config_file_name(self) -> str:
-        return "settings.json"
-
-    @property
-    def config_file_format(self) -> str:
-        return "json"
-
-    @property
-    def preserved_fields(self) -> list[str]:
-        return ["enabledPlugins", "hooks"]
-
-    @property
-    def settings_symlink_target(self) -> Path:
-        return Path("~/.claude/settings.json")
-
-    @cached_property
-    def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Claude Code symlinks including dynamic agents/commands."""
+    def _extra_symlinks(self) -> list[tuple[Path, Path]]:
+        """Dynamic symlinks for bundled agents, commands, and hooks."""
         result = []
-
-        result.append(
-            (Path("~/.claude/CLAUDE.md"), self.config_dir / "claude" / "CLAUDE.md")
-        )
-
-        settings_file = self.config_dir / "claude" / "settings.json"
-        if settings_file.exists():
-            target_file = self.config.get_settings_file_for_symlink(
-                "claude", settings_file, force=bool(self._effective_preserved_fields)
-            )
-            result.append((Path("~/.claude/settings.json"), target_file))
 
         agents_dir = self.config_dir / "claude" / "agents"
         if agents_dir.exists():

--- a/src/ai_rules/agents/codex.py
+++ b/src/ai_rules/agents/codex.py
@@ -1,6 +1,5 @@
 """Codex CLI agent implementation."""
 
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,50 +12,14 @@ if TYPE_CHECKING:
 class CodexAgent(Agent):
     """Agent for Codex CLI configuration."""
 
-    @property
-    def name(self) -> str:
-        return "Codex CLI"
-
-    @property
-    def agent_id(self) -> str:
-        return "codex"
-
-    @property
-    def config_file_name(self) -> str:
-        return "config.toml"
-
-    @property
-    def config_file_format(self) -> str:
-        return "toml"
-
-    @property
-    def preserved_fields(self) -> list[str]:
-        return ["projects"]
-
-    @property
-    def settings_symlink_target(self) -> Path:
-        return Path("~/.codex/config.toml")
-
-    @cached_property
-    def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Codex CLI symlinks."""
-        result = []
-
-        result.append(
-            (
-                Path("~/.codex/AGENTS.md"),
-                self.config_dir / "codex" / "AGENTS.md",
-            )
-        )
-
-        config_file = self.config_dir / "codex" / "config.toml"
-        if config_file.exists():
-            target_file = self.config.get_settings_file_for_symlink(
-                "codex", config_file, force=bool(self._effective_preserved_fields)
-            )
-            result.append((Path("~/.codex/config.toml"), target_file))
-
-        return result
+    name = "Codex CLI"
+    agent_id = "codex"
+    config_file_name = "config.toml"
+    config_file_format = "toml"
+    preserved_fields = ["projects"]
+    settings_symlink_target = Path("~/.codex/config.toml")
+    instructions_target = "~/.codex/AGENTS.md"
+    instructions_source = "AGENTS.md"
 
     def get_mcp_manager(self) -> MCPManager:
         from ai_rules.mcp import CodexMCPManager

--- a/src/ai_rules/agents/gemini.py
+++ b/src/ai_rules/agents/gemini.py
@@ -1,6 +1,5 @@
 """Gemini CLI agent implementation."""
 
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,29 +12,14 @@ if TYPE_CHECKING:
 class GeminiAgent(Agent):
     """Agent for Gemini CLI configuration."""
 
-    @property
-    def name(self) -> str:
-        return "Gemini CLI"
-
-    @property
-    def agent_id(self) -> str:
-        return "gemini"
-
-    @property
-    def config_file_name(self) -> str:
-        return "settings.json"
-
-    @property
-    def config_file_format(self) -> str:
-        return "json"
-
-    @property
-    def preserved_fields(self) -> list[str]:
-        return ["ide"]
-
-    @property
-    def settings_symlink_target(self) -> Path:
-        return Path("~/.gemini/settings.json")
+    name = "Gemini CLI"
+    agent_id = "gemini"
+    config_file_name = "settings.json"
+    config_file_format = "json"
+    preserved_fields = ["ide"]
+    settings_symlink_target = Path("~/.gemini/settings.json")
+    instructions_target = "~/.gemini/GEMINI.md"
+    instructions_source = "GEMINI.md"
 
     @property
     def copy_mode_targets(self) -> set[Path]:
@@ -44,27 +28,6 @@ class GeminiAgent(Agent):
         if is_platform(Platform.WINDOWS):
             return {self.settings_symlink_target.expanduser()}
         return set()
-
-    @cached_property
-    def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Gemini CLI symlinks."""
-        result = []
-
-        result.append(
-            (
-                Path("~/.gemini/GEMINI.md"),
-                self.config_dir / "gemini" / "GEMINI.md",
-            )
-        )
-
-        config_file = self.config_dir / "gemini" / "settings.json"
-        if config_file.exists():
-            target_file = self.config.get_settings_file_for_symlink(
-                "gemini", config_file, force=bool(self._effective_preserved_fields)
-            )
-            result.append((Path("~/.gemini/settings.json"), target_file))
-
-        return result
 
     def get_mcp_manager(self) -> MCPManager:
         from ai_rules.mcp import GeminiMCPManager

--- a/src/ai_rules/agents/goose.py
+++ b/src/ai_rules/agents/goose.py
@@ -1,6 +1,5 @@
 """Goose agent implementation."""
 
-from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,50 +13,24 @@ if TYPE_CHECKING:
 class GooseAgent(Agent):
     """Agent for Goose configuration."""
 
-    @property
-    def name(self) -> str:
-        return "Goose"
-
-    @property
-    def agent_id(self) -> str:
-        return "goose"
-
-    @property
-    def config_file_name(self) -> str:
-        return "config.yaml"
-
-    @property
-    def config_file_format(self) -> str:
-        return "yaml"
-
-    @property
-    def preserved_fields(self) -> list[str]:
-        return ["extensions"]
+    name = "Goose"
+    agent_id = "goose"
+    config_file_name = "config.yaml"
+    config_file_format = "yaml"
+    preserved_fields = ["extensions"]
 
     @property
     def settings_symlink_target(self) -> Path:
+        # Resolved at runtime: the Goose config dir is platform-specific.
         return get_goose_config_dir() / "config.yaml"
 
-    @cached_property
-    def symlinks(self) -> list[tuple[Path, Path]]:
-        """Cached list of all Goose symlinks."""
-        result = []
-
-        result.append(
+    def _instruction_symlinks(self) -> list[tuple[Path, Path]]:
+        return [
             (
                 get_goose_config_dir() / ".goosehints",
                 self.config_dir / "goose" / ".goosehints",
             )
-        )
-
-        config_file = self.config_dir / "goose" / "config.yaml"
-        if config_file.exists():
-            target_file = self.config.get_settings_file_for_symlink(
-                "goose", config_file, force=bool(self._effective_preserved_fields)
-            )
-            result.append((get_goose_config_dir() / "config.yaml", target_file))
-
-        return result
+        ]
 
     def get_mcp_manager(self) -> MCPManager:
         from ai_rules.mcp import GooseMCPManager

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -336,6 +336,96 @@ def get_effective_install_source(
     return ToolSource.PYPI, None
 
 
+def _switch_tool_source(
+    spec: ToolSpec,
+    source: ToolSource,
+    local_path: str | None,
+    dry_run: bool,
+) -> tuple[str, str | None] | None:
+    """Reinstall an installed tool from the desired source, if it differs.
+
+    Returns None when the current source already matches (or is unknown).
+    """
+    current_source = get_tool_source(spec.package_name)
+    if current_source is None or current_source == source:
+        return None
+
+    if dry_run:
+        return (
+            "source_switch_needed",
+            f"Would switch {spec.display_name} from {current_source.name} to {source.name}",
+        )
+
+    uninstall_success, _ = uninstall_tool(spec.package_name)
+    if uninstall_success:
+        from_github = source == ToolSource.GITHUB
+        github_url = spec.github_install_url if from_github else None
+        success, _ = install_tool(
+            spec.package_name,
+            from_github=from_github,
+            github_url=github_url,
+            local_path=local_path,
+            force=True,
+        )
+        if success:
+            return "source_switched", f"{current_source.name} → {source.name}"
+    return "failed", None
+
+
+def _reinstall_local(
+    spec: ToolSpec, local_path: str | None, dry_run: bool
+) -> tuple[str, str | None]:
+    """LOCAL source: always reinstall to pick up latest local changes."""
+    success, message = install_tool(
+        spec.package_name,
+        local_path=local_path,
+        force=True,
+        dry_run=dry_run,
+    )
+    if dry_run:
+        return "upgrade_available", message
+    if success:
+        return "upgraded", "reinstalled from local path"
+    return "failed", None
+
+
+def _check_and_apply_upgrade(
+    spec: ToolSpec, dry_run: bool
+) -> tuple[str, str | None] | None:
+    """Upgrade an installed tool when an update is available. Fails open.
+
+    Returns None when nothing was (or would be) upgraded.
+    """
+    try:
+        from ai_rules.bootstrap.updater import (
+            check_tool_updates,
+            perform_tool_upgrade,
+        )
+
+        update_info = check_tool_updates(spec, timeout=10)
+        if update_info and update_info.check_failed:
+            import logging
+
+            logging.getLogger(__name__).debug(
+                f"Update check failed for {spec.display_name}, skipping upgrade"
+            )
+        elif update_info and update_info.has_update:
+            if dry_run:
+                return (
+                    "upgrade_available",
+                    f"Would upgrade {spec.display_name} {update_info.current_version} → {update_info.latest_version}",
+                )
+            success, msg, _ = perform_tool_upgrade(spec)
+            if success:
+                return (
+                    "upgraded",
+                    f"{update_info.current_version} → {update_info.latest_version}",
+                )
+    except Exception:
+        pass
+    return None
+
+
 def ensure_tool_installed(
     spec: ToolSpec,
     dry_run: bool = False,
@@ -361,79 +451,23 @@ def ensure_tool_installed(
         "source_switched", "source_switch_needed", "failed"
         Message is only provided in dry_run mode or when upgraded/switched
     """
-    from_github = source == ToolSource.GITHUB
-
     if spec.is_installed():
         if allow_source_switch:
-            current_source = get_tool_source(spec.package_name)
-            if current_source is not None and current_source != source:
-                if dry_run:
-                    return (
-                        "source_switch_needed",
-                        f"Would switch {spec.display_name} from {current_source.name} to {source.name}",
-                    )
-                uninstall_success, _ = uninstall_tool(spec.package_name)
-                if uninstall_success:
-                    github_url = spec.github_install_url if from_github else None
-                    success, _ = install_tool(
-                        spec.package_name,
-                        from_github=from_github,
-                        github_url=github_url,
-                        local_path=local_path,
-                        force=True,
-                    )
-                    if success:
-                        return (
-                            "source_switched",
-                            f"{current_source.name} → {source.name}",
-                        )
-                return "failed", None
+            switched = _switch_tool_source(spec, source, local_path, dry_run)
+            if switched is not None:
+                return switched
 
         if source == ToolSource.LOCAL:
-            # LOCAL source: always reinstall to pick up latest local changes
-            success, message = install_tool(
-                spec.package_name,
-                local_path=local_path,
-                force=True,
-                dry_run=dry_run,
-            )
-            if dry_run:
-                return "upgrade_available", message
-            if success:
-                return "upgraded", "reinstalled from local path"
-            return "failed", None
+            return _reinstall_local(spec, local_path, dry_run)
 
         if not skip_update_check:
-            try:
-                from ai_rules.bootstrap.updater import (
-                    check_tool_updates,
-                    perform_tool_upgrade,
-                )
-
-                update_info = check_tool_updates(spec, timeout=10)
-                if update_info and update_info.check_failed:
-                    import logging
-
-                    logging.getLogger(__name__).debug(
-                        f"Update check failed for {spec.display_name}, skipping upgrade"
-                    )
-                elif update_info and update_info.has_update:
-                    if dry_run:
-                        return (
-                            "upgrade_available",
-                            f"Would upgrade {spec.display_name} {update_info.current_version} → {update_info.latest_version}",
-                        )
-                    success, msg, _ = perform_tool_upgrade(spec)
-                    if success:
-                        return (
-                            "upgraded",
-                            f"{update_info.current_version} → {update_info.latest_version}",
-                        )
-            except Exception:
-                pass
+            upgraded = _check_and_apply_upgrade(spec, dry_run)
+            if upgraded is not None:
+                return upgraded
         return "already_installed", None
 
     try:
+        from_github = source == ToolSource.GITHUB
         github_url = spec.github_install_url if from_github else None
         success, message = install_tool(
             spec.package_name,

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -498,11 +498,10 @@ _SELF_SPEC = ToolSpec(
 
 
 def get_updatable_tools() -> list[ToolSpec]:
-    """Get all updatable tool specs, deriving from registered Tool classes."""
-    from ai_rules.tools.statusline import StatuslineTool
+    """Get all updatable tool specs: self plus every registered active tool."""
+    from ai_rules.bootstrap.registry import ACTIVE_TOOLS
 
-    tools: list[ToolSpec] = [_SELF_SPEC, StatuslineTool.INSTALL_SPEC]
-    return tools
+    return [_SELF_SPEC, *(tool.get_install_spec() for tool in ACTIVE_TOOLS)]
 
 
 def check_tool_updates(tool: ToolSpec, timeout: int = 30) -> UpdateInfo | None:

--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -141,9 +141,10 @@ class ClaudeExtensionManager:
     def get_all_orphaned(self) -> dict[str, dict[str, Path]]:
         """Get all orphaned symlinks across all extension types."""
         return {
-            "commands": self.get_orphaned_symlinks(Path("~/.claude/commands"), "*.md"),
-            "agents": self.get_orphaned_symlinks(Path("~/.claude/agents"), "*.md"),
-            "hooks": self.get_orphaned_symlinks(Path("~/.claude/hooks"), "*.py"),
+            ext_type: self.get_orphaned_symlinks(
+                self.USER_DIRS[ext_type], self.PATTERNS[ext_type]
+            )
+            for ext_type in self.USER_DIRS
         }
 
     def _get_configured_hooks(self, settings: dict[str, Any]) -> set[str]:
@@ -188,10 +189,12 @@ class ClaudeExtensionManager:
         Returns:
             dict mapping hook name -> installed path for orphaned hooks
         """
-        orphaned = self.get_orphaned_symlinks(Path("~/.claude/hooks"), "*.py")
+        orphaned = self.get_orphaned_symlinks(
+            self.USER_DIRS["hooks"], self.PATTERNS["hooks"]
+        )
 
         configured_hooks = self._get_configured_hooks(settings)
-        user_hooks_dir = Path("~/.claude/hooks").expanduser()
+        user_hooks_dir = self.USER_DIRS["hooks"].expanduser()
         if user_hooks_dir.exists():
             for hook_file in user_hooks_dir.glob("*.py"):
                 if hook_file.is_symlink() and hook_file.name not in configured_hooks:
@@ -208,7 +211,7 @@ class ClaudeExtensionManager:
         """Get comprehensive status of Claude extensions (agents, commands, hooks)."""
         status = ClaudeExtensionStatus()
 
-        for ext_type in ["agents", "commands", "hooks"]:
+        for ext_type in self.USER_DIRS:
             type_status = getattr(status, ext_type)
             managed_sources = self._get_managed_extensions(ext_type)
             installed = self._scan_installed_extensions(ext_type)

--- a/src/ai_rules/claude_extensions.py
+++ b/src/ai_rules/claude_extensions.py
@@ -139,7 +139,11 @@ class ClaudeExtensionManager:
         return orphaned
 
     def get_all_orphaned(self) -> dict[str, dict[str, Path]]:
-        """Get all orphaned symlinks across all extension types."""
+        """Get all orphaned symlinks across all extension types.
+
+        Iterates in USER_DIRS order (agents, commands, hooks), consistent with
+        every other extension-type iteration in the codebase.
+        """
         return {
             ext_type: self.get_orphaned_symlinks(
                 self.USER_DIRS[ext_type], self.PATTERNS[ext_type]

--- a/src/ai_rules/cli/__init__.py
+++ b/src/ai_rules/cli/__init__.py
@@ -10,6 +10,12 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from ai_rules.cli.helpers import (
+    agents_option as agents_option,
+)
+from ai_rules.cli.helpers import (
+    build_cli_context as build_cli_context,
+)
+from ai_rules.cli.helpers import (
     complete_components as complete_components,
 )
 from ai_rules.cli.helpers import (
@@ -29,6 +35,12 @@ from ai_rules.cli.helpers import (
 )
 from ai_rules.cli.helpers import (
     get_user_config_path as get_user_config_path,
+)
+from ai_rules.cli.helpers import (
+    only_option as only_option,
+)
+from ai_rules.cli.helpers import (
+    save_user_config_and_report as save_user_config_and_report,
 )
 from ai_rules.cli.helpers import (
     select_components as select_components,
@@ -76,7 +88,7 @@ def _display_pending_symlink_changes(targets: list[ConfigTarget]) -> bool:
     """
     from ai_rules.cli.components.config import _get_copy_mode_targets
     from ai_rules.cli.display import console, print_add, print_update
-    from ai_rules.symlinks import check_file_copy, check_symlink, get_content_diff
+    from ai_rules.symlinks import check_file_copy, check_symlink, get_status_diff
 
     found_changes = False
     copy_targets = _get_copy_mode_targets(targets)
@@ -104,15 +116,7 @@ def _display_pending_symlink_changes(targets: list[ConfigTarget]) -> bool:
                 "stale_copy",
                 "not_copy",
             ]:
-                diff_output = None
-                try:
-                    if status_code == "wrong_target":
-                        actual = target_path.resolve()
-                        diff_output = get_content_diff(actual, source)
-                    elif status_code in ("not_symlink", "stale_copy"):
-                        diff_output = get_content_diff(target_path, source)
-                except OSError, RuntimeError:
-                    pass
+                diff_output = get_status_diff(status_code, target_path, source)
                 agent_changes.append(("update", target_path, source, diff_output))
 
         if agent_changes:

--- a/src/ai_rules/cli/commands/diff.py
+++ b/src/ai_rules/cli/commands/diff.py
@@ -1,64 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
 
 import ai_rules.cli as cli_facade
 
-if TYPE_CHECKING:
-    from click.shell_completion import CompletionItem
-
-
-def _complete_components(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    from ai_rules.cli.components import DIFF_COMPONENTS
-
-    ids = tuple(c.component_id for c in DIFF_COMPONENTS)
-    return cli_facade.complete_components(ctx, param, incomplete, component_ids=ids)
-
 
 @click.command()
-@click.option(
-    "--agents",
-    help="Comma-separated list of agents to check (default: all)",
-    shell_complete=cli_facade.complete_targets,
-)
-@click.option(
-    "--only",
-    "component_filter",
-    help="Comma-separated list of components to target (default: all)",
-    shell_complete=_complete_components,
-)
+@cli_facade.agents_option("check")
+@cli_facade.only_option("DIFF_COMPONENTS")
 def diff(agents: str | None, component_filter: str | None) -> None:
     """Show differences between repo configs and installed symlinks."""
     from ai_rules.cli.components import DIFF_COMPONENTS
-    from ai_rules.cli.context import CliContext
     from ai_rules.cli.display import console, print_hint
-    from ai_rules.cli.runner import run_diff_parallel
-    from ai_rules.config import Config
+    from ai_rules.cli.runner import run_parallel
 
-    config_dir = cli_facade.get_config_dir()
-    config = Config.load()
-    all_targets = cli_facade.get_targets(config_dir, config)
-    selected_targets = cli_facade.select_targets(all_targets, agents)
-
-    parsed_filter = cli_facade.select_components(DIFF_COMPONENTS, component_filter)
+    cli_ctx = cli_facade.build_cli_context(DIFF_COMPONENTS, agents, component_filter)
 
     console.print("[bold]Configuration Differences[/bold]\n")
 
-    cli_ctx = CliContext(
-        console=console,
-        config_dir=config_dir,
-        config=config,
-        profile_name=config.profile_name,
-        all_targets=tuple(all_targets),
-        selected_targets=tuple(selected_targets),
-        target_filter=agents,
-        component_filter=parsed_filter,
-    )
-    result = run_diff_parallel(DIFF_COMPONENTS, cli_ctx)
+    result = run_parallel(DIFF_COMPONENTS, "diff", cli_ctx)
 
     if not result.changed:
         console.print("[green]No differences found - all symlinks are correct![/green]")

--- a/src/ai_rules/cli/commands/install.py
+++ b/src/ai_rules/cli/commands/install.py
@@ -3,28 +3,15 @@ from __future__ import annotations
 import sys
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
 
 import ai_rules.cli as cli_facade
 
-if TYPE_CHECKING:
-    from click.shell_completion import CompletionItem
-
 from ai_rules.cli.groups.profile import (
     _detect_profile_override_conflicts,
     _handle_profile_conflicts,
 )
-
-
-def _complete_components(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    from ai_rules.cli.components import INSTALL_COMPONENTS
-
-    ids = tuple(c.component_id for c in INSTALL_COMPONENTS if c.filterable)
-    return cli_facade.complete_components(ctx, param, incomplete, component_ids=ids)
 
 
 @click.command()
@@ -40,17 +27,8 @@ def _complete_components(
     is_flag=True,
     help="Rebuild merged settings cache (use after changing overrides)",
 )
-@click.option(
-    "--agents",
-    help="Comma-separated list of agents to install (default: all)",
-    shell_complete=cli_facade.complete_targets,
-)
-@click.option(
-    "--only",
-    "component_filter",
-    help="Comma-separated list of components to target (default: all)",
-    shell_complete=_complete_components,
-)
+@cli_facade.agents_option("install")
+@cli_facade.only_option("INSTALL_COMPONENTS", filterable_only=True)
 @click.option(
     "--skip-completions",
     is_flag=True,
@@ -81,7 +59,6 @@ def install(
 ) -> None:
     """Install AI agent configs via symlinks."""
     from ai_rules.cli.components import INSTALL_COMPONENTS
-    from ai_rules.cli.context import CliContext
     from ai_rules.cli.display import console, print_error
     from ai_rules.cli.runner import run_install_parallel
     from ai_rules.config import Config
@@ -129,9 +106,6 @@ def install(
         print_label("Using profile", profile)
         console.print()
 
-    all_targets = cli_facade.get_targets(config_dir, config)
-    selected_targets = cli_facade.select_targets(all_targets, agents)
-
     from ai_rules.cli.components.agents_md import AgentsMdComponent
     from ai_rules.cli.components.settings import SettingsComponent
 
@@ -147,17 +121,13 @@ def install(
         if not isinstance(c, (SettingsComponent, AgentsMdComponent))
     )
 
-    parsed_filter = cli_facade.select_components(INSTALL_COMPONENTS, component_filter)
-
-    cli_ctx = CliContext(
-        console=console,
+    cli_ctx = cli_facade.build_cli_context(
+        INSTALL_COMPONENTS,
+        agents,
+        component_filter,
         config_dir=config_dir,
         config=config,
         profile_name=profile,
-        all_targets=tuple(all_targets),
-        selected_targets=tuple(selected_targets),
-        target_filter=agents,
-        component_filter=parsed_filter,
         yes=yes,
         dry_run=dry_run,
         rebuild_cache=rebuild_cache,

--- a/src/ai_rules/cli/commands/status.py
+++ b/src/ai_rules/cli/commands/status.py
@@ -2,52 +2,22 @@ from __future__ import annotations
 
 import sys
 
-from typing import TYPE_CHECKING
-
 import click
 
 import ai_rules.cli as cli_facade
 
-if TYPE_CHECKING:
-    from click.shell_completion import CompletionItem
-
-
-def _complete_components(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    from ai_rules.cli.components import STATUS_COMPONENTS
-
-    ids = tuple(c.component_id for c in STATUS_COMPONENTS)
-    return cli_facade.complete_components(ctx, param, incomplete, component_ids=ids)
-
 
 @click.command()
-@click.option(
-    "--agents",
-    help="Comma-separated list of agents to check (default: all)",
-    shell_complete=cli_facade.complete_targets,
-)
-@click.option(
-    "--only",
-    "component_filter",
-    help="Comma-separated list of components to target (default: all)",
-    shell_complete=_complete_components,
-)
+@cli_facade.agents_option("check")
+@cli_facade.only_option("STATUS_COMPONENTS")
 def status(agents: str | None, component_filter: str | None) -> None:
     """Check status of AI agent symlinks."""
     from ai_rules.cli.components import STATUS_COMPONENTS
-    from ai_rules.cli.context import CliContext
     from ai_rules.cli.display import console, print_hint
-    from ai_rules.cli.runner import run_status_parallel
-    from ai_rules.config import Config
+    from ai_rules.cli.runner import run_parallel
     from ai_rules.state import get_active_profile
 
-    config_dir = cli_facade.get_config_dir()
-    config = Config.load()
-    all_targets = cli_facade.get_targets(config_dir, config)
-    selected_targets = cli_facade.select_targets(all_targets, agents)
-
-    parsed_filter = cli_facade.select_components(STATUS_COMPONENTS, component_filter)
+    cli_ctx = cli_facade.build_cli_context(STATUS_COMPONENTS, agents, component_filter)
 
     console.print("[bold]AI Rules Status[/bold]\n")
 
@@ -58,17 +28,7 @@ def status(agents: str | None, component_filter: str | None) -> None:
         print_label("Profile", active_profile)
         console.print()
 
-    cli_ctx = CliContext(
-        console=console,
-        config_dir=config_dir,
-        config=config,
-        profile_name=config.profile_name or active_profile,
-        all_targets=tuple(all_targets),
-        selected_targets=tuple(selected_targets),
-        target_filter=agents,
-        component_filter=parsed_filter,
-    )
-    result = run_status_parallel(STATUS_COMPONENTS, cli_ctx)
+    result = run_parallel(STATUS_COMPONENTS, "status", cli_ctx)
 
     if not result.ok:
         if result.counts.get("cache_stale", 0):

--- a/src/ai_rules/cli/commands/uninstall.py
+++ b/src/ai_rules/cli/commands/uninstall.py
@@ -2,75 +2,36 @@ from __future__ import annotations
 
 import sys
 
-from typing import TYPE_CHECKING
-
 import click
 
 import ai_rules.cli as cli_facade
 
-if TYPE_CHECKING:
-    from click.shell_completion import CompletionItem
-
-
-def _complete_components(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    from ai_rules.cli.components import UNINSTALL_COMPONENTS
-
-    ids = tuple(c.component_id for c in UNINSTALL_COMPONENTS)
-    return cli_facade.complete_components(ctx, param, incomplete, component_ids=ids)
-
 
 @click.command()
 @click.option("-y", "--yes", is_flag=True, help="Auto-confirm without prompting")
-@click.option(
-    "--agents",
-    help="Comma-separated list of agents to uninstall (default: all)",
-    shell_complete=cli_facade.complete_targets,
-)
-@click.option(
-    "--only",
-    "component_filter",
-    help="Comma-separated list of components to target (default: all)",
-    shell_complete=_complete_components,
-)
+@cli_facade.agents_option("uninstall")
+@cli_facade.only_option("UNINSTALL_COMPONENTS")
 def uninstall(yes: bool, agents: str | None, component_filter: str | None) -> None:
     """Remove AI agent symlinks."""
     from ai_rules.cli.components import UNINSTALL_COMPONENTS
-    from ai_rules.cli.context import CliContext
     from ai_rules.cli.display import console, print_warning
-    from ai_rules.cli.runner import run_uninstall_parallel
-    from ai_rules.config import Config
+    from ai_rules.cli.runner import run_parallel
 
-    config_dir = cli_facade.get_config_dir()
-    config = Config.load()
-    all_targets = cli_facade.get_targets(config_dir, config)
-    selected_targets = cli_facade.select_targets(all_targets, agents)
-
-    parsed_filter = cli_facade.select_components(UNINSTALL_COMPONENTS, component_filter)
+    cli_ctx = cli_facade.build_cli_context(
+        UNINSTALL_COMPONENTS, agents, component_filter, yes=yes
+    )
 
     if not yes:
         print_warning("This will remove symlinks for:\n")
         console.print("[bold]Agents:[/bold]")
-        for target in selected_targets:
+        for target in cli_ctx.selected_targets:
             console.print(f"  • {target.name}")
         console.print()
         if not click.confirm("Continue?", default=False):
             print_warning("Uninstall cancelled")
             sys.exit(0)
 
-    cli_ctx = CliContext(
-        console=console,
-        config_dir=config_dir,
-        config=config,
-        profile_name=config.profile_name,
-        all_targets=tuple(all_targets),
-        selected_targets=tuple(selected_targets),
-        target_filter=agents,
-        component_filter=parsed_filter,
-        yes=yes,
-    )
-    result = run_uninstall_parallel(UNINSTALL_COMPONENTS, cli_ctx)
+    result = run_parallel(UNINSTALL_COMPONENTS, "uninstall", cli_ctx)
 
     console.print(
         f"\n[bold]Summary:[/bold] Removed {result.counts.get('removed', 0)}, "

--- a/src/ai_rules/cli/commands/validate.py
+++ b/src/ai_rules/cli/commands/validate.py
@@ -2,65 +2,27 @@ from __future__ import annotations
 
 import sys
 
-from typing import TYPE_CHECKING
-
 import click
 
 import ai_rules.cli as cli_facade
 
-if TYPE_CHECKING:
-    from click.shell_completion import CompletionItem
-
-
-def _complete_components(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    from ai_rules.cli.components import VALIDATE_COMPONENTS
-
-    ids = tuple(c.component_id for c in VALIDATE_COMPONENTS)
-    return cli_facade.complete_components(ctx, param, incomplete, component_ids=ids)
-
 
 @click.command()
-@click.option(
-    "--agents",
-    help="Comma-separated list of agents to validate (default: all)",
-    shell_complete=cli_facade.complete_targets,
-)
-@click.option(
-    "--only",
-    "component_filter",
-    help="Comma-separated list of components to target (default: all)",
-    shell_complete=_complete_components,
-)
+@cli_facade.agents_option("validate")
+@cli_facade.only_option("VALIDATE_COMPONENTS")
 def validate(agents: str | None, component_filter: str | None) -> None:
     """Validate configuration and source files."""
     from ai_rules.cli.components import VALIDATE_COMPONENTS
-    from ai_rules.cli.context import CliContext
     from ai_rules.cli.display import console, print_error
-    from ai_rules.cli.runner import run_validate_parallel
-    from ai_rules.config import Config
+    from ai_rules.cli.runner import run_parallel
 
-    config_dir = cli_facade.get_config_dir()
-    config = Config.load()
-    all_targets = cli_facade.get_targets(config_dir, config)
-    selected_targets = cli_facade.select_targets(all_targets, agents)
-
-    parsed_filter = cli_facade.select_components(VALIDATE_COMPONENTS, component_filter)
+    cli_ctx = cli_facade.build_cli_context(
+        VALIDATE_COMPONENTS, agents, component_filter
+    )
 
     console.print("[bold]Validating AI Rules Configuration[/bold]\n")
 
-    cli_ctx = CliContext(
-        console=console,
-        config_dir=config_dir,
-        config=config,
-        profile_name=config.profile_name,
-        all_targets=tuple(all_targets),
-        selected_targets=tuple(selected_targets),
-        target_filter=agents,
-        component_filter=parsed_filter,
-    )
-    result = run_validate_parallel(VALIDATE_COMPONENTS, cli_ctx)
+    result = run_parallel(VALIDATE_COMPONENTS, "validate", cli_ctx)
     total_checked = result.counts.get("checked", 0)
     total_issues = result.counts.get("errors", 0)
 

--- a/src/ai_rules/cli/components/agents_md.py
+++ b/src/ai_rules/cli/components/agents_md.py
@@ -109,9 +109,6 @@ class AgentsMdComponent(Component):
 
         return ComponentResult(ok=False, changed=True, counts={"cache_stale": 1})
 
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)
-
     def uninstall(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.config import Config
 

--- a/src/ai_rules/cli/components/config.py
+++ b/src/ai_rules/cli/components/config.py
@@ -38,6 +38,18 @@ def _get_copy_mode_targets(agents: list[ConfigTarget]) -> set[Path]:
     return result
 
 
+# status_code -> (severity, fixed annotation or None to use the check message)
+_STATUS_DISPLAY: dict[str, tuple[str, str | None]] = {
+    "missing": ("error", "not installed"),
+    "broken": ("error", "broken symlink"),
+    "wrong_target": ("warning", None),
+    "not_symlink": ("warning", "not a symlink"),
+    "stale_copy": ("warning", "copy out of date"),
+    "not_copy": ("warning", "expected managed copy, found symlink"),
+    "error": ("error", None),
+}
+
+
 def _display_symlink_status(
     status_code: str,
     target: Path,
@@ -53,68 +65,29 @@ def _display_symlink_status(
         print_success,
         print_warning,
     )
-    from ai_rules.symlinks import get_content_diff
+    from ai_rules.symlinks import get_status_diff
 
-    active_console: Console = console or get_console()
-
-    target_str = str(target)
+    target_display = str(target)
     if source.is_dir():
-        target_str = target_str.rstrip("/") + "/"
-    target_display = target_str
+        target_display = target_display.rstrip("/") + "/"
 
     if status_code == "correct":
         print_success(target_display, indent=2)
         return True
-    if status_code == "missing":
-        print_error(f"{target_display} {dim('(not installed)')}", indent=2)
-        return False
-    if status_code == "broken":
-        print_error(f"{target_display} {dim('(broken symlink)')}", indent=2)
-        return False
-    if status_code == "wrong_target":
-        print_warning(f"{target_display} {dim(f'({message})')}", indent=2)
 
-        try:
-            actual = target.expanduser().resolve()
-            diff_output = get_content_diff(actual, source)
-            if diff_output:
-                active_console.print(diff_output)
-        except OSError, RuntimeError:
-            pass
+    if status_code not in _STATUS_DISPLAY:
+        return True
 
-        return False
-    if status_code == "not_symlink":
-        print_warning(f"{target_display} {dim('(not a symlink)')}", indent=2)
+    severity, annotation = _STATUS_DISPLAY[status_code]
+    printer = print_error if severity == "error" else print_warning
+    printer(f"{target_display} {dim(f'({annotation or message})')}", indent=2)
 
-        try:
-            diff_output = get_content_diff(target.expanduser(), source)
-            if diff_output:
-                active_console.print(diff_output)
-        except OSError, RuntimeError:
-            pass
+    diff_output = get_status_diff(status_code, target.expanduser(), source)
+    if diff_output:
+        active_console: Console = console or get_console()
+        active_console.print(diff_output)
 
-        return False
-    if status_code == "stale_copy":
-        print_warning(f"{target_display} {dim('(copy out of date)')}", indent=2)
-
-        try:
-            diff_output = get_content_diff(target.expanduser(), source)
-            if diff_output:
-                active_console.print(diff_output)
-        except OSError, RuntimeError:
-            pass
-
-        return False
-    if status_code == "not_copy":
-        print_warning(
-            f"{target_display} {dim('(expected managed copy, found symlink)')}",
-            indent=2,
-        )
-        return False
-    if status_code == "error":
-        print_error(f"{target_display} {dim(f'({message})')}", indent=2)
-        return False
-    return True
+    return False
 
 
 class ConfigComponent(Component):
@@ -150,19 +123,10 @@ class ConfigComponent(Component):
             return ComponentResult()
 
         from ai_rules.cli import cleanup_deprecated_symlinks
-        from ai_rules.cli.display import (
-            dim,
-            print_absent,
-            print_error,
-            print_success,
-            print_unchanged,
-            print_update,
-        )
-        from ai_rules.symlinks import SymlinkResult, create_file_copy, create_symlink
+        from ai_rules.cli.display import print_symlink_result
+        from ai_rules.symlinks import create_file_copy, create_symlink
 
-        created = updated = unchanged = skipped = excluded = errors = 0
-
-        excluded = plan.excluded_count
+        counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
 
         for target, source in plan.symlink_ops:
             if target.expanduser() in plan.copy_targets:
@@ -170,53 +134,25 @@ class ConfigComponent(Component):
             else:
                 result, message = create_symlink(target, source, True, ctx.dry_run)
 
-            if result == SymlinkResult.CREATED:
-                print_success(f"{target} → {source}", indent=2)
-                created += 1
-            elif result == SymlinkResult.ALREADY_CORRECT:
-                print_unchanged(f"{target} {dim('(already correct)')}", indent=2)
-                unchanged += 1
-            elif result == SymlinkResult.UPDATED:
-                print_update(f"{target} → {source}", indent=2)
-                updated += 1
-            elif result == SymlinkResult.SKIPPED:
-                print_absent(f"{target} {dim('(skipped)')}", indent=2)
-                skipped += 1
-            elif result == SymlinkResult.ERROR:
-                print_error(f"{target}: {message}", indent=2)
-                errors += 1
+            counts[print_symlink_result(result, target, source, message)] += 1
 
         cleanup_deprecated_symlinks(
             list(ctx.selected_targets), ctx.config_dir, ctx.dry_run
         )
 
         return ComponentResult(
-            ok=errors == 0,
-            changed=bool(created or updated),
-            counts={
-                "created": created,
-                "updated": updated,
-                "unchanged": unchanged,
-                "skipped": skipped,
-                "excluded": excluded,
-                "errors": errors,
-            },
+            ok=counts["errors"] == 0,
+            changed=bool(counts["created"] or counts["updated"]),
+            counts={**counts, "excluded": plan.excluded_count},
         )
 
     def install(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.cli import cleanup_deprecated_symlinks
-        from ai_rules.cli.display import (
-            dim,
-            print_absent,
-            print_dim,
-            print_error,
-            print_success,
-            print_unchanged,
-            print_update,
-        )
-        from ai_rules.symlinks import SymlinkResult, create_file_copy, create_symlink
+        from ai_rules.cli.display import print_dim, print_symlink_result
+        from ai_rules.symlinks import create_file_copy, create_symlink
 
-        created = updated = unchanged = skipped = excluded = errors = 0
+        counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
+        excluded = 0
         effective_force = ctx.yes or not ctx.dry_run
         copy_targets = _get_copy_mode_targets(list(ctx.selected_targets))
 
@@ -246,38 +182,16 @@ class ConfigComponent(Component):
                         target, source, effective_force, ctx.dry_run
                     )
 
-                if result == SymlinkResult.CREATED:
-                    print_success(f"{target} → {source}", indent=2)
-                    created += 1
-                elif result == SymlinkResult.ALREADY_CORRECT:
-                    print_unchanged(f"{target} {dim('(already correct)')}", indent=2)
-                    unchanged += 1
-                elif result == SymlinkResult.UPDATED:
-                    print_update(f"{target} → {source}", indent=2)
-                    updated += 1
-                elif result == SymlinkResult.SKIPPED:
-                    print_absent(f"{target} {dim('(skipped)')}", indent=2)
-                    skipped += 1
-                elif result == SymlinkResult.ERROR:
-                    print_error(f"{target}: {message}", indent=2)
-                    errors += 1
+                counts[print_symlink_result(result, target, source, message)] += 1
 
         cleanup_deprecated_symlinks(
             list(ctx.selected_targets), ctx.config_dir, ctx.dry_run
         )
 
-        results = {
-            "created": created,
-            "updated": updated,
-            "unchanged": unchanged,
-            "skipped": skipped,
-            "excluded": excluded,
-            "errors": errors,
-        }
         return ComponentResult(
-            ok=errors == 0,
-            changed=bool(created or updated),
-            counts=results,
+            ok=counts["errors"] == 0,
+            changed=bool(counts["created"] or counts["updated"]),
+            counts={**counts, "excluded": excluded},
         )
 
     def status(self, ctx: CliContext) -> ComponentResult:
@@ -322,7 +236,12 @@ class ConfigComponent(Component):
     def diff(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.cli.display import print_dim, print_error, print_warning
         from ai_rules.cli.runner import get_console
-        from ai_rules.symlinks import check_file_copy, check_symlink, get_content_diff
+        from ai_rules.symlinks import (
+            check_file_copy,
+            check_symlink,
+            get_content_diff,
+            get_status_diff,
+        )
 
         console = get_console(ctx)
         found_differences = False
@@ -371,10 +290,7 @@ class ConfigComponent(Component):
                         )
                         target_has_diff = True
                 elif status_code in ("not_symlink", "stale_copy"):
-                    try:
-                        diff_output = get_content_diff(target_path, source)
-                    except OSError, RuntimeError:
-                        diff_output = None
+                    diff_output = get_status_diff(status_code, target_path, source)
                     desc = (
                         "Copy out of date"
                         if status_code == "stale_copy"

--- a/src/ai_rules/cli/components/extensions.py
+++ b/src/ai_rules/cli/components/extensions.py
@@ -26,15 +26,14 @@ class ClaudeExtensionsComponent(Component):
         from ai_rules.cli.display import (
             dim,
             print_absent,
-            print_error,
             print_success,
-            print_unchanged,
-            print_update,
+            print_symlink_result,
         )
-        from ai_rules.symlinks import SymlinkResult, create_symlink, remove_symlink
+        from ai_rules.symlinks import create_symlink, remove_symlink
 
         ext_manager = ClaudeExtensionManager(ctx.config_dir)
-        created = updated = unchanged = skipped = errors = cleaned = 0
+        counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
+        cleaned = 0
 
         ctx.console.print("\n[bold cyan]Claude Extensions[/bold cyan]")
         for ext_type in ClaudeExtensionManager.USER_DIRS:
@@ -57,23 +56,9 @@ class ClaudeExtensionsComponent(Component):
                     dry_run=ctx.dry_run,
                 )
 
-                if result == SymlinkResult.CREATED:
-                    print_success(f"{target_path} → {source_path}", indent=2)
-                    created += 1
-                elif result == SymlinkResult.ALREADY_CORRECT:
-                    print_unchanged(
-                        f"{target_path} {dim('(already correct)')}", indent=2
-                    )
-                    unchanged += 1
-                elif result == SymlinkResult.UPDATED:
-                    print_update(f"{target_path} → {source_path}", indent=2)
-                    updated += 1
-                elif result == SymlinkResult.SKIPPED:
-                    print_absent(f"{target_path} {dim('(skipped)')}", indent=2)
-                    skipped += 1
-                elif result == SymlinkResult.ERROR:
-                    print_error(f"{target_path}: {message}", indent=2)
-                    errors += 1
+                counts[
+                    print_symlink_result(result, target_path, source_path, message)
+                ] += 1
 
         all_orphaned = ext_manager.get_all_orphaned()
         for ext_type, orphaned in all_orphaned.items():
@@ -91,16 +76,9 @@ class ClaudeExtensionsComponent(Component):
                         cleaned += 1
 
         return ComponentResult(
-            ok=errors == 0,
-            changed=bool(created or updated or cleaned),
-            counts={
-                "created": created,
-                "updated": updated,
-                "unchanged": unchanged,
-                "skipped": skipped,
-                "errors": errors,
-                "cleaned": cleaned,
-            },
+            ok=counts["errors"] == 0,
+            changed=bool(counts["created"] or counts["updated"] or cleaned),
+            counts={**counts, "cleaned": cleaned},
         )
 
     def plan(self, ctx: CliContext) -> ComponentPlan:

--- a/src/ai_rules/cli/components/extensions.py
+++ b/src/ai_rules/cli/components/extensions.py
@@ -144,19 +144,12 @@ class ClaudeExtensionsComponent(Component):
         if not isinstance(plan, ClaudeExtensionsPlan):
             return ComponentResult()
 
-        from ai_rules.cli.display import (
-            dim,
-            print_absent,
-            print_error,
-            print_success,
-            print_unchanged,
-            print_update,
-        )
+        from ai_rules.cli.display import print_symlink_result
         from ai_rules.cli.runner import get_console
-        from ai_rules.symlinks import SymlinkResult, create_symlink
+        from ai_rules.symlinks import create_symlink
 
         console = get_console(ctx)
-        created = updated = unchanged = skipped = errors = 0
+        counts = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0, "errors": 0}
 
         current_section = None
         for ext_type, target_path, source_path in plan.symlink_ops:
@@ -171,45 +164,23 @@ class ClaudeExtensionsComponent(Component):
                 dry_run=ctx.dry_run,
             )
 
-            if result == SymlinkResult.CREATED:
-                print_success(f"{target_path} → {source_path}", indent=2)
-                created += 1
-            elif result == SymlinkResult.ALREADY_CORRECT:
-                print_unchanged(f"{target_path} {dim('(already correct)')}", indent=2)
-                unchanged += 1
-            elif result == SymlinkResult.UPDATED:
-                print_update(f"{target_path} → {source_path}", indent=2)
-                updated += 1
-            elif result == SymlinkResult.SKIPPED:
-                print_absent(f"{target_path} {dim('(skipped)')}", indent=2)
-                skipped += 1
-            elif result == SymlinkResult.ERROR:
-                print_error(f"{target_path}: {message}", indent=2)
-                errors += 1
+            counts[print_symlink_result(result, target_path, source_path, message)] += 1
 
         cleaned = 0
         if not ctx.dry_run:
+            from ai_rules.cli.display import print_success
             from ai_rules.symlinks import remove_symlink
 
             for _ext_type, name, orphan_path in plan.cleanup_ops:
                 success, _message = remove_symlink(orphan_path, force=True)
                 if success:
-                    from ai_rules.cli.display import print_success
-
                     print_success(f"Removed orphaned extension: {name}", indent=2)
                     cleaned += 1
 
         return ComponentResult(
-            ok=errors == 0,
-            changed=bool(created or updated or cleaned),
-            counts={
-                "created": created,
-                "updated": updated,
-                "unchanged": unchanged,
-                "skipped": skipped,
-                "errors": errors,
-                "cleaned": cleaned,
-            },
+            ok=counts["errors"] == 0,
+            changed=bool(counts["created"] or counts["updated"] or cleaned),
+            counts={**counts, "cleaned": cleaned},
         )
 
     def uninstall(self, ctx: CliContext) -> ComponentResult:
@@ -372,6 +343,3 @@ class ClaudeExtensionsComponent(Component):
             console.print()
 
         return ComponentResult(ok=all_correct, changed=not all_correct)
-
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)

--- a/src/ai_rules/cli/components/mcp.py
+++ b/src/ai_rules/cli/components/mcp.py
@@ -261,9 +261,6 @@ class MCPComponent(Component):
 
         return ComponentResult(ok=all_correct, changed=not all_correct)
 
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)
-
     def uninstall(self, ctx: CliContext) -> ComponentResult:
         from ai_rules.mcp import OperationResult
 

--- a/src/ai_rules/cli/components/plugins.py
+++ b/src/ai_rules/cli/components/plugins.py
@@ -72,48 +72,7 @@ class ClaudePluginComponent(Component):
         )
 
     def install(self, ctx: CliContext) -> ComponentResult:
-        if not self._claude_selected(ctx) or not (
-            ctx.config.plugins or ctx.config.marketplaces
-        ):
-            return ComponentResult()
-
-        from ai_rules.cli.display import (
-            print_dim,
-            print_skipped,
-            print_success,
-            print_warning,
-        )
-        from ai_rules.plugins import OperationResult, PluginManager
-
-        plugin_manager = PluginManager()
-        if not plugin_manager.is_cli_available():
-            if not ctx.dry_run:
-                print_skipped("Skipped plugin sync (claude CLI not available)")
-            return ComponentResult()
-
-        desired_plugins = ctx.config.get_plugin_configs()
-        desired_marketplaces = ctx.config.get_marketplace_configs()
-
-        plugin_result, message, warnings = plugin_manager.sync_plugins(
-            desired_plugins, desired_marketplaces, dry_run=ctx.dry_run
-        )
-
-        if plugin_result == OperationResult.SUCCESS:
-            print_success(message)
-        elif plugin_result == OperationResult.ALREADY_INSTALLED:
-            print_skipped(message)
-        elif plugin_result == OperationResult.DRY_RUN:
-            print_dim(message)
-        elif plugin_result == OperationResult.ERROR:
-            print_warning(message)
-
-        for warning in warnings:
-            print_warning(warning)
-
-        return ComponentResult(
-            changed=plugin_result in (OperationResult.SUCCESS, OperationResult.DRY_RUN),
-            counts={"plugin_errors": int(plugin_result == OperationResult.ERROR)},
-        )
+        return self.apply(ctx, self.plan(ctx))
 
     def status(self, ctx: CliContext) -> ComponentResult:
         if not self._claude_selected(ctx):
@@ -204,6 +163,3 @@ class ClaudePluginComponent(Component):
             changed=len(successfully_removed) > 0,
             counts={"removed": len(successfully_removed)},
         )
-
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)

--- a/src/ai_rules/cli/components/settings.py
+++ b/src/ai_rules/cli/components/settings.py
@@ -200,6 +200,3 @@ class SettingsComponent(Component):
             removed += 1
 
         return ComponentResult(changed=removed > 0, counts={"removed": removed})
-
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)

--- a/src/ai_rules/cli/components/skills.py
+++ b/src/ai_rules/cli/components/skills.py
@@ -377,6 +377,3 @@ class SkillsComponent(Component):
             console.print()
 
         return ComponentResult(ok=all_correct, changed=not all_correct)
-
-    def diff(self, ctx: CliContext) -> ComponentResult:
-        return self.status(ctx)

--- a/src/ai_rules/cli/context.py
+++ b/src/ai_rules/cli/context.py
@@ -76,7 +76,8 @@ class Component(ABC):
         return ComponentResult()
 
     def diff(self, ctx: CliContext) -> ComponentResult:
-        return ComponentResult()
+        """Default: diff reports the same information as status."""
+        return self.status(ctx)
 
     def validate(self, ctx: CliContext) -> ComponentResult:
         return ComponentResult()

--- a/src/ai_rules/cli/display.py
+++ b/src/ai_rules/cli/display.py
@@ -10,9 +10,14 @@ from __future__ import annotations
 
 import contextvars
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ai_rules.symlinks import SymlinkResult
 
 _console_override: contextvars.ContextVar[Console | None] = contextvars.ContextVar(
     "_console_override", default=None
@@ -133,3 +138,25 @@ def print_dim(message: str, *, indent: int = 0) -> None:
 
 def print_label(key: str, value: str, *, indent: int = 0) -> None:
     get_console().print(f"{' ' * indent}{dim(key + ':')} {value}")
+
+
+def print_symlink_result(
+    result: SymlinkResult, target: Path, source: Path, message: str
+) -> str:
+    """Print a symlink/copy operation result and return its counter key."""
+    from ai_rules.symlinks import SymlinkResult
+
+    if result == SymlinkResult.CREATED:
+        print_success(f"{target} → {source}", indent=2)
+        return "created"
+    if result == SymlinkResult.ALREADY_CORRECT:
+        print_unchanged(f"{target} {dim('(already correct)')}", indent=2)
+        return "unchanged"
+    if result == SymlinkResult.UPDATED:
+        print_update(f"{target} → {source}", indent=2)
+        return "updated"
+    if result == SymlinkResult.SKIPPED:
+        print_absent(f"{target} {dim('(skipped)')}", indent=2)
+        return "skipped"
+    print_error(f"{target}: {message}", indent=2)
+    return "errors"

--- a/src/ai_rules/cli/groups/exclude.py
+++ b/src/ai_rules/cli/groups/exclude.py
@@ -22,7 +22,7 @@ def exclude_add(pattern: str) -> None:
 
     PATTERN can be an exact path or glob pattern (e.g., ~/.claude/*.json)
     """
-    from ai_rules.cli.display import print_success, print_warning
+    from ai_rules.cli.display import print_warning
     from ai_rules.config import Config
 
     data = Config.load_user_config()
@@ -35,18 +35,14 @@ def exclude_add(pattern: str) -> None:
         return
 
     data["exclude_symlinks"].append(pattern)
-    Config.save_user_config(data)
-
-    user_config_path = cli_facade.get_user_config_path()
-    print_success(f"Added exclusion pattern: {pattern}")
-    print_dim(f"Config updated: {user_config_path}")
+    cli_facade.save_user_config_and_report(data, f"Added exclusion pattern: {pattern}")
 
 
 @exclude.command("remove")
 @click.argument("pattern")
 def exclude_remove(pattern: str) -> None:
     """Remove an exclusion pattern from user config."""
-    from ai_rules.cli.display import print_error, print_success, print_warning
+    from ai_rules.cli.display import print_error, print_warning
     from ai_rules.config import Config
 
     user_config_path = cli_facade.get_user_config_path()
@@ -62,10 +58,9 @@ def exclude_remove(pattern: str) -> None:
         sys.exit(1)
 
     data["exclude_symlinks"].remove(pattern)
-    Config.save_user_config(data)
-
-    print_success(f"Removed exclusion pattern: {pattern}")
-    print_dim(f"Config updated: {user_config_path}")
+    cli_facade.save_user_config_and_report(
+        data, f"Removed exclusion pattern: {pattern}"
+    )
 
 
 @exclude.command("list")

--- a/src/ai_rules/cli/groups/override.py
+++ b/src/ai_rules/cli/groups/override.py
@@ -149,8 +149,6 @@ def override_set(key: str, value: str) -> None:
     from ai_rules.cli.display import (
         console,
         print_error,
-        print_hint,
-        print_success,
         print_warning,
     )
     from ai_rules.config import (
@@ -159,7 +157,6 @@ def override_set(key: str, value: str) -> None:
         validate_override_path,
     )
 
-    user_config_path = cli_facade.get_user_config_path()
     config_dir = cli_facade.get_config_dir()
 
     parts = key.split(".", 1)
@@ -213,11 +210,11 @@ def override_set(key: str, value: str) -> None:
     else:
         _override_set_scalar(agent, path_components, parsed_value, data)
 
-    Config.save_user_config(data)
-
-    print_success(f"Set override: {agent}.{setting} = {parsed_value}")
-    print_dim(f"Config updated: {user_config_path}")
-    print_hint("Run 'ai-agent-rules install --rebuild-cache' to apply changes")
+    cli_facade.save_user_config_and_report(
+        data,
+        f"Set override: {agent}.{setting} = {parsed_value}",
+        hint="Run 'ai-agent-rules install --rebuild-cache' to apply changes",
+    )
 
 
 @override.command("unset")
@@ -230,8 +227,6 @@ def override_unset(key: str) -> None:
     """
     from ai_rules.cli.display import (
         print_error,
-        print_hint,
-        print_success,
         print_warning,
     )
     from ai_rules.config import Config
@@ -287,11 +282,11 @@ def override_unset(key: str) -> None:
     if not data["settings_overrides"][agent]:
         del data["settings_overrides"][agent]
 
-    Config.save_user_config(data)
-
-    print_success(f"Removed override: {key}")
-    print_dim(f"Config updated: {user_config_path}")
-    print_hint("Run 'ai-agent-rules install --rebuild-cache' to apply changes")
+    cli_facade.save_user_config_and_report(
+        data,
+        f"Removed override: {key}",
+        hint="Run 'ai-agent-rules install --rebuild-cache' to apply changes",
+    )
 
 
 @override.command("list")

--- a/src/ai_rules/cli/helpers.py
+++ b/src/ai_rules/cli/helpers.py
@@ -1,4 +1,9 @@
-"""Shared CLI helper functions."""
+"""Shared CLI helper functions.
+
+To monkeypatch these functions in tests, patch them on the ``ai_rules.cli``
+facade, not on this module: ``build_cli_context`` resolves its dependencies
+through the facade, so only facade patches apply everywhere.
+"""
 
 from __future__ import annotations
 

--- a/src/ai_rules/cli/helpers.py
+++ b/src/ai_rules/cli/helpers.py
@@ -6,14 +6,17 @@ import sys
 
 from importlib.resources import files as resource_files
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from click.decorators import FC
     from click.shell_completion import CompletionItem
 
-    from ai_rules.cli.context import Component
+    from ai_rules.cli.context import CliContext, Component
     from ai_rules.config import Config
     from ai_rules.targets.base import ConfigTarget
 
@@ -148,6 +151,113 @@ def complete_components(
         for component_id in component_ids
         if component_id.startswith(incomplete)
     ]
+
+
+def make_component_completer(
+    components_attr: str, *, filterable_only: bool = False
+) -> Callable[[click.Context, click.Parameter, str], list[CompletionItem]]:
+    """Build a --only completion callback for a component list.
+
+    Takes the attribute name on ``ai_rules.cli.components`` (rather than the
+    tuple itself) so commands keep their lazy component imports.
+    """
+
+    def _complete(
+        ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        import ai_rules.cli.components as components_module
+
+        components = getattr(components_module, components_attr)
+        ids = tuple(
+            c.component_id for c in components if c.filterable or not filterable_only
+        )
+        return complete_components(ctx, param, incomplete, component_ids=ids)
+
+    return _complete
+
+
+def agents_option(verb: str) -> Callable[[FC], FC]:
+    """Shared ``--agents`` option with target-name completion."""
+    return click.option(
+        "--agents",
+        help=f"Comma-separated list of agents to {verb} (default: all)",
+        shell_complete=complete_targets,
+    )
+
+
+def only_option(
+    components_attr: str, *, filterable_only: bool = False
+) -> Callable[[FC], FC]:
+    """Shared ``--only`` option completing against a component list."""
+    return click.option(
+        "--only",
+        "component_filter",
+        help="Comma-separated list of components to target (default: all)",
+        shell_complete=make_component_completer(
+            components_attr, filterable_only=filterable_only
+        ),
+    )
+
+
+def build_cli_context(
+    components: tuple[Component, ...],
+    agents: str | None,
+    component_filter: str | None,
+    *,
+    config_dir: Path | None = None,
+    config: Config | None = None,
+    profile_name: str | None = None,
+    yes: bool = False,
+    dry_run: bool = False,
+    rebuild_cache: bool = False,
+    skip_completions: bool = False,
+    force: bool = False,
+) -> CliContext:
+    """Load config, resolve target/component filters, and build a CliContext."""
+    # Route through the facade so monkeypatching ai_rules.cli still applies.
+    import ai_rules.cli as cli_facade
+
+    from ai_rules.cli.context import CliContext
+    from ai_rules.cli.display import console
+    from ai_rules.config import Config as ConfigClass
+
+    if config_dir is None:
+        config_dir = cli_facade.get_config_dir()
+    if config is None:
+        config = ConfigClass.load()
+    all_targets = cli_facade.get_targets(config_dir, config)
+    selected_targets = cli_facade.select_targets(all_targets, agents)
+    parsed_filter = cli_facade.select_components(components, component_filter)
+
+    return CliContext(
+        console=console,
+        config_dir=config_dir,
+        config=config,
+        profile_name=profile_name if profile_name is not None else config.profile_name,
+        all_targets=tuple(all_targets),
+        selected_targets=tuple(selected_targets),
+        target_filter=agents,
+        component_filter=parsed_filter,
+        yes=yes,
+        dry_run=dry_run,
+        rebuild_cache=rebuild_cache,
+        skip_completions=skip_completions,
+        force=force,
+    )
+
+
+def save_user_config_and_report(
+    data: dict[str, Any], success_msg: str, hint: str | None = None
+) -> None:
+    """Save user config and print the standard confirmation lines."""
+    from ai_rules.cli.display import print_dim, print_hint, print_success
+    from ai_rules.config import Config
+
+    Config.save_user_config(data)
+    print_success(success_msg)
+    print_dim(f"Config updated: {get_user_config_path()}")
+    if hint:
+        print_hint(hint)
 
 
 def format_summary(

--- a/src/ai_rules/cli/runner.py
+++ b/src/ai_rules/cli/runner.py
@@ -101,6 +101,32 @@ def run_components(
     return acc.to_result()
 
 
+def _confirm_install(ctx: CliContext) -> bool:
+    """Show pending changes and ask for confirmation. Returns False to abort."""
+    if ctx.yes or ctx.dry_run:
+        return True
+
+    import click
+
+    from ai_rules.cli import (
+        _display_pending_changes,
+        check_first_run,
+    )
+    from ai_rules.cli.display import print_warning
+
+    if not check_first_run(list(ctx.selected_targets), ctx.yes):
+        return False
+
+    if _display_pending_changes(ctx):
+        try:
+            click.confirm("Apply these changes?", abort=True)
+        except click.exceptions.Abort:
+            print_warning("Cancelled")
+            return False
+
+    return True
+
+
 def run_install(
     infrastructure: Iterable[Component],
     semantic: Iterable[Component],
@@ -116,26 +142,9 @@ def run_install(
             acc.aborted = True
             return acc.to_result()
 
-    if not ctx.yes and not ctx.dry_run:
-        import click
-
-        from ai_rules.cli import (
-            _display_pending_changes,
-            check_first_run,
-        )
-        from ai_rules.cli.display import print_warning
-
-        if not check_first_run(list(ctx.selected_targets), ctx.yes):
-            acc.aborted = True
-            return acc.to_result()
-
-        if _display_pending_changes(ctx):
-            try:
-                click.confirm("Apply these changes?", abort=True)
-            except click.exceptions.Abort:
-                print_warning("Cancelled")
-                acc.aborted = True
-                return acc.to_result()
+    if not _confirm_install(ctx):
+        acc.aborted = True
+        return acc.to_result()
 
     for component in semantic:
         if _should_skip(component, ctx):
@@ -169,26 +178,9 @@ def run_install_parallel(
             acc.aborted = True
             return acc.to_result()
 
-    if not ctx.yes and not ctx.dry_run:
-        import click
-
-        from ai_rules.cli import (
-            _display_pending_changes,
-            check_first_run,
-        )
-        from ai_rules.cli.display import print_warning
-
-        if not check_first_run(list(ctx.selected_targets), ctx.yes):
-            acc.aborted = True
-            return acc.to_result()
-
-        if _display_pending_changes(ctx):
-            try:
-                click.confirm("Apply these changes?", abort=True)
-            except click.exceptions.Abort:
-                print_warning("Cancelled")
-                acc.aborted = True
-                return acc.to_result()
+    if not _confirm_install(ctx):
+        acc.aborted = True
+        return acc.to_result()
 
     # Run the semantic phase in two ordered waves: components that create the
     # settings symlinks first, then components flagged install_after_symlinks
@@ -242,34 +234,6 @@ def run_parallel(
             continue
         acc.fold(comp, results.get(comp, ComponentResult()))
     return acc.to_result()
-
-
-def run_uninstall_parallel(
-    components: Iterable[Component],
-    ctx: CliContext,
-) -> ComponentRunResult:
-    return run_parallel(components, "uninstall", ctx)
-
-
-def run_status_parallel(
-    components: Iterable[Component],
-    ctx: CliContext,
-) -> ComponentRunResult:
-    return run_parallel(components, "status", ctx)
-
-
-def run_diff_parallel(
-    components: Iterable[Component],
-    ctx: CliContext,
-) -> ComponentRunResult:
-    return run_parallel(components, "diff", ctx)
-
-
-def run_validate_parallel(
-    components: Iterable[Component],
-    ctx: CliContext,
-) -> ComponentRunResult:
-    return run_parallel(components, "validate", ctx)
 
 
 def get_console(ctx: CliContext) -> RichConsole:

--- a/src/ai_rules/config/skills/agents-md/SKILL.md
+++ b/src/ai_rules/config/skills/agents-md/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: agents-md
-version: 1.0.0
+version: 1.0.1
 description: Create or update AGENTS.md with repo-specific patterns, conventions, commands, and gotchas for LLM coding agents. Use after implementing features that introduce new patterns worth documenting.
-allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
+allowed-tools: Bash, Edit, Glob, Grep, Read, TodoWrite, Write
 model: sonnet
 ---
 

--- a/src/ai_rules/config/skills/code-reviewer/SKILL.md
+++ b/src/ai_rules/config/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-version: 1.0.0
+version: 1.0.1
 description: Performs thorough code review on local changes or PRs. Use this skill proactively after implementing code changes to catch issues before commit/push. Also use when reviewing PRs from other engineers.
 agent: general-purpose
 allowed-tools: Agent, AskUserQuestion, Bash, Glob, Grep, Read, TodoWrite

--- a/src/ai_rules/config/skills/code-reviewer/references/subagent-template.md
+++ b/src/ai_rules/config/skills/code-reviewer/references/subagent-template.md
@@ -1,6 +1,6 @@
 # Code Review Subagent Briefing Template
 
-Use this template to construct the briefing prompt for each review specialist subagent. Replace all `[bracketed]` fields with specific values.
+Use this template to construct the briefing prompt for each subagent. Replace all `[bracketed]` fields with specific values.
 
 Every field is load-bearing. Do not omit sections.
 
@@ -28,7 +28,7 @@ KEY QUESTIONS:
 SCOPE BOUNDARIES:
 Do NOT review for [other lenses — list explicitly]. Other agents handle those.
 Stay within your lens. If you discover something relevant but outside your scope,
-mention it briefly in Open Questions for the orchestrator.
+mention it briefly in Open Questions for the orchestrator to handle.
 
 SEVERITY FRAMEWORK:
 Categorize every finding:
@@ -69,7 +69,7 @@ Return structured findings only:
 
 ### Confidence Assessment
 Overall: HIGH / MEDIUM / LOW
-Reason: [one sentence — did you have sufficient context to review thoroughly?]
+Reason: [one sentence explaining the confidence level]
 
 CRITICAL RULES:
 - Read FULL file contents, not just diff hunks — context matters

--- a/src/ai_rules/config/skills/doc-writer/SKILL.md
+++ b/src/ai_rules/config/skills/doc-writer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: doc-writer
-version: 1.0.0
+version: 1.0.1
 description: Write, update, or review documentation (README, ARCHITECTURE.md, API docs, guides). Use after implementing features to document new APIs, CLI commands, or behavior changes.
+allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
 model: sonnet
 ---
 

--- a/src/ai_rules/config/skills/kb/SKILL.md
+++ b/src/ai_rules/config/skills/kb/SKILL.md
@@ -1,13 +1,15 @@
 ---
-disabled: true
 name: kb
-version: 1.0.0
+version: 1.0.1
 description: >-
   This skill should be used when recall MCP tools are available and the user
   asks to "save to knowledge base", "write a note", "persist this", "remember
   this pattern", "update the KB", or when the Stop hook instructs the agent to
   persist session knowledge. Also use when asking "search knowledge base",
   "what do we know about", or needing cross-project context from recall.
+disabled: true
+allowed-tools: Read, mcp__recall
+model: sonnet
 ---
 
 # Knowledge Base (recall)

--- a/src/ai_rules/config/skills/prompt-critique/SKILL.md
+++ b/src/ai_rules/config/skills/prompt-critique/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: prompt-critique
-version: 1.0.0
+version: 1.0.1
 description: Analyze your historical Claude Code prompts and get personalized feedback on how to improve your prompting technique
 disabled: true
 disable-model-invocation: true
-allowed-tools: Bash, Glob, Grep, Read, Write, Skill, AskUserQuestion
+allowed-tools: AskUserQuestion, Bash, Glob, Grep, Read, Skill, Write
 model: sonnet
 ---
 

--- a/src/ai_rules/config/skills/prompt-engineer/SKILL.md
+++ b/src/ai_rules/config/skills/prompt-engineer/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: prompt-engineer
-version: 1.0.0
+version: 1.0.1
 description: Expert guidance for writing and optimizing LLM prompts. Use when creating or updating AGENTS.md, CLAUDE.md, SKILL.md, system prompts, or custom instructions.
+allowed-tools: AskUserQuestion, Edit, Glob, Grep, Read, Write
+model: sonnet
 ---
 
 # Prompt Engineering Skill

--- a/src/ai_rules/config/skills/rebase/SKILL.md
+++ b/src/ai_rules/config/skills/rebase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rebase
-version: 1.1.0
-description: >
+version: 1.1.1
+description: >-
   Rebase a branch onto main (or a target). Squash-first strategy, semantic
   verification of auto-merged files, generated-file regeneration, and safe
   force-push. Use when rebasing PRs or branches that are behind their base.

--- a/src/ai_rules/config/skills/research/SKILL.md
+++ b/src/ai_rules/config/skills/research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research
-version: 1.0.0
-description: >
+version: 1.0.1
+description: >-
   Conduct multi-agent research on any topic. Use when the user asks to
   'research', 'investigate', 'deep dive', 'comprehensive analysis',
   'what do we know about', or when a question requires synthesizing information

--- a/src/ai_rules/config/skills/research/references/subagent-template.md
+++ b/src/ai_rules/config/skills/research/references/subagent-template.md
@@ -1,6 +1,6 @@
 # Subagent Briefing Template
 
-Use this template to construct the briefing prompt for each research subagent. Replace all `[bracketed]` fields with specific values from your research plan.
+Use this template to construct the briefing prompt for each subagent. Replace all `[bracketed]` fields with specific values.
 
 Every field is load-bearing. Do not omit sections.
 
@@ -26,7 +26,7 @@ KEY QUESTIONS TO ANSWER:
 1. [specific, answerable question]
 2. [specific, answerable question]
 3. [specific, answerable question]
-(3-5 questions maximum. Each should be independently answerable.)
+(3-5 questions. Each should be independently answerable.)
 
 RESEARCH APPROACH:
 - Start with these search terms: [2-3 suggested starting queries]

--- a/src/ai_rules/config/skills/session-search/SKILL.md
+++ b/src/ai_rules/config/skills/session-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-search
-version: 1.0.1
+version: 1.0.2
 description: >-
   Use this skill to find, locate, or search previous coding agent sessions or
   conversations. Triggers on requests to search session transcripts or

--- a/src/ai_rules/config/skills/session-search/SKILL.md
+++ b/src/ai_rules/config/skills/session-search/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: session-search
-version: 1.0.0
-description: >
+version: 1.0.1
+description: >-
   Use this skill to find, locate, or search previous coding agent sessions or
   conversations. Triggers on requests to search session transcripts or
   conversation history, recover commands or outputs from earlier sessions,
   compare recent sessions for a repository, or search across Claude Code,
   Codex CLI, Gemini CLI, Goose, or Amp session history.
+allowed-tools: Agent, Bash, Glob, Grep, Read
+model: sonnet
 ---
 
 ## Context

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
@@ -227,6 +227,26 @@ def print_session_header(session: Session) -> None:
     print(f"    {session.path}")
 
 
+class SessionMatchPrinter:
+    """Per-session match printing: header-once, truncation, max_matches cutoff."""
+
+    def __init__(self, session: Session, args: argparse.Namespace) -> None:
+        self._session = session
+        self._max_matches = getattr(args, "max_matches", 0)
+        self._width = getattr(args, "width", 280)
+        self._header_printed = False
+        self.matches = 0
+
+    def emit(self, rendered: str, prefix: str = "") -> bool:
+        """Print one match. Returns False once max_matches is reached."""
+        if not self._header_printed:
+            print_session_header(self._session)
+            self._header_printed = True
+        print(f"{prefix}{truncate(rendered, self._width)}")
+        self.matches += 1
+        return not (self._max_matches > 0 and self.matches >= self._max_matches)
+
+
 def search_jsonl_session(
     session: Session,
     pattern: re.Pattern[str],
@@ -235,10 +255,7 @@ def search_jsonl_session(
     display_text: Callable[[dict[str, Any], str], str],
 ) -> int:
     """Shared JSONL search loop: print each record once on its first match."""
-    max_matches = getattr(args, "max_matches", 0)
-    width = getattr(args, "width", 280)
-    header_printed = False
-    matches = 0
+    printer = SessionMatchPrinter(session, args)
 
     try:
         with session.path.open("r", encoding="utf-8", errors="replace") as fh:
@@ -252,15 +269,10 @@ def search_jsonl_session(
                 for text in iter_search_text(record, raw):
                     if not pattern.search(text):
                         continue
-                    if not header_printed:
-                        print_session_header(session)
-                        header_printed = True
-                    print(truncate(display_text(record, raw), width))
-                    matches += 1
-                    if max_matches > 0 and matches >= max_matches:
-                        return matches
+                    if not printer.emit(display_text(record, raw)):
+                        return printer.matches
                     break
     except OSError as exc:
         warn(f"cannot read {session.path}: {exc}")
 
-    return matches
+    return printer.matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/core.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -87,6 +88,18 @@ def repo_context(cwd_text: str, explicit_repo: str | None) -> tuple[str, str, st
     root_text = str(root) if root else str(cwd)
     repo_name = explicit_repo or repo_name_from_path(root_text)
     return str(cwd), root_text, repo_name
+
+
+def current_repo_context(args: argparse.Namespace) -> tuple[str, str, str]:
+    """Resolve (current_cwd, current_root, repo_name) from --cwd/--repo args."""
+    current_cwd = (
+        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
+    )
+    current_root = ""
+    repo_name = getattr(args, "repo", None) or ""
+    if current_cwd:
+        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+    return current_cwd, current_root, repo_name
 
 
 def repo_score(
@@ -199,3 +212,55 @@ def print_sessions(sessions: list[Session], limit: int, json_output: bool) -> No
 
 def warn(msg: str) -> None:
     print(f"[warn] {msg}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Search helpers
+# ---------------------------------------------------------------------------
+
+
+def print_session_header(session: Session) -> None:
+    """Print the standard once-per-session match header."""
+    label = f" [{session.repo_reason}]" if session.repo_reason else ""
+    title_part = f" - {session.title}" if session.title else ""
+    print(f"\n=== [{session.agent}] {session.id}{label}{title_part} ===")
+    print(f"    {session.path}")
+
+
+def search_jsonl_session(
+    session: Session,
+    pattern: re.Pattern[str],
+    args: argparse.Namespace,
+    iter_search_text: Callable[[dict[str, Any], str], Iterable[str]],
+    display_text: Callable[[dict[str, Any], str], str],
+) -> int:
+    """Shared JSONL search loop: print each record once on its first match."""
+    max_matches = getattr(args, "max_matches", 0)
+    width = getattr(args, "width", 280)
+    header_printed = False
+    matches = 0
+
+    try:
+        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                raw = raw_line.rstrip("\n")
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    record = {}
+
+                for text in iter_search_text(record, raw):
+                    if not pattern.search(text):
+                        continue
+                    if not header_printed:
+                        print_session_header(session)
+                        header_printed = True
+                    print(truncate(display_text(record, raw), width))
+                    matches += 1
+                    if max_matches > 0 and matches >= max_matches:
+                        return matches
+                    break
+    except OSError as exc:
+        warn(f"cannot read {session.path}: {exc}")
+
+    return matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
@@ -13,11 +13,10 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    SessionMatchPrinter,
     current_repo_context,
     in_date_window,
-    print_session_header,
     repo_score,
-    truncate,
     warn,
 )
 
@@ -218,10 +217,7 @@ def display_text(record: dict[str, Any], raw: str) -> str:
 def search_session(
     session: Session, pattern: re.Pattern[str], args: argparse.Namespace
 ) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    width = getattr(args, "width", 280)
-    header_printed = False
-    matches = 0
+    printer = SessionMatchPrinter(session, args)
 
     try:
         with session.path.open("r", encoding="utf-8", errors="replace") as fh:
@@ -246,14 +242,7 @@ def search_session(
         if not combined or not pattern.search(combined):
             continue
 
-        if not header_printed:
-            print_session_header(session)
-            header_printed = True
+        if not printer.emit(display_text(msg, ""), prefix=f"[msg {idx}] "):
+            return printer.matches
 
-        rendered = display_text(msg, "")
-        print(f"[msg {idx}] {truncate(rendered, width)}")
-        matches += 1
-        if max_matches > 0 and matches >= max_matches:
-            return matches
-
-    return matches
+    return printer.matches

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/amp.py
@@ -13,8 +13,9 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    current_repo_context,
     in_date_window,
-    repo_context,
+    print_session_header,
     repo_score,
     truncate,
     warn,
@@ -68,13 +69,7 @@ def _extract_cwd(data: dict[str, Any]) -> str:
 def iter_sessions(args: argparse.Namespace) -> list[Session]:
     threads_dir = _AMP_THREADS.expanduser()
 
-    current_cwd = (
-        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
-    )
-    current_root = ""
-    repo_name = getattr(args, "repo", None) or ""
-    if current_cwd:
-        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+    current_cwd, current_root, repo_name = current_repo_context(args)
 
     sessions: list[Session] = []
 
@@ -252,10 +247,7 @@ def search_session(
             continue
 
         if not header_printed:
-            label = f" [{session.repo_reason}]" if session.repo_reason else ""
-            title_part = f" - {session.title}" if session.title else ""
-            print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
-            print(f"    {session.path}")
+            print_session_header(session)
             header_printed = True
 
         rendered = display_text(msg, "")

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/codex.py
@@ -14,11 +14,10 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    current_repo_context,
     in_date_window,
-    repo_context,
     repo_score,
-    truncate,
-    warn,
+    search_jsonl_session,
 )
 
 AGENT_NAME: str = "codex"
@@ -108,13 +107,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     home = _codex_home()
     index = _read_index(home / "session_index.jsonl")
 
-    current_cwd = (
-        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
-    )
-    current_root = ""
-    repo_name = getattr(args, "repo", None) or ""
-    if current_cwd:
-        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+    current_cwd, current_root, repo_name = current_repo_context(args)
 
     dirs: list[Path] = []
     if (home / "sessions").exists():
@@ -287,40 +280,4 @@ def display_text(record: dict[str, Any], raw: str) -> str:
 def search_session(
     session: Session, pattern: re.Pattern[str], args: argparse.Namespace
 ) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    header_printed = False
-    matches = 0
-
-    try:
-        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
-            for raw_line in fh:
-                raw = raw_line.rstrip("\n")
-                try:
-                    record = json.loads(raw)
-                except json.JSONDecodeError:
-                    record = {}
-
-                for text in iter_search_text(record, raw):
-                    if not pattern.search(text):
-                        continue
-                    if not header_printed:
-                        label = (
-                            f" [{session.repo_reason}]" if session.repo_reason else ""
-                        )
-                        title_part = f" - {session.title}" if session.title else ""
-                        print(
-                            f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ==="
-                        )
-                        print(f"    {session.path}")
-                        header_printed = True
-                    rendered = display_text(record, raw)
-                    print(truncate(rendered))
-                    matches += 1
-                    if max_matches > 0 and matches >= max_matches:
-                        return matches
-                    break
-
-    except OSError as exc:
-        warn(f"cannot read {session.path}: {exc}")
-
-    return matches
+    return search_jsonl_session(session, pattern, args, iter_search_text, display_text)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
@@ -13,9 +13,11 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    current_repo_context,
     in_date_window,
-    repo_context,
+    print_session_header,
     repo_score,
+    search_jsonl_session,
     truncate,
     warn,
 )
@@ -98,13 +100,7 @@ def iter_sessions(args: argparse.Namespace) -> list[Session]:
     tmp_dir = _gemini_tmp()
     slug_map = _load_slug_map()
 
-    current_cwd = (
-        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
-    )
-    current_root = ""
-    repo_name = getattr(args, "repo", None) or ""
-    if current_cwd:
-        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+    current_cwd, current_root, repo_name = current_repo_context(args)
 
     sessions: list[Session] = []
 
@@ -223,50 +219,6 @@ def display_text(record: dict[str, Any], raw: str) -> str:
     return raw
 
 
-def _search_jsonl(
-    session: Session,
-    pattern: re.Pattern[str],
-    args: argparse.Namespace,
-) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    header_printed = False
-    matches = 0
-
-    try:
-        with session.path.open("r", encoding="utf-8", errors="replace") as fh:
-            for raw_line in fh:
-                raw = raw_line.rstrip("\n")
-                try:
-                    record = json.loads(raw)
-                except json.JSONDecodeError:
-                    record = {}
-
-                for text in iter_search_text(record, raw):
-                    if not pattern.search(text):
-                        continue
-                    if not header_printed:
-                        label = (
-                            f" [{session.repo_reason}]" if session.repo_reason else ""
-                        )
-                        title_part = f" - {session.title}" if session.title else ""
-                        print(
-                            f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ==="
-                        )
-                        print(f"    {session.path}")
-                        header_printed = True
-                    rendered = display_text(record, raw)
-                    width = getattr(args, "width", 280)
-                    print(truncate(rendered, width))
-                    matches += 1
-                    if max_matches > 0 and matches >= max_matches:
-                        return matches
-                    break
-    except OSError as exc:
-        warn(f"cannot read {session.path}: {exc}")
-
-    return matches
-
-
 def _search_legacy_json(
     session: Session,
     pattern: re.Pattern[str],
@@ -307,10 +259,7 @@ def _search_legacy_json(
             continue
 
         if not header_printed:
-            label = f" [{session.repo_reason}]" if session.repo_reason else ""
-            title_part = f" - {session.title}" if session.title else ""
-            print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
-            print(f"    {session.path}")
+            print_session_header(session)
             header_printed = True
 
         width = getattr(args, "width", 280)
@@ -327,5 +276,7 @@ def search_session(
     session: Session, pattern: re.Pattern[str], args: argparse.Namespace
 ) -> int:
     if session.path.suffix == ".jsonl":
-        return _search_jsonl(session, pattern, args)
+        return search_jsonl_session(
+            session, pattern, args, iter_search_text, display_text
+        )
     return _search_legacy_json(session, pattern, args)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/gemini.py
@@ -13,12 +13,11 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    SessionMatchPrinter,
     current_repo_context,
     in_date_window,
-    print_session_header,
     repo_score,
     search_jsonl_session,
-    truncate,
     warn,
 )
 
@@ -224,9 +223,7 @@ def _search_legacy_json(
     pattern: re.Pattern[str],
     args: argparse.Namespace,
 ) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    header_printed = False
-    matches = 0
+    printer = SessionMatchPrinter(session, args)
 
     try:
         with session.path.open("r", encoding="utf-8", errors="replace") as fh:
@@ -258,18 +255,11 @@ def _search_legacy_json(
         if not combined or not pattern.search(combined):
             continue
 
-        if not header_printed:
-            print_session_header(session)
-            header_printed = True
-
-        width = getattr(args, "width", 280)
         rendered = json.dumps({"role": role, "text": combined}, ensure_ascii=False)
-        print(truncate(rendered, width))
-        matches += 1
-        if max_matches > 0 and matches >= max_matches:
-            return matches
+        if not printer.emit(rendered):
+            return printer.matches
 
-    return matches
+    return printer.matches
 
 
 def search_session(

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
@@ -14,8 +14,9 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    current_repo_context,
     in_date_window,
-    repo_context,
+    print_session_header,
     repo_score,
     truncate,
     warn,
@@ -45,13 +46,7 @@ def _ts_from_unix(unix: int) -> str:
 
 
 def iter_sessions(args: argparse.Namespace) -> list[Session]:
-    current_cwd = (
-        str(Path(args.cwd).expanduser().resolve()) if getattr(args, "cwd", None) else ""
-    )
-    current_root = ""
-    repo_name = getattr(args, "repo", None) or ""
-    if current_cwd:
-        _, current_root, repo_name = repo_context(current_cwd, repo_name or None)
+    current_cwd, current_root, repo_name = current_repo_context(args)
 
     db = _db_path()
     if db.exists():
@@ -286,10 +281,7 @@ def _search_db_session(
                     continue
 
                 if not header_printed:
-                    label = f" [{session.repo_reason}]" if session.repo_reason else ""
-                    title_part = f" - {session.title}" if session.title else ""
-                    print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
-                    print(f"    {session.path}")
+                    print_session_header(session)
                     header_printed = True
 
                 rendered = display_text(record, content_json_raw or "")
@@ -339,10 +331,7 @@ def _search_legacy_session(
                     continue
 
                 if not header_printed:
-                    label = f" [{session.repo_reason}]" if session.repo_reason else ""
-                    title_part = f" - {session.title}" if session.title else ""
-                    print(f"\n=== [{AGENT_NAME}] {session.id}{label}{title_part} ===")
-                    print(f"    {session.path}")
+                    print_session_header(session)
                     header_printed = True
 
                 rendered = display_text(record, raw)

--- a/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
+++ b/src/ai_rules/config/skills/session-search/scripts/session_search/readers/goose.py
@@ -14,11 +14,10 @@ from typing import Any
 
 from session_search.core import (
     Session,
+    SessionMatchPrinter,
     current_repo_context,
     in_date_window,
-    print_session_header,
     repo_score,
-    truncate,
     warn,
 )
 
@@ -253,10 +252,7 @@ def _search_db_session(
     pattern: re.Pattern[str],
     args: argparse.Namespace,
 ) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    width = getattr(args, "width", 280)
-    header_printed = False
-    matches = 0
+    printer = SessionMatchPrinter(session, args)
 
     try:
         with _conn(session.path) as con:
@@ -280,21 +276,13 @@ def _search_db_session(
                 if not pattern.search(searchable):
                     continue
 
-                if not header_printed:
-                    print_session_header(session)
-                    header_printed = True
-
-                rendered = display_text(record, content_json_raw or "")
-                print(truncate(rendered, width))
-                matches += 1
-
-                if max_matches > 0 and matches >= max_matches:
-                    return matches
+                if not printer.emit(display_text(record, content_json_raw or "")):
+                    return printer.matches
 
     except sqlite3.Error as exc:
         warn(f"goose: cannot read session {session.id} from {session.path}: {exc}")
 
-    return matches
+    return printer.matches
 
 
 def _search_legacy_session(
@@ -302,10 +290,7 @@ def _search_legacy_session(
     pattern: re.Pattern[str],
     args: argparse.Namespace,
 ) -> int:
-    max_matches = getattr(args, "max_matches", 0)
-    width = getattr(args, "width", 280)
-    header_printed = False
-    matches = 0
+    printer = SessionMatchPrinter(session, args)
 
     try:
         with session.path.open("r", encoding="utf-8", errors="replace") as fh:
@@ -330,21 +315,13 @@ def _search_legacy_session(
                 if not pattern.search(searchable):
                     continue
 
-                if not header_printed:
-                    print_session_header(session)
-                    header_printed = True
-
-                rendered = display_text(record, raw)
-                print(truncate(rendered, width))
-                matches += 1
-
-                if max_matches > 0 and matches >= max_matches:
-                    return matches
+                if not printer.emit(display_text(record, raw)):
+                    return printer.matches
 
     except OSError as exc:
         warn(f"goose: cannot read {session.path}: {exc}")
 
-    return matches
+    return printer.matches
 
 
 def search_session(

--- a/src/ai_rules/config/skills/test-writer/SKILL.md
+++ b/src/ai_rules/config/skills/test-writer/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: test-writer
-version: 1.0.0
+version: 1.0.1
 description: Write, update, or review tests. Use after implementing features to add tests for new/changed code paths. Covers testing strategy, framework selection, and coverage analysis.
+allowed-tools: Bash, Edit, Glob, Grep, Read, TodoWrite, Write
+model: sonnet
 ---
 
 # Test Writing Skill

--- a/src/ai_rules/config/skills/worktree-cleanup/SKILL.md
+++ b/src/ai_rules/config/skills/worktree-cleanup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktree-cleanup
-version: 1.0.0
-description: >
+version: 1.0.1
+description: >-
   Clean up stale git worktrees to reclaim disk space. Detects merged branches,
   deleted remotes, and abandoned worktrees. Rust-aware — reports target/ sizes
   separately. Use when asked to clean up worktrees, reclaim disk space, remove

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -5,10 +5,11 @@ import json
 import shutil
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import yaml
 
@@ -49,6 +50,11 @@ class MCPManager(ABC):
 
     BACKUP_SUFFIX = "ai-agent-rules-backup"
 
+    # Default translation: copy these keys when present, then apply extras.
+    # Managers with a genuinely different native shape override _translate.
+    _translate_keys: ClassVar[tuple[str, ...]] = ("command", "args", "env")
+    _translate_extras: ClassVar[Mapping[str, Any]] = {}
+
     # --- abstract interface ---------------------------------------------------
 
     @property
@@ -64,9 +70,13 @@ class MCPManager(ABC):
     def _write_installed(self, mcps: dict[str, Any]) -> None:
         """Persist the full set of MCP entries, merging with non-MCP config."""
 
-    @abstractmethod
     def _translate(self, shared_config: dict[str, Any]) -> dict[str, Any]:
         """Convert shared MCP format to agent-native format."""
+        result: dict[str, Any] = {
+            k: shared_config[k] for k in self._translate_keys if k in shared_config
+        }
+        result.update(self._translate_extras)
+        return result
 
     @property
     def mcp_settings_key(self) -> str | None:
@@ -571,132 +581,70 @@ class CodexMCPManager(MCPManager):
         with open(self._config_path, "w") as f:
             f.write(tomlkit.dumps(doc))
 
-    def _translate(self, shared_config: dict[str, Any]) -> dict[str, Any]:
-        result: dict[str, Any] = {}
-        if "command" in shared_config:
-            result["command"] = shared_config["command"]
-        if "args" in shared_config:
-            result["args"] = shared_config["args"]
-        if "env" in shared_config:
-            result["env"] = shared_config["env"]
-        return result
-
-    def detect_conflicts(
-        self, expected: dict[str, Any], installed: dict[str, Any]
-    ) -> list[str]:
-        """Conflict detection strips the per-entry marker added during read."""
-        marker = self._marker_field
-        conflicts = []
-        for name, expected_config in expected.items():
-            if name in installed:
-                expected_clean = {
-                    k: v for k, v in expected_config.items() if k != marker
-                }
-                installed_clean = {
-                    k: v for k, v in installed[name].items() if k != marker
-                }
-                if expected_clean != installed_clean:
-                    conflicts.append(name)
-        return conflicts
-
 
 # ---------------------------------------------------------------------------
-# Gemini
+# Keyed-JSON managers (Gemini, Amp)
 # ---------------------------------------------------------------------------
 
 
-class GeminiMCPManager(MCPManager):
-    """Manages MCPs in ~/.gemini/settings.json under the mcpServers key."""
+class _KeyedJsonMCPManager(MCPManager):
+    """Manager for a JSON settings file with MCPs stored under one key."""
 
     @property
     def _marker_field(self) -> str:
         return "_managedBy"
 
     @property
-    def mcp_settings_key(self) -> str | None:
+    @abstractmethod
+    def mcp_settings_key(self) -> str:
+        """Key in the JSON file under which MCP entries are stored."""
+
+    @property
+    @abstractmethod
+    def _config_path(self) -> Path:
+        """Path to the agent's JSON settings file."""
+
+    def _load_full_config(self) -> dict[str, Any]:
+        if not self._config_path.exists():
+            return {}
+        with open(self._config_path) as f:
+            data: dict[str, Any] = json.load(f)
+        return data
+
+    def _read_installed(self) -> dict[str, Any]:
+        full = self._load_full_config()
+        return cast(dict[str, Any], full.get(self.mcp_settings_key, {}))
+
+    def _write_installed(self, mcps: dict[str, Any]) -> None:
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        full = self._load_full_config()
+        full[self.mcp_settings_key] = mcps
+        write_file_atomic(
+            self._config_path, lambda f: json.dump(full, f, indent=2, sort_keys=True)
+        )
+
+
+class GeminiMCPManager(_KeyedJsonMCPManager):
+    """Manages MCPs in ~/.gemini/settings.json under the mcpServers key."""
+
+    _translate_extras = {"timeout": 30000, "trust": False}
+
+    @property
+    def mcp_settings_key(self) -> str:
         return "mcpServers"
 
     @property
     def _config_path(self) -> Path:
         return Path.home() / ".gemini" / "settings.json"
 
-    def _load_full_config(self) -> dict[str, Any]:
-        if not self._config_path.exists():
-            return {}
-        with open(self._config_path) as f:
-            data: dict[str, Any] = json.load(f)
-        return data
 
-    def _read_installed(self) -> dict[str, Any]:
-        full = self._load_full_config()
-        return cast(dict[str, Any], full.get("mcpServers", {}))
-
-    def _write_installed(self, mcps: dict[str, Any]) -> None:
-        self._config_path.parent.mkdir(parents=True, exist_ok=True)
-        full = self._load_full_config()
-        full["mcpServers"] = mcps
-        write_file_atomic(
-            self._config_path, lambda f: json.dump(full, f, indent=2, sort_keys=True)
-        )
-
-    def _translate(self, shared_config: dict[str, Any]) -> dict[str, Any]:
-        result: dict[str, Any] = {}
-        if "command" in shared_config:
-            result["command"] = shared_config["command"]
-        if "args" in shared_config:
-            result["args"] = shared_config["args"]
-        if "env" in shared_config:
-            result["env"] = shared_config["env"]
-        result["timeout"] = 30000
-        result["trust"] = False
-        return result
-
-
-# ---------------------------------------------------------------------------
-# Amp
-# ---------------------------------------------------------------------------
-
-
-class AmpMCPManager(MCPManager):
+class AmpMCPManager(_KeyedJsonMCPManager):
     """Manages MCPs in ~/.config/amp/settings.json under the amp.mcpServers key."""
 
     @property
-    def _marker_field(self) -> str:
-        return "_managedBy"
-
-    @property
-    def mcp_settings_key(self) -> str | None:
+    def mcp_settings_key(self) -> str:
         return "amp.mcpServers"
 
     @property
     def _config_path(self) -> Path:
         return Path.home() / ".config" / "amp" / "settings.json"
-
-    def _load_full_config(self) -> dict[str, Any]:
-        if not self._config_path.exists():
-            return {}
-        with open(self._config_path) as f:
-            data: dict[str, Any] = json.load(f)
-        return data
-
-    def _read_installed(self) -> dict[str, Any]:
-        full = self._load_full_config()
-        return cast(dict[str, Any], full.get("amp.mcpServers", {}))
-
-    def _write_installed(self, mcps: dict[str, Any]) -> None:
-        self._config_path.parent.mkdir(parents=True, exist_ok=True)
-        full = self._load_full_config()
-        full["amp.mcpServers"] = mcps
-        write_file_atomic(
-            self._config_path, lambda f: json.dump(full, f, indent=2, sort_keys=True)
-        )
-
-    def _translate(self, shared_config: dict[str, Any]) -> dict[str, Any]:
-        result: dict[str, Any] = {}
-        if "command" in shared_config:
-            result["command"] = shared_config["command"]
-        if "args" in shared_config:
-            result["args"] = shared_config["args"]
-        if "env" in shared_config:
-            result["env"] = shared_config["env"]
-        return result

--- a/src/ai_rules/symlinks.py
+++ b/src/ai_rules/symlinks.py
@@ -356,6 +356,25 @@ def format_unified_diff(
     return "\n".join(diff_lines)
 
 
+def get_status_diff(
+    status_code: str, target_path: Path, expected_source: Path
+) -> str | None:
+    """Content diff for a non-correct check result, or None if unavailable.
+
+    For ``wrong_target`` the symlink is resolved to diff what it actually
+    points at; for ``not_symlink``/``stale_copy`` the target file itself is
+    diffed. Other status codes have no meaningful content diff.
+    """
+    try:
+        if status_code == "wrong_target":
+            return get_content_diff(target_path.resolve(), expected_source)
+        if status_code in ("not_symlink", "stale_copy"):
+            return get_content_diff(target_path, expected_source)
+    except OSError, RuntimeError:
+        pass
+    return None
+
+
 def get_content_diff(actual_path: Path, expected_path: Path) -> str | None:
     """Get a unified diff between two files.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,22 @@ def runner():
     return CliRunner()
 
 
+def write_config_tree(root: Path, files: dict[str, str]) -> Path:
+    """Materialize a config-dir tree from {relative_path: content}."""
+    root.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return root
+
+
+@pytest.fixture(scope="session")
+def config_tree_writer():
+    """Expose write_config_tree to sub-conftest fixtures (e.g. tests/e2e)."""
+    return write_config_tree
+
+
 @pytest.fixture
 def test_repo(tmp_path):
     """Create a test repository structure with config files.
@@ -162,49 +178,22 @@ def test_repo(tmp_path):
     Note: As of v0.5.0, config structure changed from repo/config/* to package/config/*.
     This fixture mimics the new package structure for testing.
     """
-    config_root = tmp_path / "test-config"
-    config_root.mkdir()
-
-    (config_root / "AGENTS.md").write_text("# Shared Agent Rules\nTest content")
-
-    claude_dir = config_root / "claude"
-    claude_dir.mkdir()
-    (claude_dir / "settings.json").write_text('{"test": "settings"}')
-    (claude_dir / "CLAUDE.md").write_text("@~/AGENTS.md\n")
-
-    claude_agents = claude_dir / "agents"
-    claude_agents.mkdir()
-    (claude_agents / "test-agent.md").write_text("# Test Agent\nAgent content")
-
-    claude_commands = claude_dir / "commands"
-    claude_commands.mkdir()
-    (claude_commands / "test-command.md").write_text("# Test Command\nCommand content")
-
-    codex_dir = config_root / "codex"
-    codex_dir.mkdir()
-    (codex_dir / "config.toml").write_text(
-        'model = "gpt-5.2-codex"\napproval_policy = "on-request"\n'
+    return write_config_tree(
+        tmp_path / "test-config",
+        {
+            "AGENTS.md": "# Shared Agent Rules\nTest content",
+            "claude/settings.json": '{"test": "settings"}',
+            "claude/CLAUDE.md": "@~/AGENTS.md\n",
+            "claude/agents/test-agent.md": "# Test Agent\nAgent content",
+            "claude/commands/test-command.md": "# Test Command\nCommand content",
+            "claude/mcps.json": "{}",
+            "codex/config.toml": 'model = "gpt-5.2-codex"\napproval_policy = "on-request"\n',
+            "codex/AGENTS.md": "@~/AGENTS.md\n",
+            "gemini/settings.json": '{"name": "gemini-3.1-pro-preview"}',
+            "gemini/GEMINI.md": "@~/AGENTS.md\n",
+            "amp/settings.json": '{"amp.anthropic.thinking.enabled": true, "amp.showCosts": true}',
+            "amp/AGENTS.md": "@~/AGENTS.md\n",
+            "goose/config.yaml": "test: config",
+            "goose/.goosehints": "@~/AGENTS.md\n",
+        },
     )
-    (codex_dir / "AGENTS.md").write_text("@~/AGENTS.md\n")
-
-    gemini_dir = config_root / "gemini"
-    gemini_dir.mkdir()
-    (gemini_dir / "settings.json").write_text('{"name": "gemini-3.1-pro-preview"}')
-    (gemini_dir / "GEMINI.md").write_text("@~/AGENTS.md\n")
-
-    amp_dir = config_root / "amp"
-    amp_dir.mkdir()
-    (amp_dir / "settings.json").write_text(
-        '{"amp.anthropic.thinking.enabled": true, "amp.showCosts": true}'
-    )
-    (amp_dir / "AGENTS.md").write_text("@~/AGENTS.md\n")
-
-    goose_dir = config_root / "goose"
-    goose_dir.mkdir()
-    (goose_dir / "config.yaml").write_text("test: config")
-    (goose_dir / ".goosehints").write_text("@~/AGENTS.md\n")
-
-    mcps_file = claude_dir / "mcps.json"
-    mcps_file.write_text("{}")
-
-    return config_root

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,45 +34,25 @@ def e2e_home(tmp_path):
 
 
 @pytest.fixture
-def e2e_config_dir(tmp_path):
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-
-    (config_dir / "AGENTS.md").write_text("# Shared Agent Rules\n")
-
-    claude_dir = config_dir / "claude"
-    claude_dir.mkdir()
-    (claude_dir / "CLAUDE.md").write_text("")
-    (claude_dir / "settings.json").write_text('{"test": "e2e"}')
-    (claude_dir / "mcps.json").write_text("{}")
-
-    codex_dir = config_dir / "codex"
-    codex_dir.mkdir()
-    (codex_dir / "config.toml").write_text('model = "test-model"\n')
-    (codex_dir / "AGENTS.md").write_text("@~/AGENTS.md\n")
-
-    gemini_dir = config_dir / "gemini"
-    gemini_dir.mkdir()
-    (gemini_dir / "GEMINI.md").write_text("")
-    (gemini_dir / "settings.json").write_text('{"name": "test"}')
-
-    amp_dir = config_dir / "amp"
-    amp_dir.mkdir()
-    (amp_dir / "AGENTS.md").write_text("")
-    (amp_dir / "settings.json").write_text('{"test": true}')
-
-    goose_dir = config_dir / "goose"
-    goose_dir.mkdir()
-    (goose_dir / "config.yaml").write_text("test: e2e\n")
-    (goose_dir / ".goosehints").write_text("")
-
-    profiles_dir = config_dir / "profiles"
-    profiles_dir.mkdir()
-    (profiles_dir / "default.yaml").write_text(
-        "name: default\nagents:\n  - claude\n  - codex\n"
+def e2e_config_dir(tmp_path, config_tree_writer):
+    return config_tree_writer(
+        tmp_path / "config",
+        {
+            "AGENTS.md": "# Shared Agent Rules\n",
+            "claude/CLAUDE.md": "",
+            "claude/settings.json": '{"test": "e2e"}',
+            "claude/mcps.json": "{}",
+            "codex/config.toml": 'model = "test-model"\n',
+            "codex/AGENTS.md": "@~/AGENTS.md\n",
+            "gemini/GEMINI.md": "",
+            "gemini/settings.json": '{"name": "test"}',
+            "amp/AGENTS.md": "",
+            "amp/settings.json": '{"test": true}',
+            "goose/config.yaml": "test: e2e\n",
+            "goose/.goosehints": "",
+            "profiles/default.yaml": "name: default\nagents:\n  - claude\n  - codex\n",
+        },
     )
-
-    return config_dir
 
 
 @pytest.fixture
@@ -105,32 +85,9 @@ def run_cli(e2e_home):
 
 
 @pytest.fixture
-def run_cli_with_config(e2e_home, e2e_config_dir):
-    home_dir, env_overrides = e2e_home
-    repo_root = Path(__file__).parents[2]
-    src_path = repo_root / "src"
-
-    def _run(args, extra_env=None, timeout=30):
-        base_env = {**os.environ, **env_overrides}
-        existing_pythonpath = base_env.get("PYTHONPATH", "")
-        base_env["PYTHONPATH"] = (
-            str(src_path)
-            if not existing_pythonpath
-            else os.pathsep.join([str(src_path), existing_pythonpath])
-        )
-        if extra_env:
-            base_env.update(extra_env)
-        return subprocess.run(
-            [sys.executable, "-m", "ai_rules.cli", *args],
-            capture_output=True,
-            encoding="utf-8",
-            check=False,
-            cwd=repo_root,
-            env=base_env,
-            timeout=timeout,
-        )
-
-    return _run, home_dir, e2e_config_dir
+def run_cli_with_config(run_cli, e2e_home, e2e_config_dir):
+    home_dir, _env_overrides = e2e_home
+    return run_cli, home_dir, e2e_config_dir
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,9 +1,3 @@
-import os
-import subprocess
-import sys
-
-from pathlib import Path
-
 import pytest
 
 from tests.e2e.helpers import (
@@ -17,20 +11,7 @@ from tests.e2e.helpers import (
 def e2e_home(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()
-    env_overrides = {
-        "HOME": str(home_dir),
-        "USERPROFILE": str(home_dir),
-        "APPDATA": str(home_dir / "AppData" / "Roaming"),
-        "LOCALAPPDATA": str(home_dir / "AppData" / "Local"),
-        "NO_COLOR": "1",
-        "PYTHONIOENCODING": "utf-8",
-        "PYTHONUTF8": "1",
-        "XDG_CACHE_HOME": str(tmp_path / "cache"),
-        "XDG_DATA_HOME": str(tmp_path / "data"),
-        "PATH": os.environ.get("PATH", ""),
-        "SHELL": "/bin/bash",
-    }
-    return home_dir, env_overrides
+    return home_dir, make_home_env(home_dir)
 
 
 @pytest.fixture
@@ -57,31 +38,8 @@ def e2e_config_dir(tmp_path, config_tree_writer):
 
 @pytest.fixture
 def run_cli(e2e_home):
-    home_dir, env_overrides = e2e_home
-    repo_root = Path(__file__).parents[2]
-    src_path = repo_root / "src"
-
-    def _run(args, extra_env=None, timeout=30):
-        base_env = {**os.environ, **env_overrides}
-        existing_pythonpath = base_env.get("PYTHONPATH", "")
-        base_env["PYTHONPATH"] = (
-            str(src_path)
-            if not existing_pythonpath
-            else os.pathsep.join([str(src_path), existing_pythonpath])
-        )
-        if extra_env:
-            base_env.update(extra_env)
-        return subprocess.run(
-            [sys.executable, "-m", "ai_rules.cli", *args],
-            capture_output=True,
-            encoding="utf-8",
-            check=False,
-            cwd=repo_root,
-            env=base_env,
-            timeout=timeout,
-        )
-
-    return _run
+    home_dir, env = e2e_home
+    return make_cli_runner(home_dir, env)
 
 
 @pytest.fixture

--- a/tests/integration/test_tool_commands.py
+++ b/tests/integration/test_tool_commands.py
@@ -2,14 +2,7 @@
 
 import pytest
 
-from click.testing import CliRunner
-
 from ai_rules.cli import main
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 @pytest.mark.integration

--- a/tests/unit/test_bootstrap_installer.py
+++ b/tests/unit/test_bootstrap_installer.py
@@ -47,12 +47,9 @@ class TestInstallTool:
         def mock_run(*args, **kwargs):
             captured_args.append((args, kwargs))
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, message = install_tool("test-package")
@@ -75,12 +72,9 @@ class TestInstallTool:
         def mock_run(*args, **kwargs):
             captured_args.append((args, kwargs))
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, message = install_tool("test-package", force=True)
@@ -149,12 +143,9 @@ class TestInstallTool:
         def mock_run(cmd, **kwargs):
             captured.append(cmd)
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, _ = install_tool("some-package", local_path=str(tmp_path))
@@ -173,12 +164,9 @@ class TestInstallTool:
         def mock_run(cmd, **kwargs):
             captured.append(cmd)
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, _ = install_tool("this-is-invalid!!!name", local_path=str(tmp_path))
@@ -194,12 +182,9 @@ class TestInstallTool:
         def mock_run(cmd, **kwargs):
             captured.append(cmd)
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, _ = install_tool(
@@ -237,12 +222,9 @@ class TestUninstallTool:
         def mock_run(*args, **kwargs):
             captured_args.append((args, kwargs))
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("subprocess.run", mock_run)
         success, message = uninstall_tool("test-package")
@@ -469,12 +451,13 @@ class TestGetToolVersion:
             "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True
         )
 
-        class Result:
-            returncode = 0
-            stdout = "ai-agent-rules-extra v0.1.0\n  - ai-agent-rules-extra\nai-agent-rules v0.62.4\n  - ai-agent-rules\n"
-            stderr = ""
-
-        monkeypatch.setattr("subprocess.run", lambda *a, **kw: Result())
+        result = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="ai-agent-rules-extra v0.1.0\n  - ai-agent-rules-extra\nai-agent-rules v0.62.4\n  - ai-agent-rules\n",
+            stderr="",
+        )
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: result)
         version = get_tool_version("ai-agent-rules")
         assert version == "0.62.4"
 
@@ -497,12 +480,9 @@ class TestInstallToolGithub:
         def mock_run(cmd, **kwargs):
             captured.append(cmd)
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
 
         monkeypatch.setattr(
             "ai_rules.bootstrap.installer.is_command_available", lambda cmd: True

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -93,12 +93,12 @@ class TestCheckIndexUpdates:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stdout = "test-package (1.0.0)\nAvailable versions: 1.0.0"
-                stderr = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="test-package (1.0.0)\nAvailable versions: 1.0.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
 
@@ -114,12 +114,12 @@ class TestCheckIndexUpdates:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stdout = "test-package (1.1.0)\nAvailable versions: 1.1.0, 1.0.0"
-                stderr = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="test-package (1.1.0)\nAvailable versions: 1.1.0, 1.0.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
 
@@ -136,12 +136,9 @@ class TestCheckIndexUpdates:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 1
-                stdout = ""
-                stderr = "Network error"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Network error"
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
 
@@ -181,12 +178,9 @@ class TestCheckIndexUpdates:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stdout = "Unexpected output format"
-                stderr = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Unexpected output format", stderr=""
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
 
@@ -242,12 +236,12 @@ class TestPerformToolUpgrade:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Upgraded test-package from 1.0.0 to 1.1.0"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Upgraded test-package from 1.0.0 to 1.1.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(test_tool)
@@ -262,12 +256,9 @@ class TestPerformToolUpgrade:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 1
-                stderr = "Package not found"
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Package not found"
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(test_tool)
@@ -312,12 +303,9 @@ class TestPerformToolUpgrade:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 1
-                stderr = ""
-                stdout = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=""
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(test_tool)
@@ -335,12 +323,12 @@ class TestPerformToolUpgrade:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Upgraded test-package from 1.0.0 to 1.1.0"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Upgraded test-package from 1.0.0 to 1.1.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(test_tool)
@@ -681,12 +669,12 @@ class TestPerformToolUpgradeWithPythonSwitch:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Upgraded test-package from 1.0.0 to 2.0.0"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Upgraded test-package from 1.0.0 to 2.0.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, msg, was_upgraded = perform_tool_upgrade(
@@ -714,12 +702,9 @@ class TestPerformToolUpgradeWithPythonSwitch:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Nothing to upgrade"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Nothing to upgrade", stderr=""
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         perform_tool_upgrade(test_tool, target_version="1.0.0")
@@ -738,12 +723,9 @@ class TestPerformToolUpgradeWithPythonSwitch:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Nothing to upgrade"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Nothing to upgrade", stderr=""
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         perform_tool_upgrade(test_tool)
@@ -767,12 +749,12 @@ class TestPerformToolUpgradeWithPythonSwitch:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Installed 1 executable: test-package"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Installed 1 executable: test-package",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, msg, was_upgraded = perform_tool_upgrade(
@@ -1019,12 +1001,12 @@ class TestPerformToolUpgradeSourceResolution:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Installed 1 executable: test-package"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Installed 1 executable: test-package",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(tool)
@@ -1061,12 +1043,12 @@ class TestPerformToolUpgradeSourceResolution:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Upgraded test-package from 1.0.0 to 1.1.0"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Upgraded test-package from 1.0.0 to 1.1.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(tool)
@@ -1101,12 +1083,12 @@ class TestPerformToolUpgradeSourceResolution:
         def mock_run(*args, **kwargs):
             captured_cmd.extend(args[0])
 
-            class Result:
-                returncode = 0
-                stderr = ""
-                stdout = "Installed 1 executable: test-package"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="Installed 1 executable: test-package",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         success, message, was_upgraded = perform_tool_upgrade(tool)
@@ -1126,12 +1108,9 @@ class TestCheckFailedPropagation:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 1
-                stdout = ""
-                stderr = "Network error"
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="Network error"
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         result = check_index_updates("test-package", "1.0.0")
@@ -1157,12 +1136,12 @@ class TestCheckFailedPropagation:
         )
 
         def mock_run(*args, **kwargs):
-            class Result:
-                returncode = 0
-                stdout = "test-package (1.0.0)\nAvailable versions: 1.0.0"
-                stderr = ""
-
-            return Result()
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="test-package (1.0.0)\nAvailable versions: 1.0.0",
+                stderr="",
+            )
 
         monkeypatch.setattr("ai_rules.bootstrap.updater.subprocess.run", mock_run)
         result = check_index_updates("test-package", "1.0.0")

--- a/tests/unit/test_cli_completers.py
+++ b/tests/unit/test_cli_completers.py
@@ -1,0 +1,61 @@
+"""Tests locking CLI completer wiring and the facade patch seam.
+
+The --only completers resolve their component list by attribute name on
+ai_rules.cli.components at completion time (to keep command imports lazy).
+A typo or rename there is invisible to mypy and would only surface as
+silently broken shell completion — these tests make it fail CI instead.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from ai_rules.cli import main
+
+COMPLETER_CASES = [
+    ("install", "INSTALL_COMPONENTS", True),
+    ("status", "STATUS_COMPONENTS", False),
+    ("uninstall", "UNINSTALL_COMPONENTS", False),
+    ("diff", "DIFF_COMPONENTS", False),
+    ("validate", "VALIDATE_COMPONENTS", False),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "command_name,components_attr,filterable_only", COMPLETER_CASES
+)
+def test_only_completer_returns_component_ids(
+    command_name, components_attr, filterable_only
+):
+    import ai_rules.cli.components as components_module
+
+    command = main.commands[command_name]
+    param = next(p for p in command.params if p.name == "component_filter")
+    ctx = click.Context(command)
+
+    items = param.shell_complete(ctx, "")
+
+    components = getattr(components_module, components_attr)
+    expected = [
+        c.component_id for c in components if c.filterable or not filterable_only
+    ]
+    assert [item.value for item in items] == expected
+    assert expected, f"{components_attr} produced no completion candidates"
+
+
+@pytest.mark.unit
+def test_build_cli_context_honors_facade_patch(tmp_path, monkeypatch, mock_home):
+    """build_cli_context must resolve get_config_dir through the facade seam."""
+    import ai_rules.cli as cli_facade
+
+    from ai_rules.cli.components import STATUS_COMPONENTS
+
+    config_dir = tmp_path / "facade-config"
+    config_dir.mkdir()
+    monkeypatch.setattr(cli_facade, "get_config_dir", lambda: config_dir)
+
+    cli_ctx = cli_facade.build_cli_context(STATUS_COMPONENTS, None, None)
+
+    assert cli_ctx.config_dir == config_dir

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -412,7 +412,7 @@ def test_run_install_parallel_reports_failure_on_apply_error(tmp_path: Path) -> 
 
 
 @pytest.mark.unit
-def test_run_uninstall_parallel_aggregates_counts(tmp_path: Path) -> None:
+def test_run_parallel_uninstall_aggregates_counts(tmp_path: Path) -> None:
     first = PlanApplyComponent(
         "first", uninstall_result=ComponentResult(counts={"removed": 2})
     )
@@ -428,7 +428,7 @@ def test_run_uninstall_parallel_aggregates_counts(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_run_uninstall_parallel_reports_failure_on_error(tmp_path: Path) -> None:
+def test_run_parallel_uninstall_reports_failure_on_error(tmp_path: Path) -> None:
     bad = PlanApplyComponent("bad", uninstall_error=RuntimeError("uninstall exploded"))
     good = PlanApplyComponent("good")
 

--- a/tests/unit/test_cli_runner.py
+++ b/tests/unit/test_cli_runner.py
@@ -17,7 +17,6 @@ from ai_rules.cli.runner import (
     run_install,
     run_install_parallel,
     run_parallel,
-    run_uninstall_parallel,
 )
 from ai_rules.config import Config
 
@@ -421,7 +420,9 @@ def test_run_uninstall_parallel_aggregates_counts(tmp_path: Path) -> None:
         "second", uninstall_result=ComponentResult(counts={"removed": 1, "errors": 0})
     )
 
-    result = run_uninstall_parallel([first, second], make_context(tmp_path, yes=True))
+    result = run_parallel(
+        [first, second], "uninstall", make_context(tmp_path, yes=True)
+    )
 
     assert result.counts == {"removed": 3, "errors": 0}
 
@@ -431,7 +432,7 @@ def test_run_uninstall_parallel_reports_failure_on_error(tmp_path: Path) -> None
     bad = PlanApplyComponent("bad", uninstall_error=RuntimeError("uninstall exploded"))
     good = PlanApplyComponent("good")
 
-    result = run_uninstall_parallel([bad, good], make_context(tmp_path, yes=True))
+    result = run_parallel([bad, good], "uninstall", make_context(tmp_path, yes=True))
 
     assert result.ok is False
 

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -1,10 +1,13 @@
 """Unit tests for skills module."""
 
 import importlib.metadata
+import re
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from ai_rules.skills import SkillManager
 
@@ -420,3 +423,67 @@ class TestListBundledSkillsDisabled:
         assert names == {"active", "inactive"}
         disabled_skill = next(s for s in results if s.name == "inactive")
         assert disabled_skill.disabled is True
+
+
+@pytest.mark.unit
+class TestBundledSkillFrontmatter:
+    """Schema validation for the bundled SKILL.md files."""
+
+    SKILLS_DIR = Path(__file__).parents[2] / "src" / "ai_rules" / "config" / "skills"
+    CANONICAL_FIELD_ORDER = [
+        "name",
+        "version",
+        "description",
+        "disabled",
+        "disable-model-invocation",
+        "agent",
+        "allowed-tools",
+        "model",
+    ]
+    KNOWN_MODELS = {"haiku", "sonnet", "opus"}
+
+    @staticmethod
+    def _frontmatter(skill_md: Path) -> tuple[dict, list[str]]:
+        """Return (parsed frontmatter, top-level keys in file order)."""
+        parts = skill_md.read_text().split("---", 2)
+        assert len(parts) >= 3, f"{skill_md}: missing frontmatter"
+        raw = parts[1]
+        data = yaml.safe_load(raw)
+        keys = re.findall(r"^([A-Za-z][A-Za-z-]*):", raw, flags=re.MULTILINE)
+        return data, keys
+
+    def _skill_files(self) -> list[Path]:
+        files = sorted(self.SKILLS_DIR.glob("*/SKILL.md"))
+        assert files, f"no bundled skills found under {self.SKILLS_DIR}"
+        return files
+
+    def test_required_fields_and_values(self):
+        for skill_md in self._skill_files():
+            data, _ = self._frontmatter(skill_md)
+            assert data["name"] == skill_md.parent.name, skill_md
+            assert re.fullmatch(r"\d+\.\d+\.\d+", str(data["version"])), skill_md
+            assert isinstance(data["description"], str) and data["description"], (
+                skill_md
+            )
+            if "model" in data:
+                assert data["model"] in self.KNOWN_MODELS, skill_md
+
+    def test_fields_are_known_and_canonically_ordered(self):
+        for skill_md in self._skill_files():
+            _, keys = self._frontmatter(skill_md)
+            unknown = set(keys) - set(self.CANONICAL_FIELD_ORDER)
+            assert not unknown, f"{skill_md}: unknown fields {unknown}"
+            indices = [self.CANONICAL_FIELD_ORDER.index(k) for k in keys]
+            assert indices == sorted(indices), (
+                f"{skill_md}: fields out of canonical order {keys}"
+            )
+
+    def test_allowed_tools_are_sorted(self):
+        for skill_md in self._skill_files():
+            data, _ = self._frontmatter(skill_md)
+            tools_value = data.get("allowed-tools")
+            if tools_value is None:
+                continue
+            tools = [t.strip() for t in tools_value.split(",")]
+            assert tools == sorted(tools), f"{skill_md}: tools not sorted {tools}"
+            assert len(tools) == len(set(tools)), f"{skill_md}: duplicate tools"


### PR DESCRIPTION
Systematic deduplication across the CLI, agents, MCP managers, bootstrap layer, tests, and bundled skills: **58 files, +1,008/−1,491 (−483 net LOC)** across 14 commits. No behavior change except the deliberate items listed below. Rebased onto the latest `main` (through `7f87f8e`: the `buzz` rename, 0.65.1, GitHub-Releases changelog, and the new E2E harness). **The full suite passes — 942 unit/integration + 38 e2e** (mypy strict, ruff clean), and main's new golden-snapshot E2E suite confirms our refactored code reproduces main's recorded install plan, symlink manifest, and all five per-agent MCP translations byte-for-byte.

## Changes by area

**Metadata/docs** — pyproject classifiers corrected to Python 3.14 (matched `requires-python`), stale `tomli.*` mypy override dropped, AGENTS.md's nonexistent `info` command removed.

**CLI layer** — shared `--agents`/`--only` option decorators + completer factory + `build_cli_context()` replace five copies of command boilerplate; `Component.diff()` defaults to `status()` (six trivial overrides deleted); runner's duplicated confirmation block extracted to `_confirm_install` and four one-line `run_*_parallel` wrappers removed; one `print_symlink_result()` formatter replaces four hand-rolled `SymlinkResult` switches; the 8-branch status display is table-driven; `claude_extensions` iterates its `USER_DIRS` table instead of hardcoded triplets; `save_user_config_and_report()` for the exclude/override mutations. (Cleanly integrated with main's two-wave `install_after_symlinks` MCP-race fix.)

**Agents** — constant properties became class attributes (the pattern `StatuslineTool` already used) and the five near-identical `symlinks` builders collapsed into a base-class template method (`_instruction_symlinks` / `_settings_symlinks` / `_extra_symlinks`). Goose keeps its runtime-resolved paths, Claude its dynamic extension globs, Gemini its Windows copy-mode override.

**MCP managers** — `_translate` is a base default driven by `_translate_keys`/`_translate_extras` (Codex/Amp deleted theirs; Gemini keeps only its extras); new `_KeyedJsonMCPManager` absorbs Gemini/Amp's byte-identical JSON file handling; Codex's `detect_conflicts` was identical to the base and removed. `ClaudeMCPManager`'s backup-on-write handling intentionally untouched.

**Bootstrap** — `get_updatable_tools()` derives from `registry.ACTIVE_TOOLS` (single source of truth); 113-line `ensure_tool_installed()` decomposed into three helpers with its status-string contract frozen (tests pass unmodified).

**Tests** — 25 inline `class Result` subprocess stubs replaced with `subprocess.CompletedProcess`; shadowed `runner` fixture removed; config-tree fixtures are declarative `{path: content}` dicts over one shared builder; `run_cli_with_config` reuses `run_cli`. After rebasing in main's `tests/e2e/helpers.py`, the legacy `e2e_home`/`run_cli` fixtures were collapsed onto `make_home_env`/`make_cli_runner` so the e2e layer has one home-env builder and one subprocess runner.

**session-search skill** — verbatim-duplicated blocks extracted into `core.py` (`current_repo_context`, `print_session_header`, `search_jsonl_session`, `SessionMatchPrinter`); readers keep their format-specific iteration. Skill bumped to 1.0.2.

**Skill frontmatter** — canonical field order across all 15 bundled skills, alphabetized tool lists, `>-` description style, `allowed-tools`/`model` added where missing, subagent-template skeletons aligned between code-reviewer and research, patch versions bumped; a new `TestBundledSkillFrontmatter` suite enforces the schema in CI.

## Deliberate behavior changes

- codex session-search now honors the `--width` flag (it was the only reader ignoring it)
- five skills gained `allowed-tools`, four gained `model: sonnet` (user-approved; `continue-crash` intentionally left unpinned so it inherits the session model)
- orphaned-extension messages print in `USER_DIRS` order (agents, commands, hooks) — the old commands-first order was the outlier vs every other extension-type iteration

## Code review

A high-effort review of the branch surfaced no correctness bugs and 7 cleanup/robustness findings, all addressed: the missed `install()` symlink-display migration in the extensions component, CI tests locking the string-resolved completer wiring and the facade monkeypatch seam, the remaining session-search match-loop duplication, stale test names, and verification that kb's `mcp__recall` allowlist entry matches the server name registered in `bootstrap/registry.py`.

https://claude.ai/code/session_01XF6uvcWfXbb9PFyHpgNNQr