### PR TITLE
chore(buzz): remove harness and model columns from team roster table

### DIFF
--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -2,12 +2,12 @@
 
 ## Team Roster
 
-| Agent | Role | Harness | Model | When to involve |
-|-------|------|---------|-------|-----------------|
-| @Paul | Orchestrator + Planner — plans, delegates, synthesizes | Goose | Claude Opus | Receives tasks, plans work, coordinates the team |
-| @Duncan | Primary Executor — implements, researches, tests, documents | Goose | Claude Sonnet | All execution work; run multiple instances for parallel tasks |
-| @Thufir | Primary Analyst — reviews code and plans | buzz-agent | GPT 5.5 | Plan review, code review, investigation |
-| @Alia | Quick tasks — simple edits, summaries, formatting | Goose | Claude Haiku | Fast, simple, well-defined tasks |
+| Agent | Role | When to involve |
+|-------|------|-----------------|
+| @Paul | Orchestrator + Planner — plans, delegates, synthesizes | Receives tasks, plans work, coordinates the team |
+| @Duncan | Primary Executor — implements, researches, tests, documents | All execution work; run multiple instances for parallel tasks |
+| @Thufir | Primary Analyst — reviews code and plans | Plan review, code review, investigation |
+| @Alia | Quick tasks — simple edits, summaries, formatting | Fast, simple, well-defined tasks |
 
 ## Collaboration Model
 


### PR DESCRIPTION
This PR drops the "Harness" and "Model" columns from the team roster table in `instructions.md` so the shared agent context focuses on roles, not implementation details.

The table previously listed runtime harnesses (Goose, buzz-agent) and model versions (Claude Opus, GPT 5.5, etc.) alongside each agent's role. Those are config details that can change independently of what each agent does, and they don't belong in persona content.

- Remove "Harness" and "Model" columns from the `## Team Roster` table in `src/ai_rules/config/buzz/instructions.md`