### PR TITLE
feat: add conventional commit PR title rule and agent-author trailers

### DIFF
--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -163,7 +163,13 @@ Iterate until all three are genuinely 9/10. A 9 means you actively tried to find
 
 **Rule:** After pushing to an open PR, re-evaluate title and description. A PR description is a snapshot of what this branch changes vs. main — never a timeline of how it evolved.
 
-After every push: `gh pr view <number> --json title,body` → evaluate if title/description covers ALL commits (not just latest push) → if stale, rewrite from scratch via `gh pr edit`. Never add "Review fixes" sections — rewrite the full description.
+After every push: `gh pr view <number> --json title,body` → evaluate if title/description covers ALL commits (not just latest push) → if stale, rewrite from scratch via `gh pr edit`. Also verify the title still uses the correct conventional commit type. Never add "Review fixes" sections — rewrite the full description.
+
+### PR Titles
+
+**Rule:** PR titles must follow the same conventional commit format as commit message subjects — repos use squash merge, so the PR title becomes the squash commit subject line.
+
+**Format:** `<type>(<optional-scope>): <imperative verb> <specific change>` (50-70 chars). Same types and accuracy rules as the Commit Messages section below.
 
 ### PR Description Content
 
@@ -228,6 +234,19 @@ for complex filtered queries rather than converting to ORM. Fixes
 None-safety bug in statistics display (obstructive_apneas > 0
 crashed when value was None).
 ```
+
+### Agent-Authored Commits
+
+**Rule:** When the agent is the git commit author — detected by checking `git config user.name` and confirming it is not the user's name — every commit must include both trailers:
+
+```
+Co-authored-by: Will Pfleger <email>
+Signed-off-by: Will Pfleger <email>
+```
+
+**Discover email:** Run `git log --format="%aN <%aE>" | grep -i "will pfleger" | head -1` in the repo. Never hardcode.
+
+**Why:** `Co-authored-by` ensures proper GitHub attribution. `Signed-off-by` satisfies DCO checks requiring human sign-off on agent-authored commits. Applies to commit messages only — not PR descriptions.
 
 ---
 

--- a/src/ai_rules/config/skills/pr-creator/SKILL.md
+++ b/src/ai_rules/config/skills/pr-creator/SKILL.md
@@ -85,7 +85,7 @@ git push -u origin HEAD
 
 ### Create PR
 
-**Extract title** from opening paragraph (50-70 chars)
+**Title** must use conventional commit format: `<type>(<optional-scope>): <imperative verb> <specific change>` (50-70 chars). Use the PR type detected in Step 1. Same accuracy rules as Commit Messages in AGENTS.md.
 
 **Create** (use HEREDOC for formatting):
 

--- a/src/ai_rules/config/skills/pr-creator/references/templates.md
+++ b/src/ai_rules/config/skills/pr-creator/references/templates.md
@@ -327,18 +327,6 @@ Authentication overhead was allowing unbounded request rates.
 
 ## Title Guidelines
 
-**Length:** 50-70 characters
+**Format:** `<type>(<optional-scope>): <imperative verb> <specific change>` (50-70 chars)
 
-**Format:** Start with verb, be specific
-
-**Good titles:**
-- "Add email verification to user registration"
-- "Fix duplicate notifications on self-comments"
-- "Refactor auth middleware for dependency injection"
-- "Update API docs for new pagination format"
-
-**Bad titles:**
-- "Feature" (too vague)
-- "Fix bug" (what bug?)
-- "Update" (update what?)
-- "This PR adds a comprehensive email verification system with token generation, expiry, and email sending capabilities" (too long)
+Squash merges use the PR title as the commit subject — follow the same conventional commit format as Commit Messages in AGENTS.md. Use the PR type detected during classification (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`). Same accuracy rules apply.


### PR DESCRIPTION
This PR adds conventional commit format requirements for PR titles and co-author/sign-off trailer rules for agent-authored commits.

Repos now squash-merge using the PR title as the commit subject, so title format directly affects git history and changelogs. Agent-authored commits from cloud sessions (e.g., Claude Code Web) also lacked human attribution footers needed for DCO compliance and GitHub attribution.

- Add `PR Titles` section to `AGENTS.md` requiring `<type>(<scope>): verb change` format (50-70 chars), referencing the existing Commit Messages type table rather than duplicating it
- Add `Agent-Authored Commits` section to `AGENTS.md`: detect agent authorship via `git config user.name`, discover email from repo history, require `Co-authored-by` and `Signed-off-by` trailers
- Update `PR Maintenance` rule to also verify the title's conventional commit type on each push
- Update `pr-creator` skill (`SKILL.md` and `references/templates.md`) to enforce conventional commit format for PR titles, replacing the previous "start with verb, be specific" guidance