### PR TITLE
refactor(buzz): remove legacy Sprout symlink paths

### DIFF
--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -6,7 +6,7 @@
 |-------|------|---------|-------|-----------------|
 | @Paul | Orchestrator + Planner — plans, delegates, synthesizes | Goose | Claude Opus | Receives tasks, plans work, coordinates the team |
 | @Duncan | Primary Executor — implements, researches, tests, documents | Goose | Claude Sonnet | All execution work; run multiple instances for parallel tasks |
-| @Thufir | Primary Analyst — reviews code and plans | sprout-agent | GPT 5.5 | Plan review, code review, investigation |
+| @Thufir | Primary Analyst — reviews code and plans | buzz-agent | GPT 5.5 | Plan review, code review, investigation |
 | @Alia | Quick tasks — simple edits, summaries, formatting | Goose | Claude Haiku | Fast, simple, well-defined tasks |
 
 ## Collaboration Model

--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -114,9 +114,3 @@ def get_statusline_config_dir() -> Path:
 def get_buzz_teams_dir(dev: bool = False) -> Path:
     bundle = "xyz.block.buzz.app.dev" if dev else "xyz.block.buzz.app"
     return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"
-
-
-def get_legacy_sprout_teams_dir(dev: bool = False) -> Path:
-    """Pre-rename Sprout bundle paths — remove once upstream desktop rename is fully shipped."""
-    bundle = "xyz.block.sprout.app.dev" if dev else "xyz.block.sprout.app"
-    return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"

--- a/src/ai_rules/tools/buzz.py
+++ b/src/ai_rules/tools/buzz.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from ai_rules.platform import (
     Platform,
     get_buzz_teams_dir,
-    get_legacy_sprout_teams_dir,
     is_platform,
 )
 from ai_rules.tools.base import Tool
@@ -58,7 +57,4 @@ class BuzzTool(Tool):
         return [
             (get_buzz_teams_dir(dev=False) / pack_id, source),
             (get_buzz_teams_dir(dev=True) / pack_id, source),
-            # Legacy Sprout paths — remove once upstream desktop rename is fully shipped
-            (get_legacy_sprout_teams_dir(dev=False) / pack_id, source),
-            (get_legacy_sprout_teams_dir(dev=True) / pack_id, source),
         ]

--- a/tests/unit/test_buzz_tool.py
+++ b/tests/unit/test_buzz_tool.py
@@ -40,7 +40,7 @@ def test_buzz_tool_symlinks_on_macos(
 
     links = tool.symlinks
 
-    assert len(links) == 4
+    assert len(links) == 2
 
 
 @pytest.mark.unit
@@ -77,7 +77,7 @@ def test_buzz_tool_target_paths_use_correct_bundles(
     tool = BuzzTool(tmp_path, Config())
 
     links = tool.symlinks
-    assert len(links) == 4
+    assert len(links) == 2
 
     target_prod, _ = links[0]
     target_dev, _ = links[1]
@@ -87,28 +87,6 @@ def test_buzz_tool_target_paths_use_correct_bundles(
     assert "xyz.block.buzz.app.dev" in target_dev.as_posix()
     assert target_prod.name == "com.test.my-pack"
     assert target_dev.name == "com.test.my-pack"
-
-
-@pytest.mark.unit
-def test_buzz_tool_legacy_sprout_symlinks(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mock_home: Path
-) -> None:
-    """Legacy Sprout paths — remove this test once upstream desktop rename is fully shipped."""
-    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
-    buzz_dir = tmp_path / "buzz"
-    buzz_dir.mkdir()
-    _create_pack_manifest(buzz_dir, pack_id="com.test.my-pack")
-    tool = BuzzTool(tmp_path, Config())
-
-    links = tool.symlinks
-    legacy_prod, _ = links[2]
-    legacy_dev, _ = links[3]
-
-    assert "xyz.block.sprout.app" in legacy_prod.as_posix()
-    assert "xyz.block.sprout.app.dev" not in legacy_prod.as_posix()
-    assert "xyz.block.sprout.app.dev" in legacy_dev.as_posix()
-    assert legacy_prod.name == "com.test.my-pack"
-    assert legacy_dev.name == "com.test.my-pack"
 
 
 @pytest.mark.unit
@@ -169,7 +147,7 @@ def test_buzz_tool_symlinks_use_pack_id_from_manifest(
     tool = BuzzTool(tmp_path, Config())
 
     links = tool.symlinks
-    assert len(links) == 4
+    assert len(links) == 2
 
     for target, _source in links:
         assert target.name == "com.example.custom-pack"


### PR DESCRIPTION
The Buzz desktop app rename from Sprout is fully shipped upstream, so the transitional `xyz.block.sprout.app` bundle symlink paths are dead code and can be removed.

`BuzzTool.symlinks` was maintaining four symlink targets — prod and dev for both `xyz.block.buzz.app` and `xyz.block.sprout.app` — so that persona packs would install into both app data directories during the transition period. Since the old Sprout bundle no longer exists, only the two Buzz paths are needed.

- Delete `get_legacy_sprout_teams_dir()` from `platform.py`
- Remove the two legacy symlink entries and their import from `buzz.py`
- Delete `test_buzz_tool_legacy_sprout_symlinks` and update three `len(links)` assertions from 4 → 2 in `test_buzz_tool.py`
- Update Thufir's harness name from `sprout-agent` to `buzz-agent` in `instructions.md`