### PR TITLE
fix: gate commit trailer rule on explicit identity check

### DIFF
--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -210,7 +210,9 @@ After every push: `gh pr view <number> --json title,body` → evaluate if title/
 
 ### Agent-Authored Commits
 
-**Rule:** When the agent is the git commit author — detected by checking `git config user.name` and confirming it is not the user's name — every commit must include both trailers:
+**Rule:** Before every commit, run `git config user.name` and compare to "Will Pfleger". Only add trailers when they differ — i.e., the agent has its own git identity. If the user's name is already the committer, omit all trailers.
+
+**When trailers are needed** (agent identity ≠ user identity), include both:
 
 ```
 Co-authored-by: Will Pfleger <email>


### PR DESCRIPTION
## Summary

- Restructure the agent-authored commits rule so the `git config user.name` check is an explicit gating step rather than a subordinate clause
- When the user's name is already the git committer, agents now clearly skip all trailers instead of adding redundant `Co-authored-by`/`Signed-off-by` lines

The prior wording made it easy for agents to skip the check and blindly add trailers on every commit, even when committing under the user's own identity.