### PR TITLE
ci: switch e2e exclusion to marker-based filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=ai_rules --cov-report=term-missing -n auto --ignore=tests/e2e"
+addopts = "-v --cov=ai_rules --cov-report=term-missing -n auto -m 'not e2e'"
 markers = [
     "unit: marks tests as unit tests",
     "integration: marks tests as integration tests",


### PR DESCRIPTION
## Summary

- Replace `--ignore=tests/e2e` with `-m 'not e2e'` in pyproject `addopts`, aligning with the org-wide CI standard being rolled out in [github-config#36](https://github.com/wpfleger96/github-config/pull/36)
- The managed `Justfile` (synced from github-config) uses `just test` → `uv run pytest -m "not e2e"` and `just test-e2e` → `uv run pytest -m e2e --no-cov` — both rely on markers, so the `--ignore` path-based exclusion in `addopts` prevented `just test-e2e` from collecting any tests
- All 42 e2e tests already carry `@pytest.mark.e2e`; no test file changes needed

Related: [shell-configs#84](https://github.com/wpfleger96/shell-configs/pull/84), [github-config#36](https://github.com/wpfleger96/github-config/pull/36)

## Verification

- `uv run pytest -m 'not e2e' --collect-only` → 933 collected, 42 deselected (e2e excluded)
- `uv run pytest -m e2e --no-cov --collect-only` → 42 collected, 933 deselected (e2e only)