### PR TITLE
fix(windows): defer self-upgrade via detached process to avoid exe lock

### DIFF
--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -415,7 +415,9 @@ def _check_and_apply_upgrade(
                     "upgrade_available",
                     f"Would upgrade {spec.display_name} {update_info.current_version} → {update_info.latest_version}",
                 )
-            success, msg, _ = perform_tool_upgrade(spec, is_self=(spec.tool_id == "ai-agent-rules"))
+            success, msg, _ = perform_tool_upgrade(
+                spec, is_self=(spec.tool_id == "ai-agent-rules")
+            )
             if success:
                 return (
                     "upgraded",

--- a/src/ai_rules/bootstrap/installer.py
+++ b/src/ai_rules/bootstrap/installer.py
@@ -415,7 +415,7 @@ def _check_and_apply_upgrade(
                     "upgrade_available",
                     f"Would upgrade {spec.display_name} {update_info.current_version} → {update_info.latest_version}",
                 )
-            success, msg, _ = perform_tool_upgrade(spec)
+            success, msg, _ = perform_tool_upgrade(spec, is_self=(spec.tool_id == "ai-agent-rules"))
             if success:
                 return (
                     "upgraded",

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
+from ai_rules.platform import Platform, is_platform
+
 from .installer import (
     UV_NOT_FOUND_ERROR,
     ToolSource,
@@ -24,7 +26,6 @@ from .installer import (
     make_github_install_url,
 )
 from .version import is_newer
-from ai_rules.platform import Platform, is_platform
 
 _SELF_GITHUB_REPO = "wpfleger96/ai-agent-rules"
 
@@ -393,15 +394,14 @@ def _spawn_deferred_upgrade(
     uv_cmd: list[str],
     post_upgrade_cmd: list[str] | None = None,
 ) -> tuple[bool, str, bool]:
-    import subprocess
-
     parts = ["timeout /t 3 /nobreak >nul", subprocess.list2cmdline(uv_cmd)]
     if post_upgrade_cmd:
         parts.append(subprocess.list2cmdline(post_upgrade_cmd))
 
     subprocess.Popen(
         ["cmd.exe", "/c", " && ".join(parts)],
-        creationflags=0x00000008 | 0x00000200,  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        creationflags=0x00000008
+        | 0x00000200,  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
         close_fds=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -24,6 +24,7 @@ from .installer import (
     make_github_install_url,
 )
 from .version import is_newer
+from ai_rules.platform import Platform, is_platform
 
 _SELF_GITHUB_REPO = "wpfleger96/ai-agent-rules"
 
@@ -388,9 +389,32 @@ def _resolve_effective_source(tool: ToolSpec) -> ToolSource:
     return receipt_source or ToolSource.PYPI
 
 
+def _spawn_deferred_upgrade(
+    uv_cmd: list[str],
+    post_upgrade_cmd: list[str] | None = None,
+) -> tuple[bool, str, bool]:
+    import subprocess
+
+    parts = ["timeout /t 3 /nobreak >nul", subprocess.list2cmdline(uv_cmd)]
+    if post_upgrade_cmd:
+        parts.append(subprocess.list2cmdline(post_upgrade_cmd))
+
+    subprocess.Popen(
+        ["cmd.exe", "/c", " && ".join(parts)],
+        creationflags=0x00000008 | 0x00000200,  # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        close_fds=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+    return True, "deferred", True
+
+
 def perform_tool_upgrade(
     tool: ToolSpec,
     target_version: str | None = None,
+    is_self: bool = False,
+    post_upgrade_cmd: list[str] | None = None,
 ) -> tuple[bool, str, bool]:
     """Upgrade a tool via uv, handling PyPI and GitHub sources.
 
@@ -435,6 +459,9 @@ def perform_tool_upgrade(
 
     if python_flag:
         cmd.extend(["--python", python_flag])
+
+    if is_self and is_platform(Platform.WINDOWS):
+        return _spawn_deferred_upgrade(cmd, post_upgrade_cmd)
 
     try:
         result = subprocess.run(

--- a/src/ai_rules/cli/commands/setup.py
+++ b/src/ai_rules/cli/commands/setup.py
@@ -172,7 +172,9 @@ def setup(
                             print_warning("Skipped ai-agent-rules upgrade")
                             tool_install_success = True
                         else:
-                            success, msg, _ = perform_tool_upgrade(ai_rules_tool, is_self=True)
+                            success, msg, _ = perform_tool_upgrade(
+                                ai_rules_tool, is_self=True
+                            )
                             if success:
                                 print_success(
                                     f"Upgraded ai-agent-rules ({update_info.current_version} → {update_info.latest_version})"

--- a/src/ai_rules/cli/commands/setup.py
+++ b/src/ai_rules/cli/commands/setup.py
@@ -172,7 +172,7 @@ def setup(
                             print_warning("Skipped ai-agent-rules upgrade")
                             tool_install_success = True
                         else:
-                            success, msg, _ = perform_tool_upgrade(ai_rules_tool)
+                            success, msg, _ = perform_tool_upgrade(ai_rules_tool, is_self=True)
                             if success:
                                 print_success(
                                     f"Upgraded ai-agent-rules ({update_info.current_version} → {update_info.latest_version})"

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -190,8 +190,13 @@ def upgrade(
 
     current_profile = get_active_profile() or "default"
     self_post_upgrade_cmd = [
-        "ai-agent-rules", "install", "--rebuild-cache", "--force", "-y",
-        "--profile", current_profile,
+        "ai-agent-rules",
+        "install",
+        "--rebuild-cache",
+        "--force",
+        "-y",
+        "--profile",
+        current_profile,
     ]
 
     ai_rules_upgraded = False
@@ -202,7 +207,9 @@ def upgrade(
                     tool,
                     target_version=update_info.latest_version,
                     is_self=(tool.tool_id == "ai-agent-rules"),
-                    post_upgrade_cmd=self_post_upgrade_cmd if tool.tool_id == "ai-agent-rules" else None,
+                    post_upgrade_cmd=self_post_upgrade_cmd
+                    if tool.tool_id == "ai-agent-rules"
+                    else None,
                 )
             except Exception as e:
                 print_error(f"{tool.display_name} upgrade failed: {e}")
@@ -211,7 +218,9 @@ def upgrade(
         if success:
             if msg == "deferred":
                 print_success(f"{tool.display_name} upgrade started in the background")
-                print_hint("Run 'ai-agent-rules install --rebuild-cache' once it completes if needed")
+                print_hint(
+                    "Run 'ai-agent-rules install --rebuild-cache' once it completes if needed"
+                )
             else:
                 new_version = tool.get_version()
                 if new_version == update_info.latest_version:

--- a/src/ai_rules/cli/commands/upgrade.py
+++ b/src/ai_rules/cli/commands/upgrade.py
@@ -186,40 +186,55 @@ def upgrade(
             print_warning("Cancelled")
             return
 
+    from ai_rules.state import get_active_profile
+
+    current_profile = get_active_profile() or "default"
+    self_post_upgrade_cmd = [
+        "ai-agent-rules", "install", "--rebuild-cache", "--force", "-y",
+        "--profile", current_profile,
+    ]
+
     ai_rules_upgraded = False
     for tool, update_info in tool_updates:
         with console.status(f"Upgrading {tool.display_name}..."):
             try:
                 success, msg, was_upgraded = perform_tool_upgrade(
-                    tool, target_version=update_info.latest_version
+                    tool,
+                    target_version=update_info.latest_version,
+                    is_self=(tool.tool_id == "ai-agent-rules"),
+                    post_upgrade_cmd=self_post_upgrade_cmd if tool.tool_id == "ai-agent-rules" else None,
                 )
             except Exception as e:
                 print_error(f"{tool.display_name} upgrade failed: {e}")
                 continue
 
         if success:
-            new_version = tool.get_version()
-            if new_version == update_info.latest_version:
-                print_success(f"{tool.display_name} upgraded to {new_version}")
-                if tool.tool_id == "ai-agent-rules":
-                    ai_rules_upgraded = True
-            elif new_version == update_info.current_version:
-                print_warning(
-                    f"{tool.display_name} upgrade reported success but version "
-                    f"unchanged ({new_version})"
-                )
-                if msg and msg != "Upgrade successful":
-                    print_hint(msg)
-                else:
-                    print_hint(
-                        "This may be due to a Python version mismatch. Check the "
-                        "package's requires-python and try: "
-                        f"uv tool upgrade {tool.package_name} --python <version>"
-                    )
+            if msg == "deferred":
+                print_success(f"{tool.display_name} upgrade started in the background")
+                print_hint("Run 'ai-agent-rules install --rebuild-cache' once it completes if needed")
             else:
-                print_success(f"{tool.display_name} upgraded to {new_version}")
-                if tool.tool_id == "ai-agent-rules":
-                    ai_rules_upgraded = True
+                new_version = tool.get_version()
+                if new_version == update_info.latest_version:
+                    print_success(f"{tool.display_name} upgraded to {new_version}")
+                    if tool.tool_id == "ai-agent-rules":
+                        ai_rules_upgraded = True
+                elif new_version == update_info.current_version:
+                    print_warning(
+                        f"{tool.display_name} upgrade reported success but version "
+                        f"unchanged ({new_version})"
+                    )
+                    if msg and msg != "Upgrade successful":
+                        print_hint(msg)
+                    else:
+                        print_hint(
+                            "This may be due to a Python version mismatch. Check the "
+                            "package's requires-python and try: "
+                            f"uv tool upgrade {tool.package_name} --python <version>"
+                        )
+                else:
+                    print_success(f"{tool.display_name} upgraded to {new_version}")
+                    if tool.tool_id == "ai-agent-rules":
+                        ai_rules_upgraded = True
         else:
             print_error(f"{tool.display_name} upgrade failed: {msg}")
 


### PR DESCRIPTION
On Windows, `ai-agent-rules upgrade` fails when upgrading itself:

```
error: failed to remove directory `...\Scripts`: Access is denied. (os error 5)
```

The running `ai-agent-rules.exe` holds a lock on the `Scripts/` directory, so `uv tool install --force --reinstall` cannot replace it.

When upgrading itself (`is_self=True`) on Windows, the tool now spawns a detached `cmd.exe` process that waits 3 seconds for the current process to exit, then runs the uv upgrade and post-install step. The current process exits cleanly with a "completing in the background" message.

Non-self upgrades (e.g. upgrading `statusline`) and non-Windows platforms use the existing synchronous path unchanged.

Related: [shell-configs#95](https://github.com/wpfleger96/shell-configs/pull/95)