### PR TITLE
feat: expand BuzzTool to Linux/WSL and Windows

### DIFF
--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -122,6 +122,13 @@ def get_buzz_teams_dir(dev: bool = False) -> Path:
     if is_platform(Platform.WINDOWS):
         return get_appdata_dir() / bundle / "agents" / "teams"
     if is_platform(Platform.MACOS):
-        return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / bundle
+            / "agents"
+            / "teams"
+        )
     data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
     return Path(data_home) / bundle / "agents" / "teams"

--- a/src/ai_rules/platform.py
+++ b/src/ai_rules/platform.py
@@ -112,5 +112,16 @@ def get_statusline_config_dir() -> Path:
 
 
 def get_buzz_teams_dir(dev: bool = False) -> Path:
+    """Return Buzz teams directory.
+
+    macOS:       ~/Library/Application Support/<bundle>/agents/teams
+    Linux / WSL: $XDG_DATA_HOME/<bundle>/agents/teams (~/.local/share fallback)
+    Windows:     %APPDATA%\\<bundle>\\agents\\teams
+    """
     bundle = "xyz.block.buzz.app.dev" if dev else "xyz.block.buzz.app"
-    return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"
+    if is_platform(Platform.WINDOWS):
+        return get_appdata_dir() / bundle / "agents" / "teams"
+    if is_platform(Platform.MACOS):
+        return Path.home() / "Library" / "Application Support" / bundle / "agents" / "teams"
+    data_home = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
+    return Path(data_home) / bundle / "agents" / "teams"

--- a/src/ai_rules/tools/buzz.py
+++ b/src/ai_rules/tools/buzz.py
@@ -7,11 +7,7 @@ import json
 from functools import cached_property
 from pathlib import Path
 
-from ai_rules.platform import (
-    Platform,
-    get_buzz_teams_dir,
-    is_platform,
-)
+from ai_rules.platform import get_buzz_teams_dir
 from ai_rules.tools.base import Tool
 
 
@@ -22,12 +18,6 @@ class BuzzTool(Tool):
     tool_id = "buzz"
     config_file_name = ""
     config_file_format = ""
-
-    @classmethod
-    def is_supported_on_current_platform(cls) -> bool:
-        from ai_rules.platform import Platform, is_platform
-
-        return is_platform(Platform.MACOS)
 
     @property
     def needs_cache(self) -> bool:
@@ -46,8 +36,6 @@ class BuzzTool(Tool):
 
     @cached_property
     def symlinks(self) -> list[tuple[Path, Path]]:
-        if not is_platform(Platform.MACOS):
-            return []
         source = self.config_dir / "buzz"
         if not source.exists():
             return []

--- a/tests/unit/test_buzz_tool.py
+++ b/tests/unit/test_buzz_tool.py
@@ -1,4 +1,4 @@
-"""Tests for BuzzTool and _is_specialized_path."""
+"""Tests for BuzzTool, get_buzz_teams_dir, and _is_specialized_path."""
 
 import json
 
@@ -9,7 +9,7 @@ import pytest
 from ai_rules.agents.claude import ClaudeAgent
 from ai_rules.cli.components.config import _is_specialized_path
 from ai_rules.config import Config
-from ai_rules.platform import Platform
+from ai_rules.platform import Platform, get_buzz_teams_dir
 from ai_rules.tools.buzz import BuzzTool
 
 # ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ def test_buzz_tool_symlinks_on_macos(
 
 
 @pytest.mark.unit
-def test_buzz_tool_symlinks_empty_on_linux(
+def test_buzz_tool_symlinks_on_linux(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
@@ -53,7 +53,7 @@ def test_buzz_tool_symlinks_empty_on_linux(
     _create_pack_manifest(buzz_dir)
     tool = BuzzTool(tmp_path, Config())
 
-    assert tool.symlinks == []
+    assert len(tool.symlinks) == 2
 
 
 @pytest.mark.unit
@@ -151,6 +151,77 @@ def test_buzz_tool_symlinks_use_pack_id_from_manifest(
 
     for target, _source in links:
         assert target.name == "com.example.custom-pack"
+
+
+# ---------------------------------------------------------------------------
+# get_buzz_teams_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_macos(monkeypatch: pytest.MonkeyPatch, mock_home: Path) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
+
+    result = get_buzz_teams_dir(dev=False)
+
+    assert result == mock_home / "Library" / "Application Support" / "xyz.block.buzz.app" / "agents" / "teams"
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_macos_dev(monkeypatch: pytest.MonkeyPatch, mock_home: Path) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
+
+    result = get_buzz_teams_dir(dev=True)
+
+    assert result == mock_home / "Library" / "Application Support" / "xyz.block.buzz.app.dev" / "agents" / "teams"
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_linux_xdg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    result = get_buzz_teams_dir(dev=False)
+
+    assert result == tmp_path / "data" / "xyz.block.buzz.app" / "agents" / "teams"
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_linux_fallback(
+    monkeypatch: pytest.MonkeyPatch, mock_home: Path
+) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.LINUX)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    result = get_buzz_teams_dir(dev=False)
+
+    assert result == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_wsl(
+    monkeypatch: pytest.MonkeyPatch, mock_home: Path
+) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WSL)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+    result = get_buzz_teams_dir(dev=False)
+
+    assert result == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+
+
+@pytest.mark.unit
+def test_get_buzz_teams_dir_windows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.WINDOWS)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+
+    result = get_buzz_teams_dir(dev=False)
+
+    assert result == tmp_path / "AppData" / "Roaming" / "xyz.block.buzz.app" / "agents" / "teams"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_buzz_tool.py
+++ b/tests/unit/test_buzz_tool.py
@@ -159,21 +159,41 @@ def test_buzz_tool_symlinks_use_pack_id_from_manifest(
 
 
 @pytest.mark.unit
-def test_get_buzz_teams_dir_macos(monkeypatch: pytest.MonkeyPatch, mock_home: Path) -> None:
+def test_get_buzz_teams_dir_macos(
+    monkeypatch: pytest.MonkeyPatch, mock_home: Path
+) -> None:
     monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
 
     result = get_buzz_teams_dir(dev=False)
 
-    assert result == mock_home / "Library" / "Application Support" / "xyz.block.buzz.app" / "agents" / "teams"
+    assert (
+        result
+        == mock_home
+        / "Library"
+        / "Application Support"
+        / "xyz.block.buzz.app"
+        / "agents"
+        / "teams"
+    )
 
 
 @pytest.mark.unit
-def test_get_buzz_teams_dir_macos_dev(monkeypatch: pytest.MonkeyPatch, mock_home: Path) -> None:
+def test_get_buzz_teams_dir_macos_dev(
+    monkeypatch: pytest.MonkeyPatch, mock_home: Path
+) -> None:
     monkeypatch.setattr("ai_rules.platform.detect_platform", lambda: Platform.MACOS)
 
     result = get_buzz_teams_dir(dev=True)
 
-    assert result == mock_home / "Library" / "Application Support" / "xyz.block.buzz.app.dev" / "agents" / "teams"
+    assert (
+        result
+        == mock_home
+        / "Library"
+        / "Application Support"
+        / "xyz.block.buzz.app.dev"
+        / "agents"
+        / "teams"
+    )
 
 
 @pytest.mark.unit
@@ -197,7 +217,10 @@ def test_get_buzz_teams_dir_linux_fallback(
 
     result = get_buzz_teams_dir(dev=False)
 
-    assert result == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+    assert (
+        result
+        == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+    )
 
 
 @pytest.mark.unit
@@ -209,7 +232,10 @@ def test_get_buzz_teams_dir_wsl(
 
     result = get_buzz_teams_dir(dev=False)
 
-    assert result == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+    assert (
+        result
+        == mock_home / ".local" / "share" / "xyz.block.buzz.app" / "agents" / "teams"
+    )
 
 
 @pytest.mark.unit
@@ -221,7 +247,10 @@ def test_get_buzz_teams_dir_windows(
 
     result = get_buzz_teams_dir(dev=False)
 
-    assert result == tmp_path / "AppData" / "Roaming" / "xyz.block.buzz.app" / "agents" / "teams"
+    assert (
+        result
+        == tmp_path / "AppData" / "Roaming" / "xyz.block.buzz.app" / "agents" / "teams"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_target_registry.py
+++ b/tests/unit/test_target_registry.py
@@ -25,11 +25,10 @@ def test_target_registry_returns_unique_targets_in_lifecycle_order(
         "goose",
         "shared",
         "statusline",
+        "buzz",
     ]
     assert len(target_ids) == len(set(target_ids))
-    # BuzzTool is macOS-only, so TARGET_CLASSES has one more entry than the
-    # Linux-filtered list.
-    assert len(TARGET_CLASSES) == len(target_ids) + 1
+    assert len(TARGET_CLASSES) == len(target_ids)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- `get_buzz_teams_dir()` now branches on platform: XDG_DATA_HOME (with `~/.local/share` fallback) on Linux/WSL, `%APPDATA%` on Windows, and `~/Library/Application Support` on macOS — matching the pattern already used by `get_goose_config_dir()`
- Removed the `is_supported_on_current_platform()` override from `BuzzTool` — the base class already returns `True`, so the override was dead code
- Removed the macOS-only early-exit from `BuzzTool.symlinks`
- Updated tests: fixed the now-wrong Linux test (was asserting `[]`, should be 2 symlinks), added `get_buzz_teams_dir()` coverage for all four platform branches, fixed the target registry assertion that encoded Buzz as macOS-only