### PR TITLE
feat(work): add npm registry VPN guidance for personal repos

### DIFF
--- a/src/ai_rules/config/profiles/work.yaml
+++ b/src/ai_rules/config/profiles/work.yaml
@@ -41,5 +41,27 @@ agents_md: |
   Always reconnect immediately after — WARP is the corporate VPN and must stay active for
   work network resources. This only affects personal repos; work repos use Artifactory
   intentionally.
+
+  ## Work Laptop: npm Registry Access in Personal Repos
+
+  The same WARP interception applies to npm: direct access to `registry.npmjs.org` is
+  hard-blocked by Cloudflare Gateway (Dependency Confusion policy — see
+  go/dependencyconfusionnpm), and the machine-level `~/.npmrc` routes npm traffic through
+  Artifactory instead. Personal repos must never resolve or lock against Artifactory.
+
+  Same fix as uv — toggle the VPN around network-touching npm/pnpm commands (install,
+  import, add, update) and reconnect immediately after:
+
+  ```bash
+  warp-cli disconnect
+  pnpm install  # or npm install, pnpm import, pnpm add, etc.
+  warp-cli connect
+  ```
+
+  Additionally, personal JS repos should commit a project-level `.npmrc` containing
+  `registry=https://registry.npmjs.org/` so the machine-level Artifactory registry can
+  never leak in (a no-op in CI, where npmjs is the default). pnpm lockfiles are
+  registry-agnostic, but npm's `package-lock.json` embeds resolved URLs — never commit
+  one generated against Artifactory.
 exclude_symlinks:
   - ~/.config/goose/config.yaml


### PR DESCRIPTION
Adds a sibling section to the work profile's `agents_md` documenting that WARP also hard-blocks `registry.npmjs.org` (Cloudflare dependency-confusion policy) and that the machine-level `~/.npmrc` reroutes npm through Artifactory — I hit both while migrating SNORE's UI to pnpm. It's the same VPN-toggle playbook as the existing uv section, plus guidance to commit a project-level `.npmrc` pinning npmjs in personal JS repos, and a note that npm's `package-lock.json` embeds resolved URLs (pnpm lockfiles don't) so lockfiles should never be generated against Artifactory.

Related: [SNORE#100](https://github.com/wpfleger96/SNORE/pull/100)