### PR TITLE
chore: disable Claude Code session feedback survey prompts

### DIFF
--- a/src/ai_rules/config/claude/settings.json
+++ b/src/ai_rules/config/claude/settings.json
@@ -11,7 +11,8 @@
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6[1m]",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_CODE_EFFORT_LEVEL": "max",
-    "ENABLE_LSP_TOOL": "1"
+    "ENABLE_LSP_TOOL": "1",
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1"
   },
   "attribution": {
     "commit": "",


### PR DESCRIPTION
Adds `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY=1` to the `env` block in `src/ai_rules/config/claude/settings.json` to suppress the occasional 0-3 session rating prompt in Claude Code.

This is the most targeted suppression option — it leaves telemetry, error reporting, and all other Claude Code behavior untouched.

https://claude.ai/code/session_01MZuKLyQ9pUV2L7iqGNRX6Q