### PR TITLE
fix: add explicit UTF-8 encoding to all text file I/O for Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ where = ["src"]
 ai_rules = ["config/**/*", "config/**/.*", "config/**/.*/*"]
 
 [tool.ruff.lint]
-select = ["I", "F", "UP", "B"]  # isort, pyflakes, pyupgrade, bugbear
+preview = true
+select = ["I", "F", "UP", "B", "PLW1514"]  # isort, pyflakes, pyupgrade, bugbear, unspecified-encoding
 
 [tool.ruff.lint.isort]
 lines-between-types = 1

--- a/src/ai_rules/bootstrap/registry.py
+++ b/src/ai_rules/bootstrap/registry.py
@@ -43,7 +43,7 @@ def _is_recall_configured(config: object) -> bool:
             if hasattr(traversable, "is_file") and traversable.is_file():
                 import json
 
-                data = json.loads(traversable.read_text())
+                data = json.loads(traversable.read_text(encoding="utf-8"))
                 if "recall" in data:
                     return True
     except Exception:

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -304,7 +304,7 @@ def _get_tool_venv_python(package_name: str) -> str | None:
 
     pyvenv_cfg = get_uv_tools_dir() / package_name / "pyvenv.cfg"
     try:
-        for line in pyvenv_cfg.read_text().splitlines():
+        for line in pyvenv_cfg.read_text(encoding="utf-8").splitlines():
             if line.startswith("version_info"):
                 return line.split("=", 1)[1].strip()
     except OSError:

--- a/src/ai_rules/cli/groups/config.py
+++ b/src/ai_rules/cli/groups/config.py
@@ -112,7 +112,7 @@ def config_show(merged: bool, agent: str | None) -> None:
         console.print("[bold]Configuration:[/bold]\n")
 
         if user_config_path.exists():
-            with open(user_config_path) as f:
+            with open(user_config_path, encoding="utf-8") as f:
                 content = f.read()
             console.print(f"[bold]User Config:[/bold] {user_config_path}")
             console.print(content)
@@ -138,7 +138,7 @@ def config_edit() -> None:
 
     if not user_config_path.exists():
         user_config_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             f.write("version: 1\n")
 
     try:

--- a/src/ai_rules/completions.py
+++ b/src/ai_rules/completions.py
@@ -132,7 +132,7 @@ def is_completion_installed(config_path: Path) -> bool:
     if not config_path.exists():
         return False
 
-    content = config_path.read_text()
+    content = config_path.read_text(encoding="utf-8")
     return _has_any_marker(content)
 
 
@@ -144,7 +144,7 @@ def is_legacy_completion_block(config_path: Path) -> bool:
     if not config_path.exists():
         return False
 
-    content = config_path.read_text()
+    content = config_path.read_text(encoding="utf-8")
     if _LEGACY_MARKER_START in content:
         return True
     if COMPLETION_MARKER_START in content and "command -v" not in content:
@@ -283,7 +283,7 @@ def install_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
         return True, f"Would append completion script to {config_path}"
 
     try:
-        with config_path.open("a") as f:
+        with config_path.open("a", encoding="utf-8") as f:
             f.write(f"\n{script}\n")
         return (
             True,
@@ -305,7 +305,7 @@ def update_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
     if dry_run:
         return True, f"Would update completion in {config_path}"
 
-    content = config_path.read_text()
+    content = config_path.read_text(encoding="utf-8")
 
     start_re = (
         re.escape(COMPLETION_MARKER_START) + "|" + re.escape(_LEGACY_MARKER_START)
@@ -315,7 +315,7 @@ def update_completion(shell: str, dry_run: bool = False) -> tuple[bool, str]:
     new_content, n = re.subn(pattern, new_script, content, flags=re.DOTALL)
     if n == 0:
         return False, f"Could not find completion block in {config_path}"
-    config_path.write_text(new_content)
+    config_path.write_text(new_content, encoding="utf-8")
     return (
         True,
         f"Completion updated in {config_path}. Restart your shell or run: source {config_path}",
@@ -338,7 +338,7 @@ def uninstall_completion(config_path: Path) -> tuple[bool, str]:
         return True, f"Completion not installed in {config_path}"
 
     try:
-        content = config_path.read_text()
+        content = config_path.read_text(encoding="utf-8")
 
         start_re = (
             re.escape(COMPLETION_MARKER_START) + "|" + re.escape(_LEGACY_MARKER_START)
@@ -350,7 +350,7 @@ def uninstall_completion(config_path: Path) -> tuple[bool, str]:
         # Clean up extra blank lines left behind
         new_content = re.sub(r"\n{3,}", "\n\n", new_content)
 
-        config_path.write_text(new_content)
+        config_path.write_text(new_content, encoding="utf-8")
         return True, f"Completion removed from {config_path}"
     except Exception as e:
         return False, f"Failed to modify {config_path}: {e}"

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -459,7 +459,7 @@ class ManagedFieldsTracker:
             with open(self.path, encoding="utf-8") as f:
                 self._data = json.load(f)
                 return self._data
-        except (OSError, json.JSONDecodeError):
+        except OSError, json.JSONDecodeError:
             self._data = {"version": 1}
             return self._data
 

--- a/src/ai_rules/config.py
+++ b/src/ai_rules/config.py
@@ -149,11 +149,11 @@ def load_config_file(path: Path, config_format: str) -> dict[str, Any]:
         with open(path, "rb") as f:
             return tomllib.load(f)
     elif config_format == "json":
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             result: dict[str, Any] = json.load(f)
             return result
     elif config_format == "yaml":
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             result = yaml.safe_load(f) or {}
             return result
     raise ValueError(f"Unsupported config format: {config_format}")
@@ -195,7 +195,7 @@ def write_file_atomic(
     fd, temp_path = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
     try:
         mode = "wb" if binary else "w"
-        with open(fd, mode) as f:
+        with open(fd, mode, encoding=None if binary else "utf-8") as f:
             write_fn(f)
         if path.exists():
             shutil.copymode(path, temp_path)
@@ -456,10 +456,10 @@ class ManagedFieldsTracker:
             return self._data
 
         try:
-            with open(self.path) as f:
+            with open(self.path, encoding="utf-8") as f:
                 self._data = json.load(f)
                 return self._data
-        except OSError, json.JSONDecodeError:
+        except (OSError, json.JSONDecodeError):
             self._data = {"version": 1}
             return self._data
 
@@ -470,7 +470,7 @@ class ManagedFieldsTracker:
 
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.path, "w") as f:
+            with open(self.path, "w", encoding="utf-8") as f:
                 json.dump(self._data, f, indent=2, sort_keys=True)
                 f.write("\n")
         except Exception:
@@ -679,7 +679,7 @@ class Config:
 
         user_config_path = get_user_config_path()
         if user_config_path.exists():
-            with open(user_config_path) as f:
+            with open(user_config_path, encoding="utf-8") as f:
                 user_data = yaml.safe_load(f) or {}
             fields = cls._merge_user_overrides(fields, user_data)
 
@@ -898,7 +898,7 @@ class Config:
         user_config_path = get_user_config_path()
 
         if user_config_path.exists():
-            with open(user_config_path) as f:
+            with open(user_config_path, encoding="utf-8") as f:
                 return yaml.safe_load(f) or {"version": 1}
         return {"version": 1}
 
@@ -912,7 +912,7 @@ class Config:
         user_config_path = get_user_config_path()
         user_config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=True)
 
     def cleanup_orphaned_cache(self, agents_needing_cache: set[str]) -> list[str]:

--- a/src/ai_rules/mcp.py
+++ b/src/ai_rules/mcp.py
@@ -121,10 +121,10 @@ class MCPManager(ABC):
         legacy_file = config_dir / "claude" / "mcps.json"
 
         if shared_file.exists():
-            with open(shared_file) as f:
+            with open(shared_file, encoding="utf-8") as f:
                 base_mcps: dict[str, Any] = json.load(f)
         elif legacy_file.exists():
-            with open(legacy_file) as f:
+            with open(legacy_file, encoding="utf-8") as f:
                 base_mcps = json.load(f)
         else:
             return {}
@@ -349,7 +349,7 @@ class ClaudeMCPManager(MCPManager):
     def _read_installed(self) -> dict[str, Any]:
         if not self._claude_json_path.exists():
             return {}
-        with open(self._claude_json_path) as f:
+        with open(self._claude_json_path, encoding="utf-8") as f:
             data: dict[str, Any] = json.load(f)
         return cast(dict[str, Any], data.get("mcpServers", {}))
 
@@ -357,7 +357,7 @@ class ClaudeMCPManager(MCPManager):
         self._claude_json_path.parent.mkdir(parents=True, exist_ok=True)
 
         if self._claude_json_path.exists():
-            with open(self._claude_json_path) as f:
+            with open(self._claude_json_path, encoding="utf-8") as f:
                 data: dict[str, Any] = json.load(f)
         else:
             data = {}
@@ -436,7 +436,7 @@ class GooseMCPManager(MCPManager):
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():
             return {}
-        with open(self._config_path) as f:
+        with open(self._config_path, encoding="utf-8") as f:
             result = yaml.safe_load(f)
         return cast(dict[str, Any], result) if result else {}
 
@@ -451,7 +451,7 @@ class GooseMCPManager(MCPManager):
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
         full = self._load_full_config()
         full["extensions"] = mcps
-        with open(self._config_path, "w") as f:
+        with open(self._config_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(full, f, default_flow_style=False, sort_keys=True)
 
     def _translate(self, shared_config: dict[str, Any]) -> dict[str, Any]:
@@ -509,7 +509,7 @@ class CodexMCPManager(MCPManager):
 
         if not self._config_path.exists():
             return tomlkit.document()
-        with open(self._config_path) as f:
+        with open(self._config_path, encoding="utf-8") as f:
             return tomlkit.load(f)
 
     def _get_managed_names(self, doc: Any) -> set[str]:
@@ -574,7 +574,7 @@ class CodexMCPManager(MCPManager):
         if self._LEGACY_MANAGED_SECTION in doc:
             del doc[self._LEGACY_MANAGED_SECTION]
 
-        with open(self._config_path, "w") as f:
+        with open(self._config_path, "w", encoding="utf-8") as f:
             f.write(tomlkit.dumps(doc))
 
 
@@ -603,7 +603,7 @@ class _KeyedJsonMCPManager(MCPManager):
     def _load_full_config(self) -> dict[str, Any]:
         if not self._config_path.exists():
             return {}
-        with open(self._config_path) as f:
+        with open(self._config_path, encoding="utf-8") as f:
             data: dict[str, Any] = json.load(f)
         return data
 

--- a/src/ai_rules/plugins.py
+++ b/src/ai_rules/plugins.py
@@ -86,7 +86,7 @@ class PluginManager:
             return {"version": 2, "plugins": {}}
 
         try:
-            with open(self.INSTALLED_PLUGINS_PATH) as f:
+            with open(self.INSTALLED_PLUGINS_PATH, encoding="utf-8") as f:
                 data: dict[str, Any] = json.load(f)
                 return data
         except OSError, json.JSONDecodeError:
@@ -98,7 +98,7 @@ class PluginManager:
             return []
 
         try:
-            with open(self.KNOWN_MARKETPLACES_PATH) as f:
+            with open(self.KNOWN_MARKETPLACES_PATH, encoding="utf-8") as f:
                 data = json.load(f)
                 return list(data.keys())
         except OSError, json.JSONDecodeError:
@@ -110,7 +110,7 @@ class PluginManager:
             return set()
 
         try:
-            with open(self.MANAGED_PLUGINS_PATH) as f:
+            with open(self.MANAGED_PLUGINS_PATH, encoding="utf-8") as f:
                 data = json.load(f)
                 return set(data.get("plugins", []))
         except OSError, json.JSONDecodeError:
@@ -122,9 +122,9 @@ class PluginManager:
             self.MANAGED_PLUGINS_PATH.parent.mkdir(parents=True, exist_ok=True)
 
             data = {"plugins": sorted(list(plugins))}
-            with open(self.MANAGED_PLUGINS_PATH, "w") as f:
+            with open(self.MANAGED_PLUGINS_PATH, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, sort_keys=True)
-            with open(self.MANAGED_PLUGINS_PATH, "a") as f:
+            with open(self.MANAGED_PLUGINS_PATH, "a", encoding="utf-8") as f:
                 f.write("\n")
         except Exception:
             pass
@@ -199,7 +199,7 @@ class PluginManager:
         try:
             settings = {}
             if self.SETTINGS_PATH.exists():
-                with open(self.SETTINGS_PATH) as f:
+                with open(self.SETTINGS_PATH, encoding="utf-8") as f:
                     settings = json.load(f)
 
             if "enabledPlugins" not in settings:
@@ -213,9 +213,9 @@ class PluginManager:
 
             settings["enabledPlugins"][plugin_key] = True
 
-            with open(self.SETTINGS_PATH, "w") as f:
+            with open(self.SETTINGS_PATH, "w", encoding="utf-8") as f:
                 json.dump(settings, f, indent=2, sort_keys=True)
-            with open(self.SETTINGS_PATH, "a") as f:
+            with open(self.SETTINGS_PATH, "a", encoding="utf-8") as f:
                 f.write("\n")
 
             return (OperationResult.SUCCESS, f"Enabled {plugin_key}")
@@ -242,13 +242,13 @@ class PluginManager:
 
             del plugins[plugin_key]
 
-            with open(self.INSTALLED_PLUGINS_PATH, "w") as f:
+            with open(self.INSTALLED_PLUGINS_PATH, "w", encoding="utf-8") as f:
                 json.dump(installed_data, f, indent=2, sort_keys=True)
-            with open(self.INSTALLED_PLUGINS_PATH, "a") as f:
+            with open(self.INSTALLED_PLUGINS_PATH, "a", encoding="utf-8") as f:
                 f.write("\n")
 
             if self.SETTINGS_PATH.exists():
-                with open(self.SETTINGS_PATH) as f:
+                with open(self.SETTINGS_PATH, encoding="utf-8") as f:
                     settings = json.load(f)
 
                 if (
@@ -257,9 +257,9 @@ class PluginManager:
                 ):
                     del settings["enabledPlugins"][plugin_key]
 
-                    with open(self.SETTINGS_PATH, "w") as f:
+                    with open(self.SETTINGS_PATH, "w", encoding="utf-8") as f:
                         json.dump(settings, f, indent=2, sort_keys=True)
-                    with open(self.SETTINGS_PATH, "a") as f:
+                    with open(self.SETTINGS_PATH, "a", encoding="utf-8") as f:
                         f.write("\n")
 
             if clean_cache and cache_path and cache_path.exists():

--- a/src/ai_rules/profiles.py
+++ b/src/ai_rules/profiles.py
@@ -111,7 +111,7 @@ class ProfileLoader:
             )
 
         try:
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
         except yaml.YAMLError as e:
             raise ProfileError(f"Profile '{name}' has invalid YAML: {e}") from e
@@ -246,7 +246,7 @@ class ProfileLoader:
             raise ProfileNotFoundError(f"Profile '{name}' not found")
 
         try:
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 return yaml.safe_load(f) or {}
         except yaml.YAMLError as e:
             raise ProfileError(f"Profile '{name}' has invalid YAML: {e}") from e

--- a/src/ai_rules/state.py
+++ b/src/ai_rules/state.py
@@ -37,7 +37,7 @@ def get_state() -> dict[str, Any]:
         return {}
 
     try:
-        with state_file.open() as f:
+        with state_file.open(encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except Exception:
         return {}
@@ -47,7 +47,7 @@ def _save_state(state: dict[str, Any]) -> None:
     """Save state to file."""
     state_file = _get_state_file()
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    with state_file.open("w") as f:
+    with state_file.open("w", encoding="utf-8") as f:
         yaml.dump(state, f, default_flow_style=False, sort_keys=True)
 
 

--- a/src/ai_rules/tools/buzz.py
+++ b/src/ai_rules/tools/buzz.py
@@ -33,7 +33,7 @@ class BuzzTool(Tool):
         if not manifest.is_file():
             return None
         try:
-            data = json.loads(manifest.read_text())
+            data = json.loads(manifest.read_text(encoding="utf-8"))
             pack_id = data.get("id")
             return pack_id if isinstance(pack_id, str) and pack_id else None
         except json.JSONDecodeError, OSError:

--- a/tests/integration/test_config_commands.py
+++ b/tests/integration/test_config_commands.py
@@ -32,7 +32,7 @@ class TestConfigInitCommand:
         assert result.exit_code == 0
         assert config_path.exists()
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["version"] == 1
@@ -62,7 +62,7 @@ class TestConfigInitCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         normalized = [s.replace("\\", "/") for s in data["exclude_symlinks"]]
@@ -98,7 +98,7 @@ class TestConfigInitCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "settings_overrides" in data
@@ -114,7 +114,7 @@ class TestConfigInitCommand:
         config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump({"version": 1}, f)
 
         inputs = ["n"]  # Decline overwrite
@@ -130,7 +130,7 @@ class TestConfigInitCommand:
         config_path = tmp_path / ".ai-agent-rules-config.yaml"
         monkeypatch.setenv("HOME", str(tmp_path))
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump({"version": 1, "old_key": "old_value"}, f)
 
         inputs = [
@@ -153,7 +153,7 @@ class TestConfigInitCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "old_key" not in data
@@ -198,7 +198,7 @@ class TestConfigShowCommand:
             "exclude_symlinks": ["~/.claude/settings.json"],
         }
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(config_data, f)
 
         result = runner.invoke(main, ["config", "show"])

--- a/tests/integration/test_exclude_commands.py
+++ b/tests/integration/test_exclude_commands.py
@@ -17,7 +17,7 @@ class TestExcludeAddCommand:
         assert result.exit_code == 0
         assert config_path.exists()
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["version"] == 1
@@ -33,14 +33,14 @@ class TestExcludeAddCommand:
             "version": 1,
             "exclude_symlinks": ["~/.existing/pattern.txt"],
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["exclude", "add", "~/.new/pattern.txt"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert len(data["exclude_symlinks"]) == 2
@@ -55,7 +55,7 @@ class TestExcludeAddCommand:
             "version": 1,
             "exclude_symlinks": ["~/.claude/settings.json"],
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["exclude", "add", "~/.claude/settings.json"])
@@ -63,7 +63,7 @@ class TestExcludeAddCommand:
         assert result.exit_code == 0
         assert "already excluded" in result.output
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["exclude_symlinks"].count("~/.claude/settings.json") == 1
@@ -76,7 +76,7 @@ class TestExcludeAddCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "~/.claude/*.json" in data["exclude_symlinks"]
@@ -93,7 +93,7 @@ class TestExcludeRemoveCommand:
             "version": 1,
             "exclude_symlinks": ["~/.pattern1.txt", "~/.pattern2.txt"],
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["exclude", "remove", "~/.pattern1.txt"])
@@ -101,7 +101,7 @@ class TestExcludeRemoveCommand:
         assert result.exit_code == 0
         assert "Removed exclusion pattern" in result.output
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "~/.pattern1.txt" not in data["exclude_symlinks"]
@@ -127,7 +127,7 @@ class TestExcludeRemoveCommand:
             "version": 1,
             "exclude_symlinks": ["~/.other.txt"],
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["exclude", "remove", "~/.nonexistent.txt"])
@@ -147,7 +147,7 @@ class TestExcludeListCommand:
             "version": 1,
             "exclude_symlinks": ["~/.pattern1.txt", "~/.pattern2.txt"],
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         repo_root = tmp_path / "repo"
@@ -165,7 +165,7 @@ class TestExcludeListCommand:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {"version": 1}
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         repo_root = tmp_path / "repo"

--- a/tests/integration/test_override_commands.py
+++ b/tests/integration/test_override_commands.py
@@ -21,7 +21,7 @@ class TestOverrideSetCommand:
         assert result.exit_code == 0
         assert config_path.exists()
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["settings_overrides"]["claude"]["model"] == "claude-3-opus"
@@ -36,7 +36,7 @@ class TestOverrideSetCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["settings_overrides"]["claude"]["cleanupPeriodDays"] == 30
@@ -54,7 +54,7 @@ class TestOverrideSetCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["settings_overrides"]["claude"]["model"] == "my-model-name"
@@ -75,7 +75,7 @@ class TestOverrideSetCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert (
@@ -93,14 +93,14 @@ class TestOverrideSetCommand:
             "version": 1,
             "settings_overrides": {"claude": {"model": "old-model"}},
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "set", "claude.model", "new-model"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["settings_overrides"]["claude"]["model"] == "new-model"
@@ -116,7 +116,7 @@ class TestOverrideSetCommand:
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["settings_overrides"]["claude"]["model"] == "claude-model"
@@ -134,14 +134,14 @@ class TestOverrideUnsetCommand:
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-3-opus", "timeout": 30}},
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "unset", "claude.model"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "model" not in data["settings_overrides"]["claude"]
@@ -159,14 +159,14 @@ class TestOverrideUnsetCommand:
                 }
             },
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "unset", "claude.api.endpoint"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "endpoint" not in data["settings_overrides"]["claude"]["api"]
@@ -182,14 +182,14 @@ class TestOverrideUnsetCommand:
                 "claude": {"api": {"endpoint": "https://api.example.com"}}
             },
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "unset", "claude.api.endpoint"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "claude" not in data.get("settings_overrides", {})
@@ -204,14 +204,14 @@ class TestOverrideUnsetCommand:
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-3-opus"}},
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "unset", "claude.model"])
 
         assert result.exit_code == 0
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert "claude" not in data.get("settings_overrides", {})
@@ -236,7 +236,7 @@ class TestOverrideUnsetCommand:
             "version": 1,
             "settings_overrides": {"claude": {"timeout": 30}},
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         result = runner.invoke(main, ["override", "unset", "claude.model"])
@@ -259,7 +259,7 @@ class TestOverrideListCommand:
                 "goose": {"model": "gpt-4"},
             },
         }
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         repo_root = tmp_path / "repo"
@@ -278,7 +278,7 @@ class TestOverrideListCommand:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         existing_data = {"version": 1}
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(existing_data, f)
 
         repo_root = tmp_path / "repo"
@@ -356,7 +356,7 @@ class TestOverrideSetArrayIndex:
         import yaml
 
         config_path = home / ".ai-agent-rules-config.yaml"
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         stored_list = data["settings_overrides"]["claude"]["hooks"]["SubagentStop"]

--- a/tests/integration/test_status_command.py
+++ b/tests/integration/test_status_command.py
@@ -91,7 +91,7 @@ class TestStatusValidation:
         target_path = Path(str(target).replace("~", str(mock_home)))
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        target_path.write_text("not a symlink")
+        target_path.write_text("not a symlink", encoding="utf-8")
 
         status, message = check_symlink(target_path, source)
 
@@ -111,7 +111,7 @@ class TestStatusValidation:
         target3, source3 = symlinks[2]
         target3_path = Path(str(target3).replace("~", str(mock_home)))
         target3_path.parent.mkdir(parents=True, exist_ok=True)
-        target3_path.write_text("regular file")
+        target3_path.write_text("regular file", encoding="utf-8")
 
         statuses = {}
         for target, source in [
@@ -145,7 +145,7 @@ class TestStatusCacheValidation:
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
         }
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config = Config.load()
@@ -180,7 +180,7 @@ class TestStatusCacheValidation:
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
         }
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config = Config.load()
@@ -193,7 +193,7 @@ class TestStatusCacheValidation:
         time.sleep(0.01)
 
         user_config["settings_overrides"]["claude"]["test_override"] = "updated_value"
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config_reloaded = Config.load()
@@ -216,7 +216,7 @@ class TestStatusCacheValidation:
             "version": 1,
             "settings_overrides": {"claude": {"test_override": "value"}},
         }
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config = Config.load()
@@ -286,7 +286,7 @@ class TestStatusCacheValidation:
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-sonnet-4"}},
         }
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config = Config.load()
@@ -331,7 +331,7 @@ class TestStatusCacheValidation:
             "version": 1,
             "settings_overrides": {"claude": {"model": "claude-sonnet-4"}},
         }
-        with open(user_config_path, "w") as f:
+        with open(user_config_path, "w", encoding="utf-8") as f:
             yaml.dump(user_config, f)
 
         config = Config.load()

--- a/tests/unit/test_cli_lifecycle_components.py
+++ b/tests/unit/test_cli_lifecycle_components.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -36,9 +37,9 @@ class FailingCacheTarget:
         raise ValueError("invalid override")
 
 
+@dataclass
 class Target:
-    def __init__(self, target_id: str):
-        self.target_id = target_id
+    target_id: str
 
 
 class UnavailablePluginManager:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -259,7 +259,7 @@ settings_overrides:
         assert cache_path is not None
         assert cache_path.exists()
 
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             cached = json.load(f)
 
         assert cached["model"] == "claude-sonnet-4-5-20250929"
@@ -383,7 +383,7 @@ settings_overrides:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert result["model"] == "new"
         assert result["enabledPlugins"] == {"my-plugin@marketplace": True}
@@ -416,7 +416,7 @@ settings_overrides:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert "Stop" in result["hooks"]
         assert result["hooks"]["Stop"] == stop_hook
@@ -454,7 +454,7 @@ settings_overrides:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert "Stop" in result["hooks"]
         assert "PreCompact" in result["hooks"]
@@ -691,7 +691,7 @@ settings_overrides:
         cache_path = agent.build_merged_settings(force_rebuild=True)
         assert cache_path is not None
 
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             cached = json.load(f)
 
         assert "amp.mcpServers" in cached
@@ -723,19 +723,19 @@ settings_overrides:
         cache_path = agent.build_merged_settings(force_rebuild=True)
         assert cache_path is not None
 
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             cached = json.load(f)
         cached["amp.mcpServers"]["stale-mcp"] = {
             "command": "old",
             "args": [],
             "_managedBy": "ai-agent-rules",
         }
-        with open(cache_path, "w") as f:
+        with open(cache_path, "w", encoding="utf-8") as f:
             json.dump(cached, f)
 
         cache_path2 = agent.build_merged_settings(force_rebuild=True)
         assert cache_path2 is not None
-        with open(cache_path2) as f:
+        with open(cache_path2, encoding="utf-8") as f:
             result = json.load(f)
 
         assert "keep-mcp" in result["amp.mcpServers"]
@@ -913,7 +913,7 @@ class TestUserContributedKeysPreservation:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert result["model"] == "new"
         assert result["verbose"] is True
@@ -921,7 +921,7 @@ class TestUserContributedKeysPreservation:
         # Second rebuild — the bug dropped user keys here
         result_path2 = agent.build_merged_settings(force_rebuild=True)
         assert result_path2 is not None
-        with open(result_path2) as f:
+        with open(result_path2, encoding="utf-8") as f:
             result2 = json.load(f)
         assert result2["model"] == "new"
         assert result2["verbose"] is True
@@ -953,7 +953,7 @@ class TestUserContributedKeysPreservation:
         for i in range(3):
             result_path = agent.build_merged_settings(force_rebuild=True)
             assert result_path is not None
-            with open(result_path) as f:
+            with open(result_path, encoding="utf-8") as f:
                 result = json.load(f)
             assert result["verbose"] is True, f"verbose missing after rebuild {i + 1}"
 
@@ -1016,7 +1016,7 @@ class TestUserContributedKeysPreservation:
         result_path = agent_b.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert result["verbose"] is True
         assert result["model"] == "beta"
@@ -1048,18 +1048,18 @@ class TestUserContributedKeysPreservation:
 
         result_path = agent.build_merged_settings(force_rebuild=True)
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             first_result = json.load(f)
         assert first_result["verbose"] is True
 
         # Simulate user deleting the key from the cache
         del first_result["verbose"]
-        with open(result_path, "w") as f:
+        with open(result_path, "w", encoding="utf-8") as f:
             json.dump(first_result, f)
 
         result_path2 = agent.build_merged_settings(force_rebuild=True)
         assert result_path2 is not None
-        with open(result_path2) as f:
+        with open(result_path2, encoding="utf-8") as f:
             result2 = json.load(f)
         assert "verbose" not in result2
 
@@ -1099,13 +1099,13 @@ class TestUserContributedKeysPreservation:
 
         result_path = agent.build_merged_settings(force_rebuild=True)
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert "autoCompactEnabled" not in result
 
         result_path2 = agent.build_merged_settings(force_rebuild=True)
         assert result_path2 is not None
-        with open(result_path2) as f:
+        with open(result_path2, encoding="utf-8") as f:
             result2 = json.load(f)
         assert "autoCompactEnabled" not in result2
 
@@ -1191,7 +1191,7 @@ class TestUserContributedKeysPreservation:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert result["model"] == "new"
         assert "autoCompactEnabled" not in result
@@ -1230,7 +1230,7 @@ class TestUserContributedKeysPreservation:
         result_path = agent.build_merged_settings(force_rebuild=True)
 
         assert result_path is not None
-        with open(result_path) as f:
+        with open(result_path, encoding="utf-8") as f:
             result = json.load(f)
         assert result["verbose"] is True
         assert result["autoCompactEnabled"] is False

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -21,7 +21,7 @@ def setup_test_mcp(test_repo):
     """Add test-mcp to mcps.json for MCP-specific tests."""
     mcps_file = test_repo / "claude" / "mcps.json"
     mcps_data = {"test-mcp": {"type": "stdio", "command": "test", "args": []}}
-    mcps_file.write_text(json.dumps(mcps_data, indent=2))
+    mcps_file.write_text(json.dumps(mcps_data, indent=2), encoding="utf-8")
     return test_repo
 
 
@@ -74,7 +74,7 @@ def test_install_mcps_fresh(manager, mock_home, test_repo):
     assert conflicts == []
 
     assert manager.CLAUDE_JSON.exists()
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "mcpServers" in data
         assert "test-mcp" in data["mcpServers"]
@@ -88,16 +88,16 @@ def test_install_mcps_update(manager, mock_home, test_repo):
     manager.install_mcps(test_repo, config, force=True)
 
     mcps_file = test_repo / "claude" / "mcps.json"
-    with open(mcps_file) as f:
+    with open(mcps_file, encoding="utf-8") as f:
         mcps_data = json.load(f)
         mcps_data["test-mcp"]["args"] = ["modified"]
-    with open(mcps_file, "w") as f:
+    with open(mcps_file, "w", encoding="utf-8") as f:
         json.dump(mcps_data, f)
 
     result, message, conflicts = manager.install_mcps(test_repo, config, force=True)
     assert result == OperationResult.UPDATED
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert data["mcpServers"]["test-mcp"]["args"] == ["modified"]
 
@@ -108,10 +108,10 @@ def test_install_mcps_conflict_detection(manager, mock_home, test_repo):
 
     manager.install_mcps(test_repo, config, force=True)
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         data["mcpServers"]["test-mcp"]["args"] = ["user-modified"]
-    with open(manager.CLAUDE_JSON, "w") as f:
+    with open(manager.CLAUDE_JSON, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
     result, message, conflicts = manager.install_mcps(test_repo, config, force=False)
@@ -128,7 +128,7 @@ def test_uninstall_mcps(manager, mock_home, test_repo):
     assert result == OperationResult.REMOVED
     assert "Removed" in message
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "test-mcp" not in data.get("mcpServers", {})
 
@@ -138,19 +138,19 @@ def test_uninstall_preserves_user_mcps(manager, mock_home, test_repo):
     config = Config()
     manager.install_mcps(test_repo, config, force=True)
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         data["mcpServers"]["user-custom-mcp"] = {
             "type": "stdio",
             "command": "user-mcp",
             "args": [],
         }
-    with open(manager.CLAUDE_JSON, "w") as f:
+    with open(manager.CLAUDE_JSON, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
     manager.uninstall_mcps()
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "user-custom-mcp" in data["mcpServers"]
         assert "test-mcp" not in data["mcpServers"]
@@ -161,14 +161,14 @@ def test_status_shows_managed_vs_unmanaged(manager, mock_home, test_repo):
     config = Config()
     manager.install_mcps(test_repo, config, force=True)
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         data["mcpServers"]["user-mcp"] = {
             "type": "stdio",
             "command": "user-mcp",
             "args": [],
         }
-    with open(manager.CLAUDE_JSON, "w") as f:
+    with open(manager.CLAUDE_JSON, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
     status = manager.get_status(test_repo, config)
@@ -186,7 +186,7 @@ def test_claude_json_missing(manager, mock_home, test_repo):
     assert result == OperationResult.UPDATED
     assert manager.CLAUDE_JSON.exists()
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "mcpServers" in data
 
@@ -197,7 +197,7 @@ def test_atomic_write_backup(manager, mock_home, test_repo):
 
     original_content = {"mcpServers": {}, "existingKey": "existingValue"}
     manager.CLAUDE_JSON.parent.mkdir(parents=True, exist_ok=True)
-    with open(manager.CLAUDE_JSON, "w") as f:
+    with open(manager.CLAUDE_JSON, "w", encoding="utf-8") as f:
         json.dump(original_content, f)
 
     manager.install_mcps(test_repo, config, force=True)
@@ -205,7 +205,7 @@ def test_atomic_write_backup(manager, mock_home, test_repo):
     backup_files = list(manager.CLAUDE_JSON.parent.glob("*.ai-agent-rules-backup.*"))
     assert len(backup_files) == 1
 
-    with open(backup_files[0]) as f:
+    with open(backup_files[0], encoding="utf-8") as f:
         backup_data = json.load(f)
         assert backup_data == original_content
 
@@ -252,10 +252,10 @@ def test_status_sync_detection(manager, mock_home, test_repo):
     status = manager.get_status(test_repo, config)
     assert status.installed["test-mcp"] is True
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         data["mcpServers"]["test-mcp"]["args"] = ["modified"]
-    with open(manager.CLAUDE_JSON, "w") as f:
+    with open(manager.CLAUDE_JSON, "w", encoding="utf-8") as f:
         json.dump(data, f)
 
     status = manager.get_status(test_repo, config)
@@ -278,7 +278,7 @@ def test_install_removes_mcps_no_longer_in_repo(manager, mock_home, test_repo):
     config = Config()
 
     manager.install_mcps(test_repo, config, force=True)
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "test-mcp" in data["mcpServers"]
         assert data["mcpServers"]["test-mcp"]["_managedBy"] == "ai-agent-rules"
@@ -290,7 +290,7 @@ def test_install_removes_mcps_no_longer_in_repo(manager, mock_home, test_repo):
     assert result == OperationResult.UPDATED
     assert "removed" in message
 
-    with open(manager.CLAUDE_JSON) as f:
+    with open(manager.CLAUDE_JSON, encoding="utf-8") as f:
         data = json.load(f)
         assert "test-mcp" not in data.get("mcpServers", {})
 
@@ -383,7 +383,7 @@ def test_goose_install_and_uninstall(mock_home, test_repo):
 
     config_path = mock_home / ".config" / "goose" / "config.yaml"
     assert config_path.exists()
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     assert "recall" in data["extensions"]
@@ -392,7 +392,7 @@ def test_goose_install_and_uninstall(mock_home, test_repo):
 
     result, message = mgr.uninstall_mcps()
     assert result == OperationResult.REMOVED
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     assert "recall" not in data.get("extensions", {})
 
@@ -419,7 +419,7 @@ def test_goose_install_removes_unmarked_recall_orphan(mock_home, test_repo):
     result, _message, _conflicts = GooseMCPManager().install_mcps(test_repo, Config())
     assert result == OperationResult.UPDATED
 
-    with open(config_path / "config.yaml") as f:
+    with open(config_path / "config.yaml", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     assert "recall" not in data.get("extensions", {})
 
@@ -449,7 +449,7 @@ def test_goose_install_preserves_unmarked_entry_not_in_previously_managed(
     # Empty mcps.json + no orphans to remove → nothing to do
     assert result == OperationResult.NOT_FOUND
 
-    with open(config_path / "config.yaml") as f:
+    with open(config_path / "config.yaml", encoding="utf-8") as f:
         data = yaml.safe_load(f)
     assert "custom-tool" in data["extensions"]
 
@@ -468,7 +468,7 @@ def test_goose_preserves_non_extension_keys(mock_home, test_repo):
     mgr = GooseMCPManager()
     mgr.install_mcps(test_repo, Config())
 
-    with open(config_path / "config.yaml") as f:
+    with open(config_path / "config.yaml", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     assert data["GOOSE_MODEL"] == "claude-opus-4-5"
@@ -527,7 +527,7 @@ def test_codex_install_and_uninstall(mock_home, test_repo):
 
     config_path = mock_home / ".codex" / "config.toml"
     assert config_path.exists()
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         doc = tomlkit.load(f)
 
     mcp_servers = dict(doc["mcp_servers"])
@@ -538,7 +538,7 @@ def test_codex_install_and_uninstall(mock_home, test_repo):
 
     result, message = mgr.uninstall_mcps()
     assert result == OperationResult.REMOVED
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         doc = tomlkit.load(f)
     mcp_servers_after = dict(doc.get("mcp_servers", {}))
     assert "recall" not in mcp_servers_after
@@ -561,7 +561,7 @@ def test_codex_preserves_non_mcp_keys(mock_home, test_repo):
 
     CodexMCPManager().install_mcps(test_repo, Config())
 
-    with open(config_dir / "config.toml") as f:
+    with open(config_dir / "config.toml", encoding="utf-8") as f:
         doc = tomlkit.load(f)
 
     assert doc["model"] == "gpt-5.2-codex"
@@ -617,7 +617,7 @@ def test_gemini_install_and_uninstall(mock_home, test_repo):
 
     config_path = mock_home / ".gemini" / "settings.json"
     assert config_path.exists()
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert "recall" in data["mcpServers"]
@@ -627,7 +627,7 @@ def test_gemini_install_and_uninstall(mock_home, test_repo):
 
     result, message = mgr.uninstall_mcps()
     assert result == OperationResult.REMOVED
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = json.load(f)
     assert "recall" not in data.get("mcpServers", {})
 
@@ -644,7 +644,7 @@ def test_gemini_preserves_non_mcp_keys(mock_home, test_repo):
 
     GeminiMCPManager().install_mcps(test_repo, Config())
 
-    with open(gemini_dir / "settings.json") as f:
+    with open(gemini_dir / "settings.json", encoding="utf-8") as f:
         data = json.load(f)
 
     assert data["model"] == "gemini-3.1-pro-preview"
@@ -703,7 +703,7 @@ def test_amp_install_and_uninstall(mock_home, test_repo):
 
     config_path = mock_home / ".config" / "amp" / "settings.json"
     assert config_path.exists()
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert "recall" in data["amp.mcpServers"]
@@ -712,7 +712,7 @@ def test_amp_install_and_uninstall(mock_home, test_repo):
 
     result, message = mgr.uninstall_mcps()
     assert result == OperationResult.REMOVED
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         data = json.load(f)
     assert "recall" not in data.get("amp.mcpServers", {})
 
@@ -729,7 +729,7 @@ def test_amp_preserves_non_mcp_keys(mock_home, test_repo):
 
     AmpMCPManager().install_mcps(test_repo, Config())
 
-    with open(amp_dir / "settings.json") as f:
+    with open(amp_dir / "settings.json", encoding="utf-8") as f:
         data = json.load(f)
 
     assert data["amp.showCosts"] is True

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -445,7 +445,7 @@ class TestBundledSkillFrontmatter:
     @staticmethod
     def _frontmatter(skill_md: Path) -> tuple[dict, list[str]]:
         """Return (parsed frontmatter, top-level keys in file order)."""
-        parts = skill_md.read_text().split("---", 2)
+        parts = skill_md.read_text(encoding="utf-8").split("---", 2)
         assert len(parts) >= 3, f"{skill_md}: missing frontmatter"
         raw = parts[1]
         data = yaml.safe_load(raw)


### PR DESCRIPTION
Fixes Windows crashes where `uvx ai-agent-rules setup` fails with `UnicodeDecodeError: 'charmap' codec can't decode byte` because Python defaults to `cp1252` on Windows instead of UTF-8.

The specific crash site (`skills.py`) was fixed in v0.62.0 and is published on PyPI. The user's Windows machine likely resolved an older version because `requires-python >= 3.14` filters out newer releases when Python < 3.14 is installed. An audit found 41 additional production code instances with the same bug across 10 files — any file containing a non-ASCII character (emoji in a skill description, curly quote in YAML) would trigger a crash on Windows.

- Adds `encoding="utf-8"` to all `open()`, `.read_text()`, and `.write_text()` calls in production code (`config.py`, `mcp.py`, `plugins.py`, `completions.py`, `profiles.py`, `state.py`, `cli/groups/config.py`, `bootstrap/updater.py`, `bootstrap/registry.py`, `tools/buzz.py`)
- Fixes `write_file_atomic` with `encoding=None if binary else "utf-8"` to cover its 5+ callers in one change
- Enables ruff `PLW1514` (unspecified-encoding) with `preview = true` to catch regressions at lint time — also fixes all 94 violations the rule surfaces in test files, and converts a single test helper class to a `@dataclass` to resolve `B903` (also activated by preview mode)