### PR TITLE
fix(updater): fetch release notes from GitHub Releases API

### DIFF
--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -88,6 +88,8 @@ def fetch_changelog_entries(
 ) -> list[tuple[str, str]]:
     """Fetch changelog entries for versions between current and latest.
 
+    Uses the GitHub Releases API so version headings don't need to be parsed.
+
     Args:
         repo: GitHub repository in format "owner/repo"
         current_version: Currently installed version
@@ -99,42 +101,28 @@ def fetch_changelog_entries(
         Returns empty list on any error (private repo, network failure, etc).
     """
     try:
-        url = f"https://raw.githubusercontent.com/{repo}/main/CHANGELOG.md"
+        url = f"https://api.github.com/repos/{repo}/releases"
 
         req = urllib.request.Request(url)
         req.add_header("User-Agent", f"ai-rules/{current_version}")
 
         with urllib.request.urlopen(req, timeout=timeout) as response:
-            changelog_content = response.read().decode()
+            releases = json.loads(response.read().decode())
 
         entries: list[tuple[str, str]] = []
-        current_entry_version: str | None = None
-        current_entry_lines: list[str] = []
-
-        for line in changelog_content.split("\n"):
-            version_match = re.match(r"^##\s+v?(\d+\.\d+\.\d+)", line)
-            if version_match:
-                if current_entry_version and current_entry_lines:
-                    version_obj = current_entry_version
-                    if is_newer(version_obj, current_version) and (
-                        version_obj == latest_version
-                        or not is_newer(version_obj, latest_version)
-                    ):
-                        entries.append(
-                            (current_entry_version, "\n".join(current_entry_lines))
-                        )
-
-                current_entry_version = version_match.group(1)
-                current_entry_lines = []
-            elif current_entry_version and line.strip():
-                current_entry_lines.append(line)
-
-        if current_entry_version and current_entry_lines:
-            if is_newer(current_entry_version, current_version) and (
-                current_entry_version == latest_version
-                or not is_newer(current_entry_version, latest_version)
+        for release in releases:
+            version = release["tag_name"].lstrip("v")
+            if not (
+                is_newer(version, current_version)
+                and (version == latest_version or not is_newer(version, latest_version))
             ):
-                entries.append((current_entry_version, "\n".join(current_entry_lines)))
+                continue
+
+            # Strip the CI-appended Skills Downloads trailer if present
+            body: str = release.get("body") or ""
+            notes = body.split("\n---\n", 1)[0].strip()
+
+            entries.append((version, notes))
 
         return entries
 

--- a/tests/unit/test_bootstrap_updater.py
+++ b/tests/unit/test_bootstrap_updater.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import urllib.error
 
@@ -21,6 +22,7 @@ from ai_rules.bootstrap.updater import (
     check_github_updates,
     check_index_updates,
     check_tool_updates,
+    fetch_changelog_entries,
     get_configured_index_url,
     perform_tool_upgrade,
 )
@@ -1273,3 +1275,72 @@ class TestResolveEffectiveSource:
         from ai_rules.bootstrap.updater import _resolve_effective_source
 
         assert _resolve_effective_source(tool) == ToolSource.PYPI
+
+
+@pytest.mark.unit
+@pytest.mark.bootstrap
+class TestFetchChangelogEntries:
+    """Tests for fetch_changelog_entries using the GitHub Releases API."""
+
+    def _releases_payload(self, releases: list[dict]) -> bytes:
+        return json.dumps(releases).encode()
+
+    def test_returns_entries_in_version_range(self, monkeypatch):
+        """Returns entries for versions newer than current and not newer than latest."""
+        releases = [
+            {"tag_name": "v1.2.0", "body": "## Changes\n\nAdded feature X"},
+            {"tag_name": "v1.1.0", "body": "## Changes\n\nFixed bug Y"},
+            {"tag_name": "v1.0.0", "body": "## Changes\n\nInitial release"},
+        ]
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.urllib.request.urlopen",
+            _mock_urlopen(self._releases_payload(releases)),
+        )
+
+        result = fetch_changelog_entries("owner/repo", "1.0.0", "1.2.0")
+
+        versions = [v for v, _ in result]
+        assert "1.2.0" in versions
+        assert "1.1.0" in versions
+        assert "1.0.0" not in versions
+
+    def test_strips_skills_downloads_trailer(self, monkeypatch):
+        """Skills Downloads section appended by CI is removed from release notes."""
+        body = (
+            "## Changes\n\nSome change\n\n---\n\n"
+            "### Skills Downloads\n\n| table content |"
+        )
+        releases = [{"tag_name": "v2.0.0", "body": body}]
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.urllib.request.urlopen",
+            _mock_urlopen(self._releases_payload(releases)),
+        )
+
+        result = fetch_changelog_entries("owner/repo", "1.0.0", "2.0.0")
+
+        assert len(result) == 1
+        _, notes = result[0]
+        assert "Skills Downloads" not in notes
+
+    def test_empty_releases_returns_empty_list(self, monkeypatch):
+        """Empty releases array returns an empty list."""
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.urllib.request.urlopen",
+            _mock_urlopen(self._releases_payload([])),
+        )
+
+        result = fetch_changelog_entries("owner/repo", "1.0.0", "1.1.0")
+
+        assert result == []
+
+    def test_network_error_returns_empty_list(self, monkeypatch):
+        """Network failure returns empty list without raising."""
+
+        def _raise(*args: Any, **kwargs: Any) -> None:
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr("ai_rules.bootstrap.updater.urllib.request.urlopen", _raise)
+
+        result = fetch_changelog_entries("owner/repo", "1.0.0", "1.1.0")
+
+        assert result == []


### PR DESCRIPTION
Inline changelog display stopped working after the migration to release-please because the CHANGELOG heading format changed from `## v0.49.0` to `## [0.65.1](url)`, breaking the regex parser in `fetch_changelog_entries()`.

Rather than patch the regex (which would break again on any future release tooling change), this switches to the GitHub Releases API. The `body` field on each release object is already the changelog content — no parsing required. This makes the feature robust to any future release tooling changes.

- Replace raw CHANGELOG.md fetch + regex parse with `GET /repos/{repo}/releases` via `urllib.request` (same transport already used in `check_github_updates`)
- Filter releases to the version range between `current_version` and `latest_version` using the existing `is_newer()` helper
- Strip the CI-appended `Skills Downloads` table from each release body before display (split on `\n---\n`, keep first part)
- Add `TestFetchChangelogEntries` unit tests covering version range filtering, trailer stripping, empty response, and network error