### PR TITLE
Rewrite Dropbox connector tips for current toolset

### DIFF
--- a/src/ai_rules/config/chat_agent_hints.md
+++ b/src/ai_rules/config/chat_agent_hints.md
@@ -30,21 +30,28 @@ I use Dropbox to store important documents across multiple life domains. Top-lev
 
 ### Connector Tips
 
+**Reading files:**
+
+- Use `fetch` (param `id`, accepts file_id / fq_path / ns_path) to read a file's extracted text. Max ~5 MiB; PDF, docx, xlsx, csv, md, txt, code.
+- `fetch` errors on failure rather than returning partial content. For scanned PDFs/images you need to *see*, use `file_preview` (thumbnail + open-in-Dropbox URL). For a download URL, use `download_link`.
+
 **Search strategy:**
 
 - Search by document type, provider, or keyword — NOT by diagnosis or abstract topic. Files are typically named by date and description.
 - Always scope searches with `path` when you know the relevant folder to avoid noise from unrelated folders (especially `/Backups/` which contains thousands of files).
+- A bare `query` runs simplified search: up to 20 results, no pagination. Adding any filter (`path`, `filename_only`, `file_categories`, `file_extensions`, `last_modified_after`/`last_modified_before`, `order_by`, `max_results`) switches to advanced mode with `cursor` pagination.
 - Use `filename_only: true` when you roughly know the filename. Use default (content + filename) when searching for a topic.
-- Keep `max_results` at 10-20 for targeted searches. Default 100 returns too much noise.
+- Keep `max_results` at 10-20 for targeted searches (advanced default page size is 100, max 1000).
 - Use `order_by: "last_modified"` with date filters (`last_modified_after`/`last_modified_before`) to find recent additions.
 
-**Path handling (critical):**
+**Path handling:**
 
-- Search and list_folder return ns_path format (e.g. `ns:2207500880//Medical/file.pdf`). Always use the full ns_path or `id:<file_id>` for follow-on calls (get_file_content, get_file_metadata). Never strip the `ns:` prefix to convert to a simple path — this breaks the call.
+- Search and list_folder return `path` (ns_path, e.g. `ns:2207500880//Medical/file.pdf`) and `path_display` (fq_path, e.g. `/Medical/file.pdf`); search also returns a tool-ready `id` (file_id). fq_path and file_id both work directly in follow-on calls — prefer the returned `id` or `path_display`.
+- Recursive `list_folder` populates ns_path only (`path_display` is empty in recursive mode); use the ns_path exactly as returned and don't strip the `ns:` prefix.
 
-**list_folder gotchas:**
+**list_folder:**
 
-- It's recursive — listing a top-level folder dumps everything including deep subfolders. Always target specific subfolders.
-- Paginates at 100 items — check `has_more` and use `cursor` for next pages. When paginating, send ONLY `cursor` (omit `path`).
+- Recursive by default — listing a top-level folder returns everything including deep subfolders. Pass `recursive=false` for immediate children only, and target specific subfolders.
+- Page size defaults to 300 (max 600). Check `has_more` and paginate with `cursor` until `has_more=false`. When paginating, send ONLY `cursor` (omit `path`).
 
-**get_file_content:** Max 5MB. Works with PDF, docx, xlsx, csv, md, txt, code files. Does NOT extract images/audio/video but returns a `content_link`.
+**Write operations:** `move`, `copy`, `delete`, `create_folder`, `create_file`, `create_shared_link`, `create_file_request` are available. Each requires explicit confirmation before running. `create_file` won't overwrite an existing path (it errors) and is text-only. `delete` moves items to Dropbox trash (recoverable), not a permanent wipe.


### PR DESCRIPTION
## Summary
Updated the Dropbox connector documentation to comprehensively cover the current MCP toolset capabilities.

## Changes
- **Reading files**: Added guidance on `fetch` (text extraction, max ~5 MiB), `file_preview` (for scanned PDFs/images), and `download_link` (for direct URLs)
- **Search strategy**: Expanded with details on simplified vs. advanced search modes, pagination behavior, and filter-specific details
- **Path handling**: Clarified distinction between ns_path and fq_path formats, and guidance on when to use each
- **list_folder**: Documented recursive default behavior, pagination details (300 default, 600 max), and cursor-only pagination pattern
- **Write operations**: Added new subsection documenting available operations (`move`, `copy`, `delete`, `create_folder`, `create_file`, `create_shared_link`, `create_file_request`), confirmation requirements, and recovery behavior

## Testing
Documentation updates only — no code changes that require testing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015HsvLd8GKRds2nGQqzvsZT)_