### PR TITLE
fix(windows): correct uv tools directory path

### DIFF
--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -61,14 +61,14 @@ def get_uv_tools_dir() -> Path:
     """Return the platform-appropriate uv tools directory.
 
     Honors UV_TOOL_DIR env var if set (uv's official override).
-    Windows default: %APPDATA%/uv/data/tools
+    Windows default: %APPDATA%/uv/tools
     Unix default:    $XDG_DATA_HOME/uv/tools (fallback ~/.local/share/uv/tools)
     """
     override = os.environ.get("UV_TOOL_DIR")
     if override:
         return Path(override)
     if is_platform(Platform.WINDOWS):
-        return get_appdata_dir() / "uv" / "data" / "tools"
+        return get_appdata_dir() / "uv" / "tools"
     data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
     return Path(data_home) / "uv" / "tools"
 


### PR DESCRIPTION
`get_uv_tools_dir()` on Windows constructed `%APPDATA%/uv/data/tools`, but `uv tool dir` on Windows actually returns `%APPDATA%/uv/tools` (no `data` segment). This caused `get_tool_config_dir()` to look in a nonexistent directory, fall back to `resource_files("ai_rules")`, and create symlinks pointing at the ephemeral `uvx` cache (`AppData\Local\uv\cache\...`) instead of the persistent tools install (`AppData\Roaming\uv\tools\...`).

After a successful `ai-agent-rules setup`, every config file and skill showed "wrong target" in `ai-agent-rules status`.

**Fix:** Remove the spurious `data` path segment in `platform.py:71`.

Related: [shell-configs#94](https://github.com/wpfleger96/shell-configs/pull/94)