### PR TITLE
docs: suppress Claude-Session footer from PR descriptions and commits

### DIFF
--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -177,6 +177,8 @@ After every push: `gh pr view <number> --json title,body` → evaluate if title/
 
 **NEVER mention internal workflow tools** (code-reviewer, crossfire, test-writer, etc.) in PR descriptions.
 
+**NEVER append `Claude-Session:` links or agent attribution footers** to PR descriptions or commit messages.
+
 ### PR Cross-Referencing
 
 **Rule:** Every PR that is part of a stack or has related PRs (same repo or cross-repo) must explicitly reference all related PRs. No PR description may contain a placeholder, TODO, or "TBD" for a cross-reference when the session ends.

--- a/src/ai_rules/config/skills/pr-creator/SKILL.md
+++ b/src/ai_rules/config/skills/pr-creator/SKILL.md
@@ -65,6 +65,7 @@ Use structure from `references/templates.md`. Key principles:
 - Plain bullets (`-`), no bold/headers in body; no hard line wraps in prose paragraphs; no `&nbsp;` or non-breaking spaces — regular spaces only
 - Issue refs at end with proper keywords; all external references as clickable markdown links (see `references/templates.md`)
 - Never include a "Test Plan" or "Testing" section -- leave test planning to humans
+- Never append `Claude-Session:` links or agent attribution footers
 
 See `references/templates.md` for detailed structure and examples.
 


### PR DESCRIPTION
This PR adds explicit NEVER rules blocking `Claude-Session:` links and agent attribution footers from PR descriptions and commit messages.

Claude Code's system prompt instructs agents to manually append session links to PR bodies and commits. The `attribution` setting in `settings.json` suppresses harness-level injection but not text the model writes itself — agents were still including the footer by following the system prompt's HEREDOC examples.

- Add NEVER rule to `src/ai_rules/config/AGENTS.md` PR Description Content section covering both PR descriptions and commit messages
- Add reinforcing line to `src/ai_rules/config/skills/pr-creator/SKILL.md` for the PR creation path