### PR TITLE
fix: scope implementation delegation rule to top-level orchestrator

### DIFF
--- a/src/ai_rules/config/AGENTS.md
+++ b/src/ai_rules/config/AGENTS.md
@@ -42,12 +42,14 @@
 
 ### Delegation & Multi-Agent Orchestration
 
+**Who this applies to:** the top-level orchestrator only — the session conversing directly with the user. **If you are a subagent** (your prompt is a task brief from another agent, not a conversation with a human), this section does NOT apply to you: you are the terminal worker. Implement everything in your brief directly with your own tools and never spawn agents for implementation. Delegation depth is exactly one.
+
 **Rule:** Always delegate code implementation to parallel subagents — never write implementation diffs in the orchestrator context. Split by file/concern; one subagent per file or group of files sharing a broken intermediate state.
 
 **Delegate:** All code implementation | Non-implementation when context >50% of window | Independent parallel subtasks
 **Inline:** Single-line mechanical | Sequential-dependent | Ambiguous (clarify first)
 
-**Subagent briefing (self-containment protocol):** Subagents have ZERO access to the parent conversation. Every briefing must include: atomic objective, output format, tool guidance, scope boundaries. Implementation briefings additionally: file ownership list, plan context with interfaces, forbidden files owned by parallel agents.
+**Subagent briefing (self-containment protocol):** Subagents have ZERO access to the parent conversation. Every briefing must include: atomic objective, output format, tool guidance, scope boundaries, and an explicit "you are the worker — implement directly, do not delegate further" line. Implementation briefings additionally: file ownership list, plan context with interfaces, forbidden files owned by parallel agents.
 
 Analysis tasks: `sonnet` for execution-heavy, `opus` for judgment-heavy.
 


### PR DESCRIPTION
The `AGENTS.md` file is injected into every agent context — orchestrators and subagents alike. The "Delegation & Multi-Agent Orchestration" section previously had no scope qualifier, so spawned implementation subagents read the rule as applying to them and attempted to spawn their own nested agents. In practice this surfaces as an unexpected `Agent` tool call inside a subagent context, which either hits a permission prompt and stalls the task or silently recurses until the context fills.

The fix has two parts. First, a scope gate at the top of the section lets a subagent self-identify: if its prompt is a task brief from another agent rather than a conversation with a human, the section does not apply and it should implement directly with its own tools. Delegation depth is exactly one. Second, the briefing-protocol bullet now requires orchestrators to include an explicit "you are the worker — implement directly, do not delegate further" line in every subagent brief, so the counter-instruction is reinforced at call time regardless of what the receiving agent does with the global rule.

No other sections are changed.
