### PR TITLE
feat(personal): enable remote control at startup

### DIFF
--- a/src/ai_rules/config/profiles/personal.yaml
+++ b/src/ai_rules/config/profiles/personal.yaml
@@ -4,6 +4,7 @@ extends: default
 settings_overrides:
   claude:
     model: opusplan
+    remoteControlAtStartup: true
     permissions:
       defaultMode: bypassPermissions
   statusline:


### PR DESCRIPTION
Adds `remoteControlAtStartup: true` to the personal profile's `settings_overrides.claude` block so remote control activates automatically on every CLI session after `ai-agent-rules install`.

The setting lives in `~/.claude/settings.json`, which the profile system already manages via its `settings_overrides` merge pipeline — no code changes needed. The previously-reported bug about this setting not persisting was specific to the VS Code extension and desktop app; CLI sessions on WSL honor it correctly.