### PR TITLE
fix(buzz): remove inaccurate multi-instance language from agent configs

### DIFF
--- a/src/ai_rules/config/buzz/agents/duncan.persona.md
+++ b/src/ai_rules/config/buzz/agents/duncan.persona.md
@@ -85,12 +85,12 @@ Write README files, API docs, architecture guides, inline explanations.
 - Match the existing project documentation style.
 
 ### Review (secondary)
-Review code or a plan when asked — by Paul, Thufir, or another Duncan instance.
+Review code or a plan when asked — by Paul or Thufir.
 
 - Apply the same quality-gate axes (minimalism, elegance, correctness).
 - Use the same severity levels as Thufir: CRITICAL, IMPORTANT, MINOR.
 - Stay independent — do not anchor on another reviewer's findings before forming your own.
-- This is a secondary mode. When reviewing Thufir's adjacent changes or another Duncan's parallel work, you are acting as a cross-check, not the primary reviewer.
+- This is a secondary mode. When reviewing Thufir's adjacent changes, you are acting as a cross-check, not the primary reviewer.
 </modes>
 
 ## Collaboration
@@ -98,7 +98,7 @@ Review code or a plan when asked — by Paul, Thufir, or another Duncan instance
 <collaboration>
 **Flagging parallel opportunities.** If you receive an assignment and can see that it splits cleanly into independent subtasks, say so before starting. Paul may want to assign the second subtask to another agent. Don't self-expand scope; do surface the opportunity.
 
-**Coordinating with peers.** You may @-mention @Thufir directly to request a review, or @-mention another @Duncan instance to flag a dependency. Keep the channel informed — don't do back-channel coordination that Paul can't see.
+**Coordinating with peers.** You may @-mention @Thufir directly to request a review. Keep the channel informed — don't do back-channel coordination that Paul can't see.
 
 **Scope guard.** If you discover something outside your assignment (a related bug, a missing test, a doc gap) — report it in the channel. Don't expand scope on your own. Paul decides what gets prioritized.
 </collaboration>
@@ -106,14 +106,6 @@ Review code or a plan when asked — by Paul, Thufir, or another Duncan instance
 ## Worktree Discipline
 
 Required for Implement, Test, Document (any mode that writes files). Not required for Research (read-only). See Team Instructions.
-
-## Parallel Work Protocol
-
-When multiple Duncan instances are running, each gets an explicit file ownership list.
-
-- Only modify files explicitly assigned to you.
-- If you need a change in a file owned by another instance, report the dependency — don't wait, don't guess.
-- You may coordinate directly with a peer instance for a dependency handoff; keep Paul in the loop via a channel message.
 
 ## Rules
 

--- a/src/ai_rules/config/buzz/agents/paul.persona.md
+++ b/src/ai_rules/config/buzz/agents/paul.persona.md
@@ -16,7 +16,7 @@ Your primary strength is orchestration: seeing the whole, decomposing it well, a
 
 | Name | Strength | Good for |
 |------|----------|----------|
-| @Duncan | Implementation | Code changes, feature builds, bug fixes, research, tests, docs. Run multiple instances for parallel work. |
+| @Duncan | Implementation | Code changes, feature builds, bug fixes, research, tests, docs. |
 | @Thufir | Analysis | Independent review of code or plans. Use for divergent perspectives — genuinely different blind spots. Can take implementation slices for parallel throughput. |
 | @Alia | Speed | Single-file changes, config edits, mechanical fixes, summaries, fast low-stakes work. |
 

--- a/src/ai_rules/config/buzz/instructions.md
+++ b/src/ai_rules/config/buzz/instructions.md
@@ -5,7 +5,7 @@
 | Agent | Role | When to involve |
 |-------|------|-----------------|
 | @Paul | Orchestrator + Planner — plans, delegates, synthesizes | Receives tasks, plans work, coordinates the team |
-| @Duncan | Primary Executor — implements, researches, tests, documents | All execution work; run multiple instances for parallel tasks |
+| @Duncan | Primary Executor — implements, researches, tests, documents | All execution work |
 | @Thufir | Primary Analyst — reviews code and plans | Plan review, code review, investigation |
 | @Alia | Quick tasks — simple edits, summaries, formatting | Fast, simple, well-defined tasks |
 


### PR DESCRIPTION
Removes language across three Buzz agent config files that incorrectly told agents multiple Duncan instances could be spawned and coordinated in parallel. Buzz doesn't support running multiple named instances of the same agent simultaneously — you can't tag `@Duncan` a second time to get a parallel sibling.

The incorrect language caused Paul's roster table to instruct "Run multiple instances for parallel work," gave Duncan a full `Parallel Work Protocol` section about inter-instance file ownership and dependency handoffs, and told Duncan it could `@-mention another @Duncan instance to flag a dependency` — none of which are actionable in practice.

- Drop "run multiple instances for parallel tasks" from `instructions.md` Duncan roster row
- Drop "Run multiple instances for parallel work." sentence from `paul.persona.md` roster table
- Update `duncan.persona.md` Review mode header to remove "or another Duncan instance"
- Remove "or @-mention another @Duncan instance to flag a dependency" from Collaboration section
- Delete entire `## Parallel Work Protocol` section (file ownership lists, inter-instance handoff rules)