### PR TITLE
chore(profile): use fableplan and adjust thinking settings in work profile

### DIFF
--- a/src/ai_rules/config/profiles/work.yaml
+++ b/src/ai_rules/config/profiles/work.yaml
@@ -7,7 +7,10 @@ managed_tools:
     statusline: github
 settings_overrides:
   claude:
-    model: "opus[1m]"
+    model: "fable"
+    env:
+      CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: ""
+      CLAUDE_CODE_EFFORT_LEVEL: "xhigh"
   codex:
     service_tier: "fast"
     features:

--- a/src/ai_rules/config/profiles/work.yaml
+++ b/src/ai_rules/config/profiles/work.yaml
@@ -7,9 +7,8 @@ managed_tools:
     statusline: github
 settings_overrides:
   claude:
-    model: "fable"
     env:
-      CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: ""
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-fable-5[1m]"
       CLAUDE_CODE_EFFORT_LEVEL: "xhigh"
   codex:
     service_tier: "fast"


### PR DESCRIPTION
Implements the fableplan pattern in the work profile — Fable 5 for planning, Sonnet for execution. The `personal` profile already sets `model: opusplan`; this overrides `ANTHROPIC_DEFAULT_OPUS_MODEL` to `claude-fable-5[1m]` so the opus planning slot silently resolves to Fable 5 instead.

Also reduces the adaptive thinking effort level from `max` to `xhigh` via `CLAUDE_CODE_EFFORT_LEVEL`.

- Remove explicit `model` override from work profile (inherit `opusplan` from `personal`)
- Add `ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-fable-5[1m]"` env override for fableplan behavior
- Add `CLAUDE_CODE_EFFORT_LEVEL: "xhigh"` env override