### PR TITLE
chore: add .tokeignore to restrict LOC badge to Python source

### DIFF
--- a/.tokeignore
+++ b/.tokeignore
@@ -1,0 +1,8 @@
+*.md
+*.json
+*.yaml
+*.yml
+*.toml
+*.lock
+*.txt
+*.goosehints


### PR DESCRIPTION
Adds `.tokeignore` so the tokei Lines of Code badge counts only `.py` files instead of every tracked file type.

The badge was including JSON configs, Markdown docs, YAML, TOML, lock files, and `.goosehints` in its count, inflating the number well beyond actual source code. The `?category=code` param already strips blanks/comments, but the file-type noise remained.

- excludes `*.md`, `*.json`, `*.yaml`, `*.yml`, `*.toml`, `*.lock`, `*.txt`, `*.goosehints`
- keeps `.py` as the sole counted language