### PR TITLE
fix: install ai-agent-rules when bootstrapped via uvx

### DIFF
--- a/src/ai_rules/bootstrap/updater.py
+++ b/src/ai_rules/bootstrap/updater.py
@@ -519,7 +519,7 @@ _SELF_SPEC = ToolSpec(
     package_name="ai-agent-rules",
     display_name="ai-agent-rules",
     get_version=lambda: get_tool_version("ai-agent-rules"),
-    is_installed=lambda: True,
+    is_installed=lambda: get_tool_version("ai-agent-rules") is not None,
     github_repo=_SELF_GITHUB_REPO,
 )
 

--- a/tests/integration/test_tool_commands.py
+++ b/tests/integration/test_tool_commands.py
@@ -17,7 +17,11 @@ class TestToolList:
 
 @pytest.mark.integration
 class TestToolShow:
-    def test_show_ai_agent_rules(self, runner):
+    def test_show_ai_agent_rules(self, runner, monkeypatch):
+        monkeypatch.setattr(
+            "ai_rules.bootstrap.updater.get_tool_version",
+            lambda _: "1.0.0",
+        )
         result = runner.invoke(main, ["tool", "show", "ai-agent-rules"])
 
         assert result.exit_code == 0


### PR DESCRIPTION
`uvx ai-agent-rules setup -y` silently skipped the persistent `uv tool install` call, leaving `ai-rules` unavailable as a command after setup completed.

`_SELF_SPEC.is_installed` was hardcoded to `lambda: True` — sensible when running from a persistent install, but wrong under `uvx` where the tool runs ephemerally. The `setup` command's Step 1 saw `is_installed() == True`, entered the "already installed" branch, found no version to update, silently set `tool_install_success = True`, and skipped the actual install.

- Change `_SELF_SPEC.is_installed` to `lambda: get_tool_version("ai-agent-rules") is not None`, which parses `uv tool list` and correctly returns `False` in ephemeral `uvx` contexts
- Update `test_show_ai_agent_rules` to mock `get_tool_version` so it exercises the installed display path regardless of whether the tool is persistently installed in the test environment