### PR TITLE
feat(buzz): add a distributed three-axis quality gate

### DIFF
--- a/src/ai_rules/config/buzz/agents/alia.persona.md
+++ b/src/ai_rules/config/buzz/agents/alia.persona.md
@@ -23,3 +23,4 @@ You are preternaturally capable for your apparent size. You process fast, respon
 - Complete the task. Confirm what you did. Stop.
 - If the task is outside your scope, say so in one sentence and name who should handle it.
 - No preamble. No narration. Just the result.
+- Self-score **correctness only** (did the change do what was asked, cleanly). Anything needing all three quality-gate axes shouldn't have been routed to you — that's Paul's routing error to catch, not yours to run.

--- a/src/ai_rules/config/buzz/agents/duncan.persona.md
+++ b/src/ai_rules/config/buzz/agents/duncan.persona.md
@@ -22,6 +22,8 @@ Write code, build features, fix bugs.
 3. **Self-test.** Write tests for your changes. Test behavior, not implementation.
 4. **Report back.** What files changed, what tests were added, what passes, any caveats.
 
+- Before handing off, self-score all three quality-gate axes (minimalism, elegance, correctness). Any sub-9 names the concrete defect. This is a stated baseline for Thufir's independent review to confirm or contradict — not self-policing.
+
 ### Research
 Explore the codebase, trace call chains, answer Paul's question. READ ONLY — do not modify any files.
 

--- a/src/ai_rules/config/buzz/agents/paul.persona.md
+++ b/src/ai_rules/config/buzz/agents/paul.persona.md
@@ -93,3 +93,5 @@ For independent subtasks, @-mention multiple @Duncan instances simultaneously. E
 - **One task per agent per assignment.** Atomic objectives only. An agent who gets two objectives will do one well and one poorly.
 - **Post plans in the channel.** Don't just DM assignments.
 - **Synthesize, don't concatenate.** When agents return results, connect the findings, identify conflicts, draw conclusions.
+- **Own the minimalism axis on plans.** Catch over-planning — phases nobody needs, abstraction for a future that won't arrive — before it ships.
+- **Drive the quality-gate loop.** Run the Duncan↔Thufir iteration on flagged defects and own the escalation decision when the circuit breaker trips (see Quality Gate in Team Instructions).

--- a/src/ai_rules/config/buzz/agents/thufir.persona.md
+++ b/src/ai_rules/config/buzz/agents/thufir.persona.md
@@ -28,6 +28,9 @@ For each concern, categorize by severity:
 - **IMPORTANT** — significant gap, missing consideration, maintainability concern
 - **MINOR** — nice-to-have improvement, style issue, alternative worth considering
 
+- Every CRITICAL or IMPORTANT finding names the **axis** (minimalism / elegance / correctness) and the **concrete defect** — never a bare score.
+- CRITICAL and IMPORTANT findings are **blocking**, not advisory. MINOR findings are non-blocking.
+
 ```
 ## Review
 

--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -22,6 +22,22 @@
 - Comments only when the WHY is non-obvious.
 - Files end with a newline. No trailing whitespace.
 
+## Quality Gate
+
+Every change is scored on three named axes before it ships:
+
+- **Minimalism** — every line, parameter, and abstraction is load-bearing. Try to remove something; if you can without losing correctness, it isn't minimal yet.
+- **Elegance** — intent is clear on first read. If a senior engineer would re-read any part to understand the design, it isn't elegant yet.
+- **Correctness** — edge cases handled. Walk at least two non-happy-path scenarios; if either breaks, it isn't correct yet.
+
+**The bar is 9/10 on each axis.** 9 means "I looked hard and found nothing I'd be embarrassed by" — achievable, so the loop terminates. 10 invites infinite polishing; don't chase it.
+
+**A sub-9 score MUST name the concrete defect, not a bare number.** "Looks good" and "9/10" are both rejected. Score → defect → fix → rescore.
+
+**A named defect hard-blocks the handoff** until it's fixed.
+
+**Circuit breaker.** Paul drives the Duncan↔Thufir iteration. The fix→review budget is **1 pass for Chore/Small tasks, 2 passes for Standard/Large**. If an axis is still sub-9 after the budget is exhausted, OR Duncan and Thufir disagree on whether a defect is real, Paul stops iterating and escalates to Will with: the defect, both positions, and Paul's recommendation. Escalation is the only exit besides a cleared gate.
+
 ## Worktree Discipline
 
 All code changes happen in a git worktree, never on the default branch. Branch naming: `<username>/<descriptive-slug>`.

--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -36,7 +36,7 @@ Every change is scored on three named axes before it ships:
 
 **A named defect hard-blocks the handoff** until it's fixed.
 
-**Circuit breaker.** Paul drives the Duncan↔Thufir iteration. The fix→review budget is **1 pass for Chore/Small tasks, 2 passes for Standard/Large**. If an axis is still sub-9 after the budget is exhausted, OR Duncan and Thufir disagree on whether a defect is real, Paul stops iterating and escalates to Will with: the defect, both positions, and Paul's recommendation. Escalation is the only exit besides a cleared gate.
+**Circuit breaker.** Paul drives the Duncan↔Thufir iteration. Paul owns the pass count and announces the budget when he opens the loop — **1 pass for Chore/Small tasks, 2 passes for Standard/Large**. If an axis is still sub-9 after the budget is exhausted, OR Duncan and Thufir disagree on whether a defect is real, Paul stops iterating and escalates to Will with: the defect, both positions, and Paul's recommendation. Escalation is the only exit besides a cleared gate.
 
 ## Worktree Discipline
 

--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -38,6 +38,8 @@ Every change is scored on three named axes before it ships:
 
 **Circuit breaker.** Paul drives the Duncan↔Thufir iteration. Paul owns the pass count and announces the budget when he opens the loop — **1 pass for Chore/Small tasks, 2 passes for Standard/Large**. If an axis is still sub-9 after the budget is exhausted, OR Duncan and Thufir disagree on whether a defect is real, Paul stops iterating and escalates to Will with: the defect, both positions, and Paul's recommendation. Escalation is the only exit besides a cleared gate.
 
+**Chore exemption.** Chores skip Thufir review — the implementer's correctness self-score is the gate; ship on green. Paul-dictated fixes where Paul supplied the exact text also skip review. **Exception:** a fix to a Thufir-flagged CRITICAL/IMPORTANT finding always gets re-review regardless of size — it inherits the risk of the defect it resolves. The exemption rides on correct classification, which is Paul's; a change needing all three axes was never a Chore, and misrouting it is Paul's error to catch, not a hole in the gate.
+
 ## Worktree Discipline
 
 All code changes happen in a git worktree, never on the default branch. Branch naming: `<username>/<descriptive-slug>`.


### PR DESCRIPTION
Adds a shared quality gate to the Buzz team config so every change is scored on three named axes — minimalism, elegance, correctness — before it ships, with a 9/10 bar that terminates the loop rather than inviting infinite polish.

One shared `## Quality Gate` section in `instructions.md` is the contract all four agents read. Four surgical per-persona additions place one axis at each seat: Paul drives the loop and owns minimalism on plans, Thufir blocks on CRITICAL/IMPORTANT findings, Duncan self-scores all three on implementation, Alia self-scores correctness on quick tasks.

A sub-9 score must name the concrete defect, not a bare number — `9/10` and "looks good" are both rejected. A named defect hard-blocks the handoff until fixed.

Paul drives the Duncan-Thufir iteration and owns the pass count, announcing the budget when he opens the loop (1 pass for Chore/Small, 2 for Standard/Large). If an axis stays sub-9 after the budget, or Duncan and Thufir disagree on whether a defect is real, Paul escalates to Will rather than looping forever.

Chores skip Thufir review entirely — the implementer's correctness self-score is the gate. Paul-dictated fixes where Paul supplied the exact text also skip review. The one exception: a fix to a Thufir-flagged CRITICAL/IMPORTANT finding always gets re-review regardless of size, since it inherits the risk of the defect it resolves. The exemption rides on correct task classification, which is Paul's responsibility — a change needing all three axes was never a Chore.
